### PR TITLE
feat: relocate QuickJS heap to PSRAM to free internal SRAM

### DIFF
--- a/dev/sram-pressure/.gitignore
+++ b/dev/sram-pressure/.gitignore
@@ -1,0 +1,6 @@
+.env
+.env.*
+.DS_Store
+node_modules
+build
+.mikro

--- a/dev/sram-pressure/README.md
+++ b/dev/sram-pressure/README.md
@@ -1,0 +1,46 @@
+# sram-pressure
+
+Synthetic dev fixture for HTTPS handshake failures caused by internal-SRAM
+fragmentation on ESP32. mbedTLS handshake buffers must come from contiguous
+internal SRAM, where they compete with QuickJS heap chunks; on PSRAM-equipped
+chips, combined `systemFree` is dominated by external RAM and hides the
+pressure entirely.
+
+## What it does
+
+1. Connects to WiFi.
+2. Performs an HTTPS GET against `TARGET_URL`.
+3. Allocates `STEP_KB` of small retained JS objects (held in a global array
+   so they cannot be collected).
+4. Repeats steps 2 and 3 until the request fails or `MAX_STEPS` is reached.
+
+The goal is to reproduce, deterministically and without depending on any
+specific feature, the failure mode where retained JS state in internal SRAM
+starves the mbedTLS handshake even though `memoryUsage()` reports plenty of
+free heap (PSRAM is fine, internal is not).
+
+## Required env vars
+
+- `WIFI_SSID`
+- `WIFI_PASSPHRASE`
+
+## Optional env vars
+
+- `TARGET_URL` (default: `https://jsonplaceholder.typicode.com/posts/1`)
+- `STEP_KB` (default: `8`) bytes of ballast added per step
+- `MAX_STEPS` (default: `20`) maximum number of steps before giving up
+
+## Run
+
+```sh
+npm install
+npm run dev
+```
+
+## Reading the output
+
+Each step prints `pressure=<kb>` (cumulative ballast),
+`systemLargest` (largest contiguous free block, combined internal+PSRAM)
+and `heapUsed` (QuickJS heap). Watch for the request to fail with a
+non-zero error while `systemLargest` still looks healthy. That gap is the
+diagnostic gap motivating internal-RAM stats in `memoryUsage()`.

--- a/dev/sram-pressure/app/main.ts
+++ b/dev/sram-pressure/app/main.ts
@@ -1,0 +1,80 @@
+import {env} from 'mikrojs/env'
+import {request} from 'mikrojs/http/request'
+import {memoryUsage} from 'mikrojs/sys'
+import {wifi} from 'mikrojs/wifi'
+
+const TARGET_URL = env.get('TARGET_URL') ?? 'https://jsonplaceholder.typicode.com/posts/1'
+const STEP_KB = Number(env.get('STEP_KB') ?? '8')
+const MAX_STEPS = Number(env.get('MAX_STEPS') ?? '20')
+
+// Roughly 80 bytes per retained object (header + 4 props). Used to convert
+// the per-step KB target into an object count.
+const PER_OBJECT_BYTES = 80
+
+const ssid = env.require('WIFI_SSID')
+const passphrase = env.require('WIFI_PASSPHRASE')
+
+console.log('Connecting to %s ...', ssid)
+const connect = await wifi.connect(ssid, passphrase)
+if (!connect.ok) {
+  console.error('WiFi connect failed: %s', connect.error.name)
+} else {
+  console.log('Connected. IP: %s', connect.value.ip)
+  await sweep()
+}
+
+async function sweep() {
+  // Retained ballast. Pushing onto a global array prevents GC.
+  const ballast: object[] = []
+  const objectsPerStep = Math.floor((STEP_KB * 1024) / PER_OBJECT_BYTES)
+
+  for (let step = 0; step <= MAX_STEPS; step++) {
+    const pressureKb = step * STEP_KB
+    logMem('before', step, pressureKb)
+
+    const t0 = Date.now()
+    const result = await request(TARGET_URL)
+    const elapsed = Date.now() - t0
+
+    if (!result.ok) {
+      console.error('  FAIL after %dms: %s', elapsed, result.error.name)
+      logMem('after', step, pressureKb)
+      console.error('  threshold reached at pressure=%dKB. Stopping.', pressureKb)
+      return
+    }
+    if (!result.value.ok) {
+      console.warn('  HTTP %d after %dms', result.value.status, elapsed)
+    } else {
+      const body = await result.value.text()
+      console.log('  OK %d bytes in %dms', body.length, elapsed)
+    }
+    // Post-fetch read shows the low-water mark left by mbedTLS handshake +
+    // socket buffers. Compare to the pre-fetch reading: the handshake's own
+    // internal-SRAM allocations are what actually trip the threshold.
+    logMem('after', step, pressureKb)
+
+    for (let i = 0; i < objectsPerStep; i++) {
+      ballast.push({a: step, b: i, c: i + 1, d: 'x'})
+    }
+  }
+
+  console.log(
+    '\nNo failure within %d steps (max pressure %dKB). Increase STEP_KB or MAX_STEPS.',
+    MAX_STEPS,
+    MAX_STEPS * STEP_KB,
+  )
+  console.log('ballast retained: %d objects', ballast.length)
+}
+
+function logMem(phase: 'before' | 'after', step: number, pressureKb: number) {
+  const m = memoryUsage()
+  const header =
+    phase === 'before' ? `\n=== step ${step}  pressure=${pressureKb}KB  [pre]` : '  [post]'
+  console.log(
+    '%s  internalFree=%d  internalLargest=%d  heapUsed=%d',
+    header,
+    m.internalFree,
+    m.internalLargestFree,
+    m.heapUsed,
+  )
+}

--- a/dev/sram-pressure/env.d.ts
+++ b/dev/sram-pressure/env.d.ts
@@ -1,0 +1,7 @@
+declare interface ImportMetaEnv {
+  WIFI_SSID: string
+  WIFI_PASSPHRASE: string
+  TARGET_URL?: string
+  STEP_KB?: string
+  MAX_STEPS?: string
+}

--- a/dev/sram-pressure/mikro.config.ts
+++ b/dev/sram-pressure/mikro.config.ts
@@ -1,0 +1,6 @@
+import {defineConfig} from 'mikrojs'
+
+export default defineConfig({
+  wifiCountry: 'NO',
+  restartOnUncaughtException: false,
+})

--- a/dev/sram-pressure/package.json
+++ b/dev/sram-pressure/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "mikrojs-sram-pressure-dev",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Mikro.js dev fixture: HTTPS handshake failure under internal-SRAM pressure",
+  "license": "MIT",
+  "author": "Bjørge Næss <bjoerge@gmail.com>",
+  "files": [
+    "dist",
+    "app"
+  ],
+  "type": "module",
+  "main": "./app/main.ts",
+  "scripts": {
+    "dev": "mikro dev"
+  },
+  "dependencies": {
+    "mikrojs": "workspace:*"
+  }
+}

--- a/dev/sram-pressure/tsconfig.json
+++ b/dev/sram-pressure/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "module": "nodenext",
+    "target": "es2024",
+    "lib": ["ES2024"],
+    "noEmit": true,
+    "types": ["mikrojs/runtime"],
+    "sourceMap": true,
+    "noUncheckedIndexedAccess": true,
+    "erasableSyntaxOnly": true,
+    "strict": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noUncheckedSideEffectImports": true,
+    "moduleDetection": "force",
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "allowUnreachableCode": false
+  }
+}

--- a/packages/@mikrojs/firmware/components/mikrojs/Kconfig
+++ b/packages/@mikrojs/firmware/components/mikrojs/Kconfig
@@ -22,6 +22,32 @@ menu "mikrojs console"
 
 endmenu
 
+menu "mikrojs runtime memory"
+
+    config MIKROJS_QUICKJS_HEAP_PSRAM
+        bool "Allocate QuickJS heap in PSRAM"
+        default y if SPIRAM
+        depends on SPIRAM
+        help
+            When enabled, the QuickJS engine allocates its heap from PSRAM
+            instead of internal SRAM. This frees roughly 150-250 KB of
+            contiguous internal SRAM for mbedTLS handshake buffers, WiFi
+            and BLE driver state, and DMA-capable buffers — the most
+            common cause of HTTPS handshake failures (error 0x7002) on
+            apps with significant retained JS state.
+
+            Cost: PSRAM has higher access latency than internal SRAM,
+            so JS execution is somewhat slower. For typical embedded
+            JS workloads (event-driven, IO-bound) this is invisible
+            against networking and IO costs, while HTTPS reliability
+            matters.
+
+            Defaults on for chips with PSRAM. Disable if your workload
+            is JS-execution-bound and you can fit the JS heap in
+            internal SRAM. No effect on chips without PSRAM.
+
+endmenu
+
 menu "mikrojs Test Configuration"
 
     config MIKROJS_TEST_GPIO_PIN

--- a/packages/@mikrojs/firmware/components/mikrojs/mik_main.cpp
+++ b/packages/@mikrojs/firmware/components/mikrojs/mik_main.cpp
@@ -300,6 +300,9 @@ void MIK_Main(void) {
     if (app_config.stack_size > 0) {
         options.stack_size = app_config.stack_size;
     }
+#ifdef CONFIG_MIKROJS_QUICKJS_HEAP_PSRAM
+    options.use_psram_heap = true;
+#endif
 
     auto create_runtime = [&]() -> MIKRuntime* {
         MIKRuntime* rt = MIK_NewRuntimeOptions(&options);

--- a/packages/@mikrojs/firmware/components/mikrojs/platform_esp32.cpp
+++ b/packages/@mikrojs/firmware/components/mikrojs/platform_esp32.cpp
@@ -62,6 +62,14 @@ static size_t esp32_get_largest_free_system_mem(void) {
     return heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
 }
 
+static size_t esp32_get_free_internal_mem(void) {
+    return heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
+}
+
+static size_t esp32_get_largest_free_internal_mem(void) {
+    return heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL);
+}
+
 static bool esp32_get_fs_info(const char* label, size_t* total, size_t* used) {
 #if HAS_LITTLEFS
     return esp_littlefs_info(label, total, used) == ESP_OK;
@@ -163,6 +171,8 @@ static const MIKPlatform esp32_platform = {
     .get_min_free_system_mem = esp32_get_min_free_system_mem,
     .get_total_system_mem = esp32_get_total_system_mem,
     .get_largest_free_system_mem = esp32_get_largest_free_system_mem,
+    .get_free_internal_mem = esp32_get_free_internal_mem,
+    .get_largest_free_internal_mem = esp32_get_largest_free_internal_mem,
     .get_fs_info = esp32_get_fs_info,
     .log = esp32_log,
     .stdout_write = esp32_stdout_write,

--- a/packages/@mikrojs/firmware/components/mikrojs/platform_esp32.cpp
+++ b/packages/@mikrojs/firmware/components/mikrojs/platform_esp32.cpp
@@ -70,6 +70,35 @@ static size_t esp32_get_largest_free_internal_mem(void) {
     return heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL);
 }
 
+static void* esp32_malloc_psram(size_t size) {
+#ifdef CONFIG_SPIRAM
+    return heap_caps_malloc(size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+#else
+    (void)size;
+    return NULL;
+#endif
+}
+
+static void* esp32_calloc_psram(size_t count, size_t size) {
+#ifdef CONFIG_SPIRAM
+    return heap_caps_calloc(count, size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+#else
+    (void)count;
+    (void)size;
+    return NULL;
+#endif
+}
+
+static void* esp32_realloc_psram(void* ptr, size_t size) {
+#ifdef CONFIG_SPIRAM
+    return heap_caps_realloc(ptr, size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+#else
+    (void)ptr;
+    (void)size;
+    return NULL;
+#endif
+}
+
 static bool esp32_get_fs_info(const char* label, size_t* total, size_t* used) {
 #if HAS_LITTLEFS
     return esp_littlefs_info(label, total, used) == ESP_OK;
@@ -173,6 +202,9 @@ static const MIKPlatform esp32_platform = {
     .get_largest_free_system_mem = esp32_get_largest_free_system_mem,
     .get_free_internal_mem = esp32_get_free_internal_mem,
     .get_largest_free_internal_mem = esp32_get_largest_free_internal_mem,
+    .malloc_psram = esp32_malloc_psram,
+    .calloc_psram = esp32_calloc_psram,
+    .realloc_psram = esp32_realloc_psram,
     .get_fs_info = esp32_get_fs_info,
     .log = esp32_log,
     .stdout_write = esp32_stdout_write,

--- a/packages/@mikrojs/firmware/sdkconfig.defaults
+++ b/packages/@mikrojs/firmware/sdkconfig.defaults
@@ -129,3 +129,13 @@ CONFIG_MBEDTLS_ECP_DP_BP512R1_ENABLED=n
 CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN=y
 CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_CROSS_SIGNED_VERIFY=y
 
+# TLS record buffers must come from internal SRAM. The ESP-IDF default for
+# the inbound buffer is 16 KB, which competes with QuickJS heap allocations
+# for contiguous internal SRAM and causes HTTPS handshake failures (error
+# 0x7002) on apps with significant retained JS state. Halving it to 8 KB
+# leaves enough room for typical TLS records (handshake fragments are well
+# under 4 KB; modern servers rarely send >4 KB application records, and
+# mbedTLS will fragment larger records). The outbound buffer was already
+# 4 KB via CONFIG_MBEDTLS_ASYMMETRIC_CONTENT_LEN=y.
+CONFIG_MBEDTLS_SSL_IN_CONTENT_LEN=8192
+

--- a/packages/@mikrojs/native/addon/platform_node.cpp
+++ b/packages/@mikrojs/native/addon/platform_node.cpp
@@ -53,6 +53,23 @@ static size_t node_get_largest_free_internal_mem(void) {
     return 0;
 }
 
+static void* node_malloc_psram(size_t size) {
+    (void)size;
+    return NULL;
+}
+
+static void* node_calloc_psram(size_t count, size_t size) {
+    (void)count;
+    (void)size;
+    return NULL;
+}
+
+static void* node_realloc_psram(void* ptr, size_t size) {
+    (void)ptr;
+    (void)size;
+    return NULL;
+}
+
 static bool node_get_fs_info(const char* label, size_t* total, size_t* used) {
     (void)label;
     (void)total;
@@ -152,6 +169,9 @@ static const MIKPlatform node_platform = {
     .get_largest_free_system_mem = node_get_largest_free_system_mem,
     .get_free_internal_mem = node_get_free_internal_mem,
     .get_largest_free_internal_mem = node_get_largest_free_internal_mem,
+    .malloc_psram = node_malloc_psram,
+    .calloc_psram = node_calloc_psram,
+    .realloc_psram = node_realloc_psram,
     .get_fs_info = node_get_fs_info,
     .log = node_log,
     .stdout_write = node_stdout_write,

--- a/packages/@mikrojs/native/addon/platform_node.cpp
+++ b/packages/@mikrojs/native/addon/platform_node.cpp
@@ -45,6 +45,14 @@ static size_t node_get_largest_free_system_mem(void) {
     return 0;
 }
 
+static size_t node_get_free_internal_mem(void) {
+    return 0;
+}
+
+static size_t node_get_largest_free_internal_mem(void) {
+    return 0;
+}
+
 static bool node_get_fs_info(const char* label, size_t* total, size_t* used) {
     (void)label;
     (void)total;
@@ -142,6 +150,8 @@ static const MIKPlatform node_platform = {
     .get_min_free_system_mem = node_get_min_free_system_mem,
     .get_total_system_mem = node_get_total_system_mem,
     .get_largest_free_system_mem = node_get_largest_free_system_mem,
+    .get_free_internal_mem = node_get_free_internal_mem,
+    .get_largest_free_internal_mem = node_get_largest_free_internal_mem,
     .get_fs_info = node_get_fs_info,
     .log = node_log,
     .stdout_write = node_stdout_write,

--- a/packages/@mikrojs/native/include/mikrojs/mem.h
+++ b/packages/@mikrojs/native/include/mikrojs/mem.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdlib.h>
 
@@ -9,3 +10,19 @@ void* mik__mallocz(size_t size);
 void* mik__calloc(size_t count, size_t size);
 void mik__free(void* ptr);
 void* mik__realloc(void* ptr, size_t size);
+
+/* QuickJS-heap allocators. Backed by libc malloc by default; routed to
+ * PSRAM via the platform's malloc_psram/calloc_psram/realloc_psram hooks
+ * when mik__set_quickjs_heap_psram(true) has been called and the platform
+ * supports PSRAM. Free is unchanged: PSRAM pointers from heap_caps_malloc
+ * free cleanly via standard free() on ESP-IDF. */
+void* mik__js_malloc(size_t size);
+void* mik__js_calloc(size_t count, size_t size);
+void* mik__js_realloc(void* ptr, size_t size);
+
+/* Toggle QuickJS heap allocations to PSRAM (no-op on platforms without
+ * PSRAM). Set once before JS_NewRuntime2; do not change mid-run since
+ * mik__js_realloc relies on the flag staying consistent with the heap
+ * the original pointer came from. */
+void mik__set_quickjs_heap_psram(bool enable);
+bool mik__is_quickjs_heap_psram(void);

--- a/packages/@mikrojs/native/include/mikrojs/mikrojs.h
+++ b/packages/@mikrojs/native/include/mikrojs/mikrojs.h
@@ -10,6 +10,17 @@ typedef struct MIKRuntime MIKRuntime;
 typedef struct MIKRunOptions {
     int mem_limit;
     size_t stack_size;
+    /* Allocate the QuickJS heap from PSRAM instead of internal SRAM on
+     * chips with both. Frees ~150-250 KB of contiguous internal SRAM for
+     * mbedTLS, WiFi/BLE, and DMA buffers, the dominant root cause of
+     * HTTPS handshake failures (error 0x7002) on apps with significant
+     * retained JS state. JS execution is somewhat slower (PSRAM has
+     * higher access latency than internal SRAM); for typical embedded
+     * IO-bound workloads this is invisible against networking and IO
+     * costs. No effect on hosts and chips without PSRAM. Defaults false
+     * for backward compatibility; the firmware bootstrap flips it on
+     * when CONFIG_MIKROJS_QUICKJS_HEAP_PSRAM is set. */
+    bool use_psram_heap;
 } MIKRunOptions;
 
 typedef struct MIKConfig {

--- a/packages/@mikrojs/native/include/mikrojs/platform.h
+++ b/packages/@mikrojs/native/include/mikrojs/platform.h
@@ -37,6 +37,18 @@ typedef struct MIKPlatform {
      *  reports plenty of contiguous PSRAM. Same fallback rules as
      *  get_free_internal_mem. */
     size_t (*get_largest_free_internal_mem)(void);
+    /** Allocate `size` bytes from PSRAM/external RAM. Returns NULL if
+     *  PSRAM is unavailable (host platforms, chips without PSRAM, or
+     *  PSRAM exhaustion); the caller falls back to the regular allocator.
+     *  On ESP32 with CONFIG_SPIRAM=y, implemented via heap_caps_malloc
+     *  with MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT. The returned pointer is
+     *  freed via standard free(). */
+    void* (*malloc_psram)(size_t size);
+    /** PSRAM-targeted calloc. Same fallback rules as malloc_psram. */
+    void* (*calloc_psram)(size_t count, size_t size);
+    /** PSRAM-targeted realloc. Grows or moves the allocation while keeping
+     *  it in PSRAM. Same fallback rules as malloc_psram. */
+    void* (*realloc_psram)(void* ptr, size_t size);
     bool (*get_fs_info)(const char* label, size_t* total, size_t* used);
     void (*log)(int level, const char* tag, const char* fmt, ...);
     int (*stdout_write)(const void* buf, size_t len);

--- a/packages/@mikrojs/native/include/mikrojs/platform.h
+++ b/packages/@mikrojs/native/include/mikrojs/platform.h
@@ -18,11 +18,25 @@ typedef struct MIKPlatform {
     size_t (*get_free_system_mem)(void);
     size_t (*get_min_free_system_mem)(void); /* All-time low watermark */
     size_t (*get_total_system_mem)(void);
-    /** Largest contiguous free block (for diagnosing heap fragmentation —
+    /** Largest contiguous free block (for diagnosing heap fragmentation:
      *  an allocation larger than this fails even if total free is bigger).
      *  On platforms without a native largest-block API, implementations
      *  may return the same value as get_free_system_mem. */
     size_t (*get_largest_free_system_mem)(void);
+    /** Free internal-SRAM bytes. On chips with PSRAM this is the subset of
+     *  free heap that lives in fast on-chip RAM, which is also what mbedTLS
+     *  handshake buffers, WiFi/BLE drivers, and DMA-capable buffers compete
+     *  for. Distinct from get_free_system_mem on PSRAM-equipped chips, where
+     *  combined heap is dominated by PSRAM and hides internal-SRAM pressure.
+     *  On hosts and chips without PSRAM, may return the same value as
+     *  get_free_system_mem (or 0 if unavailable). */
+    size_t (*get_free_internal_mem)(void);
+    /** Largest contiguous free block in internal SRAM. Allocations that
+     *  must land in internal RAM (such as mbedTLS record buffers) fail when
+     *  this drops below their size, even when get_largest_free_system_mem
+     *  reports plenty of contiguous PSRAM. Same fallback rules as
+     *  get_free_internal_mem. */
+    size_t (*get_largest_free_internal_mem)(void);
     bool (*get_fs_info)(const char* label, size_t* total, size_t* used);
     void (*log)(int level, const char* tag, const char* fmt, ...);
     int (*stdout_write)(const void* buf, size_t len);

--- a/packages/@mikrojs/native/runtime/sys/types.ts
+++ b/packages/@mikrojs/native/runtime/sys/types.ts
@@ -10,10 +10,23 @@ export interface MemoryUsage {
   /** Total system heap in bytes (0 on host) */
   systemTotal: number
   /** Largest contiguous free block in bytes (0 on host). Allocations
-   *  larger than this fail even when `systemFree` is bigger — the gap
+   *  larger than this fail even when `systemFree` is bigger; the gap
    *  between `systemLargestFree` and `systemFree` measures heap
    *  fragmentation. */
   systemLargestFree: number
+  /** Free internal-SRAM bytes (0 on host). On chips with PSRAM this is
+   *  the subset of free heap that lives in fast on-chip RAM, which
+   *  also holds mbedTLS handshake buffers, WiFi/BLE driver state, and
+   *  DMA-capable buffers. On PSRAM-equipped chips `systemFree` is
+   *  dominated by PSRAM and can hide internal-SRAM pressure: watch
+   *  `internalFree` instead when diagnosing TLS handshake or driver
+   *  allocation failures. On chips without PSRAM, equals `systemFree`. */
+  internalFree: number
+  /** Largest contiguous free block in internal SRAM (0 on host).
+   *  Allocations that must land in internal RAM (such as mbedTLS record
+   *  buffers, ~16 KB each) fail when this drops below their size, even
+   *  when `systemLargestFree` reports plenty of contiguous PSRAM. */
+  internalLargestFree: number
 }
 
 export interface Uptime {

--- a/packages/@mikrojs/native/src/mem.cpp
+++ b/packages/@mikrojs/native/src/mem.cpp
@@ -5,6 +5,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "mikrojs/platform.h"
+
 /*
  * QuickJS uses malloc_usable_size to track memory consumption against its
  * memory limit. ESP-IDF lacks a standard malloc_usable_size, and the
@@ -60,4 +62,66 @@ void* mik__realloc(void* ptr, size_t size) {
     if (!raw) return nullptr;
     hdr_write(raw, size);
     return static_cast<char*>(raw) + HDR_SIZE;
+}
+
+/* QuickJS-heap allocator. When the PSRAM flag is set, route through the
+ * platform's malloc_psram first; if the platform can't satisfy the request
+ * (no PSRAM, or PSRAM exhausted), fall back to libc malloc so the runtime
+ * keeps working. The fallback only matters on host builds and in PSRAM-OOM
+ * edge cases. Under normal ESP32 operation with CONFIG_SPIRAM=y, every
+ * allocation lands in PSRAM. */
+
+static bool g_quickjs_heap_psram = false;
+
+void mik__set_quickjs_heap_psram(bool enable) {
+    g_quickjs_heap_psram = enable;
+}
+
+bool mik__is_quickjs_heap_psram(void) {
+    return g_quickjs_heap_psram;
+}
+
+void* mik__js_malloc(size_t size) {
+    void* raw = nullptr;
+    if (g_quickjs_heap_psram) {
+        const MIKPlatform* p = MIK_GetPlatform();
+        if (p && p->malloc_psram) {
+            raw = p->malloc_psram(size + HDR_SIZE);
+        }
+    }
+    if (!raw) raw = malloc(size + HDR_SIZE);
+    if (!raw) return nullptr;
+    hdr_write(raw, size);
+    return static_cast<char*>(raw) + HDR_SIZE;
+}
+
+void* mik__js_calloc(size_t count, size_t size) {
+    if (size && count > SIZE_MAX / size) return nullptr;
+    size_t total = count * size;
+    void* raw = nullptr;
+    if (g_quickjs_heap_psram) {
+        const MIKPlatform* p = MIK_GetPlatform();
+        if (p && p->calloc_psram) {
+            raw = p->calloc_psram(1, total + HDR_SIZE);
+        }
+    }
+    if (!raw) raw = calloc(1, total + HDR_SIZE);
+    if (!raw) return nullptr;
+    hdr_write(raw, total);
+    return static_cast<char*>(raw) + HDR_SIZE;
+}
+
+void* mik__js_realloc(void* ptr, size_t size) {
+    void* raw = ptr ? static_cast<char*>(ptr) - HDR_SIZE : nullptr;
+    void* new_raw = nullptr;
+    if (g_quickjs_heap_psram) {
+        const MIKPlatform* p = MIK_GetPlatform();
+        if (p && p->realloc_psram) {
+            new_raw = p->realloc_psram(raw, size + HDR_SIZE);
+        }
+    }
+    if (!new_raw) new_raw = realloc(raw, size + HDR_SIZE);
+    if (!new_raw) return nullptr;
+    hdr_write(new_raw, size);
+    return static_cast<char*>(new_raw) + HDR_SIZE;
 }

--- a/packages/@mikrojs/native/src/mik_sys.cpp
+++ b/packages/@mikrojs/native/src/mik_sys.cpp
@@ -47,6 +47,10 @@ static JSValue mik__sys_memory_usage(JSContext* ctx, JSValue this_val, int argc,
                       JS_NewInt64(ctx, (int64_t)platform->get_total_system_mem()));
     JS_SetPropertyStr(ctx, obj, "systemLargestFree",
                       JS_NewInt64(ctx, (int64_t)platform->get_largest_free_system_mem()));
+    JS_SetPropertyStr(ctx, obj, "internalFree",
+                      JS_NewInt64(ctx, (int64_t)platform->get_free_internal_mem()));
+    JS_SetPropertyStr(ctx, obj, "internalLargestFree",
+                      JS_NewInt64(ctx, (int64_t)platform->get_largest_free_internal_mem()));
     return obj;
 }
 

--- a/packages/@mikrojs/native/src/mikrojs.cpp
+++ b/packages/@mikrojs/native/src/mikrojs.cpp
@@ -17,16 +17,18 @@
 
 #define MIK__DEFAULT_STACK_SIZE 1024 * 1024  // 1 MB
 
-/* JS malloc functions */
+/* JS malloc functions. Routed through the mik__js_* family so the QuickJS
+ * heap can be relocated to PSRAM on chips with both internal SRAM and PSRAM,
+ * leaving internal SRAM free for mbedTLS, WiFi/BLE, and DMA buffers. */
 
 static void* mik__mf_calloc(void* opaque, size_t count, size_t size) {
     (void)opaque;
-    return mik__calloc(count, size);
+    return mik__js_calloc(count, size);
 }
 
 static void* mik__mf_malloc(void* opaque, size_t size) {
     (void)opaque;
-    return mik__malloc(size);
+    return mik__js_malloc(size);
 }
 
 static void mik__mf_free(void* opaque, void* ptr) {
@@ -36,7 +38,7 @@ static void mik__mf_free(void* opaque, void* ptr) {
 
 static void* mik__mf_realloc(void* opaque, void* ptr, size_t size) {
     (void)opaque;
-    return mik__realloc(ptr, size);
+    return mik__js_realloc(ptr, size);
 }
 
 static const JSMallocFunctions mik_mf = {
@@ -199,7 +201,11 @@ static void mik__promise_rejection_tracker(JSContext* ctx, JSValue promise, JSVa
 }
 
 void MIK_DefaultOptions(MIKRunOptions* options) {
-    static MIKRunOptions default_options = {.mem_limit = 0, .stack_size = MIK__DEFAULT_STACK_SIZE};
+    static MIKRunOptions default_options = {
+        .mem_limit = 0,
+        .stack_size = MIK__DEFAULT_STACK_SIZE,
+        .use_psram_heap = false,
+    };
 
     memcpy(options, &default_options, sizeof(*options));
 }
@@ -227,6 +233,12 @@ MIKRuntime* MIK_NewRuntimeInternal(MIKRunOptions* options) {
 
     memcpy(&mik_rt->options, options, sizeof(*options));
     MIK_DefaultConfig(&mik_rt->config);
+
+    /* Switch the QuickJS heap to PSRAM before constructing the runtime,
+     * so JS_NewRuntime2 and every subsequent QuickJS allocation lands
+     * in PSRAM. The MIKRuntime struct itself stays in internal SRAM:
+     * it was allocated before this point. */
+    mik__set_quickjs_heap_psram(options->use_psram_heap);
 
     rt = JS_NewRuntime2(&mik_mf, NULL);
     CHECK_NOT_NULL(rt);

--- a/packages/@mikrojs/native/src/platform_posix.cpp
+++ b/packages/@mikrojs/native/src/platform_posix.cpp
@@ -53,6 +53,23 @@ static size_t posix_get_largest_free_internal_mem(void) {
     return 0;  /* No internal/PSRAM distinction on desktop */
 }
 
+static void* posix_malloc_psram(size_t size) {
+    (void)size;
+    return NULL;  /* No PSRAM on desktop; caller falls back to libc */
+}
+
+static void* posix_calloc_psram(size_t count, size_t size) {
+    (void)count;
+    (void)size;
+    return NULL;
+}
+
+static void* posix_realloc_psram(void* ptr, size_t size) {
+    (void)ptr;
+    (void)size;
+    return NULL;
+}
+
 static bool posix_get_fs_info(const char* label, size_t* total, size_t* used) {
     (void)label;
     (void)total;
@@ -121,6 +138,9 @@ static const MIKPlatform posix_platform = {
     .get_largest_free_system_mem = posix_get_largest_free_system_mem,
     .get_free_internal_mem = posix_get_free_internal_mem,
     .get_largest_free_internal_mem = posix_get_largest_free_internal_mem,
+    .malloc_psram = posix_malloc_psram,
+    .calloc_psram = posix_calloc_psram,
+    .realloc_psram = posix_realloc_psram,
     .get_fs_info = posix_get_fs_info,
     .log = posix_log,
     .stdout_write = posix_stdout_write,

--- a/packages/@mikrojs/native/src/platform_posix.cpp
+++ b/packages/@mikrojs/native/src/platform_posix.cpp
@@ -45,6 +45,14 @@ static size_t posix_get_largest_free_system_mem(void) {
     return 0;  /* Not available on desktop */
 }
 
+static size_t posix_get_free_internal_mem(void) {
+    return 0;  /* No internal/PSRAM distinction on desktop */
+}
+
+static size_t posix_get_largest_free_internal_mem(void) {
+    return 0;  /* No internal/PSRAM distinction on desktop */
+}
+
 static bool posix_get_fs_info(const char* label, size_t* total, size_t* used) {
     (void)label;
     (void)total;
@@ -111,6 +119,8 @@ static const MIKPlatform posix_platform = {
     .get_min_free_system_mem = posix_get_min_free_system_mem,
     .get_total_system_mem = posix_get_total_system_mem,
     .get_largest_free_system_mem = posix_get_largest_free_system_mem,
+    .get_free_internal_mem = posix_get_free_internal_mem,
+    .get_largest_free_internal_mem = posix_get_largest_free_internal_mem,
     .get_fs_info = posix_get_fs_info,
     .log = posix_log,
     .stdout_write = posix_stdout_write,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/mikrojs
 
+  dev/sram-pressure:
+    dependencies:
+      mikrojs:
+        specifier: workspace:*
+        version: link:../../packages/mikrojs
+
   dev/stackoverflow:
     dependencies:
       mikrojs:


### PR DESCRIPTION
## Why

HTTPS handshake fails fast (`0x7002`) on PSRAM-equipped devices once retained JS state grows past ~30-40 KB. mbedTLS handshake buffers must come from contiguous internal SRAM, where they compete with QuickJS heap chunks; combined `systemFree` is dominated by 8 MB of PSRAM and hides the pressure entirely.

## Three mitigations, layered

1. **Surface `internalFree` / `internalLargestFree` on `memoryUsage()`.** Diagnostic. Without these, users tracking HTTPS regressions see "8 MB free" while the real constraint is under 16 KB. No behavior change.

2. **Halve mbedTLS `SSL_IN_CONTENT_LEN` from 16 KB to 8 KB.** Outbound was already 4 KB via `ASYMMETRIC_CONTENT_LEN`. Buys ~33% more JS-state headroom on every chip; ESP32-C3/C6 (no PSRAM) needs this since (3) is a no-op there.

3. **Allocate the QuickJS heap from PSRAM by default on PSRAM chips.** Structural fix. Decouples internal-SRAM headroom from JS state size entirely. Default-on via `CONFIG_MIKROJS_QUICKJS_HEAP_PSRAM` (gated on `CONFIG_SPIRAM`); flip it off if your workload is JS-execution-bound.

## Validation

`dev/sram-pressure/` is a synthetic fixture that retains JS objects step-by-step and prints the failure threshold. On esp32s3:

| | Before | With (1)+(2)+(3) |
|---|---|---|
| Boot `internalLargestFree` | 31,744 | 167,936 |
| Threshold to break HTTPS | ~32 KB ballast | >160 KB (sweep ceiling, no failure) |
| Avg fetch latency | 2660 ms | 2701 ms |

PSRAM speed penalty is invisible against TLS round-trip cost on IO-bound workloads.

## Notes

- Pure additions to `MIKPlatform`, `MIKRunOptions`, and `MemoryUsage`. No removals.
- `mem_reserved` calibration is now slightly conservative on PSRAM chips (JS heap no longer competes with mbedTLS in internal SRAM); existing apps over-reserve harmlessly.
- ESP32 / C3 / C6 (no PSRAM) get (1) and (2) only.
- Test plan: reflash and run `dev/sram-pressure` against `WIFI_SSID` / `WIFI_PASSPHRASE`; expect HTTPS to keep working past `MAX_STEPS=20` (160 KB).
