### PR TITLE
feat(firmware): add ESP32-C5 chip support

### DIFF
--- a/.github/actions/firmware-build/action.yml
+++ b/.github/actions/firmware-build/action.yml
@@ -7,7 +7,7 @@ description: Build the mikrojs firmware for a single ESP32 chip target and uploa
 #      relative `uses: ./.github/actions/firmware-build` path resolves.
 inputs:
   target:
-    description: ESP32 chip target (esp32, esp32c3, esp32c6, esp32s3)
+    description: ESP32 chip target (esp32, esp32c3, esp32c5, esp32c6, esp32s3)
     required: true
   pack-format:
     description: 'How to lay out the uploaded artifact: tarball | unpacked'

--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -13,6 +13,7 @@ on:
           - all
           - esp32
           - esp32c3
+          - esp32c5
           - esp32c6
           - esp32s3
 

--- a/dev/e2e/test/cbor.test.heap-baseline.json
+++ b/dev/e2e/test/cbor.test.heap-baseline.json
@@ -1,4 +1,7 @@
 {
+  "esp32c5": {
+    "heapDelta": 4050
+  },
   "esp32c6": {
     "heapDelta": 4050
   },

--- a/dev/e2e/test/env.test.heap-baseline.json
+++ b/dev/e2e/test/env.test.heap-baseline.json
@@ -1,4 +1,7 @@
 {
+  "esp32c5": {
+    "heapDelta": 4130
+  },
   "esp32c6": {
     "heapDelta": 4130
   },

--- a/dev/e2e/test/fs.test.heap-baseline.json
+++ b/dev/e2e/test/fs.test.heap-baseline.json
@@ -1,4 +1,7 @@
 {
+  "esp32c5": {
+    "heapDelta": 5069
+  },
   "esp32c6": {
     "heapDelta": 5069
   },

--- a/dev/e2e/test/globals.test.heap-baseline.json
+++ b/dev/e2e/test/globals.test.heap-baseline.json
@@ -1,4 +1,7 @@
 {
+  "esp32c5": {
+    "heapDelta": 16033
+  },
   "esp32c6": {
     "heapDelta": 16033
   },

--- a/dev/e2e/test/http-request-e2e.test.heap-baseline.json
+++ b/dev/e2e/test/http-request-e2e.test.heap-baseline.json
@@ -1,4 +1,7 @@
 {
+  "esp32c5": {
+    "heapDelta": 3613
+  },
   "esp32c6": {
     "heapDelta": 3613
   },

--- a/dev/e2e/test/http-request-streaming.test.heap-baseline.json
+++ b/dev/e2e/test/http-request-streaming.test.heap-baseline.json
@@ -1,4 +1,7 @@
 {
+  "esp32c5": {
+    "heapDelta": 3234
+  },
   "esp32c6": {
     "heapDelta": 3234
   },

--- a/dev/e2e/test/import-meta.test.heap-baseline.json
+++ b/dev/e2e/test/import-meta.test.heap-baseline.json
@@ -1,4 +1,7 @@
 {
+  "esp32c5": {
+    "heapDelta": 3833
+  },
   "esp32c6": {
     "heapDelta": 3833
   },

--- a/dev/e2e/test/kv.test.heap-baseline.json
+++ b/dev/e2e/test/kv.test.heap-baseline.json
@@ -1,4 +1,7 @@
 {
+  "esp32c5": {
+    "heapDelta": 4153
+  },
   "esp32c6": {
     "heapDelta": 4153
   },

--- a/dev/e2e/test/modules-network.test.heap-baseline.json
+++ b/dev/e2e/test/modules-network.test.heap-baseline.json
@@ -1,4 +1,7 @@
 {
+  "esp32c5": {
+    "heapDelta": 40624
+  },
   "esp32c6": {
     "heapDelta": 40748
   },

--- a/dev/e2e/test/modules.test.heap-baseline.json
+++ b/dev/e2e/test/modules.test.heap-baseline.json
@@ -1,4 +1,7 @@
 {
+  "esp32c5": {
+    "heapDelta": 30450
+  },
   "esp32c6": {
     "heapDelta": 30450
   },

--- a/dev/e2e/test/result.test.heap-baseline.json
+++ b/dev/e2e/test/result.test.heap-baseline.json
@@ -1,4 +1,7 @@
 {
+  "esp32c5": {
+    "heapDelta": 4050
+  },
   "esp32c6": {
     "heapDelta": 4050
   },

--- a/dev/e2e/test/schema.test.heap-baseline.json
+++ b/dev/e2e/test/schema.test.heap-baseline.json
@@ -1,4 +1,7 @@
 {
+  "esp32c5": {
+    "heapDelta": 4153
+  },
   "esp32c6": {
     "heapDelta": 4153
   },

--- a/dev/e2e/test/smoke.test.heap-baseline.json
+++ b/dev/e2e/test/smoke.test.heap-baseline.json
@@ -1,4 +1,7 @@
 {
+  "esp32c5": {
+    "heapDelta": 3833
+  },
   "esp32c6": {
     "heapDelta": 3833
   },

--- a/dev/e2e/test/sys.test.heap-baseline.json
+++ b/dev/e2e/test/sys.test.heap-baseline.json
@@ -1,4 +1,7 @@
 {
+  "esp32c5": {
+    "heapDelta": 3833
+  },
   "esp32c6": {
     "heapDelta": 3833
   },

--- a/dev/e2e/test/udp.test.heap-baseline.json
+++ b/dev/e2e/test/udp.test.heap-baseline.json
@@ -1,4 +1,7 @@
 {
+  "esp32c5": {
+    "heapDelta": -832
+  },
   "esp32c6": {
     "heapDelta": -832
   }

--- a/dev/e2e/test/wifi-e2e.test.heap-baseline.json
+++ b/dev/e2e/test/wifi-e2e.test.heap-baseline.json
@@ -1,4 +1,7 @@
 {
+  "esp32c5": {
+    "heapDelta": 41093
+  },
   "esp32c6": {
     "heapDelta": 41217
   },

--- a/docs/compatible-boards.md
+++ b/docs/compatible-boards.md
@@ -9,7 +9,7 @@ Mikro.js works with most ESP32-based development boards. This page lists boards 
 
 ## Requirements
 
-- **Chip**: ESP32, ESP32-S3, ESP32-C3, or ESP32-C6
+- **Chip**: ESP32, ESP32-S3, ESP32-C3, ESP32-C5, or ESP32-C6
 - **Flash**: At least 4 MB
 - **RAM**: At least 300 KB available
 - **USB**: USB-C recommended for ease of use
@@ -20,11 +20,12 @@ The key limiting factor is RAM: the runtime, your JavaScript application, and al
 
 These boards are actively used during Mikro.js development.
 
-| Board                     | Chip     | Flash | PSRAM | Link                                                                                 |
-| ------------------------- | -------- | ----- | ----- | ------------------------------------------------------------------------------------ |
-| Seeed Studio XIAO ESP32C3 | ESP32-C3 | 4 MB  | -     | [seeedstudio.com](https://www.seeedstudio.com/Seeed-XIAO-ESP32C3-p-5431.html)        |
-| Seeed Studio XIAO ESP32S3 | ESP32-S3 | 8 MB  | 8 MB  | [seeedstudio.com](https://www.seeedstudio.com/XIAO-ESP32S3-p-5627.html)              |
-| Seeed Studio XIAO ESP32C6 | ESP32-C6 | 4 MB  | -     | [seeedstudio.com](https://www.seeedstudio.com/Seeed-Studio-XIAO-ESP32C6-p-5884.html) |
+| Board                     | Chip     | Flash | PSRAM | Link                                                                                  |
+| ------------------------- | -------- | ----- | ----- | ------------------------------------------------------------------------------------- |
+| Seeed Studio XIAO ESP32C3 | ESP32-C3 | 4 MB  | -     | [seeedstudio.com](https://www.seeedstudio.com/Seeed-XIAO-ESP32C3-p-5431.html)         |
+| Seeed Studio XIAO ESP32S3 | ESP32-S3 | 8 MB  | 8 MB  | [seeedstudio.com](https://www.seeedstudio.com/XIAO-ESP32S3-p-5627.html)               |
+| Seeed Studio XIAO ESP32C6 | ESP32-C6 | 4 MB  | -     | [seeedstudio.com](https://www.seeedstudio.com/Seeed-Studio-XIAO-ESP32C6-p-5884.html)  |
+| Seeed Studio XIAO ESP32C5 | ESP32-C5 | 8 MB  | 8 MB  | [seeedstudio.com](https://www.seeedstudio.com/Seeed-Studio-XIAO-ESP32-C5-p-6573.html) |
 
 The XIAO ESP32C6 is small, cheap (~$5), has USB-C, and is the primary board Mikro.js is developed and tested against. If you're unsure what to buy, start here.
 
@@ -35,6 +36,7 @@ Any board that meets the [requirements](#requirements) should work, regardless o
 ## Chip notes
 
 - **ESP32-C3**: Single-core RISC-V. Works well but has less RAM than dual-core variants.
+- **ESP32-C5**: Dual-band Wi-Fi 6 (2.4 GHz and 5 GHz) and BLE 5. Requires PSRAM for the standard mikrojs configuration (Wi-Fi + BLE concurrently); bare modules without PSRAM are not currently supported. 5 GHz access requires `wifi.country` to be set to a region that allows it.
 - **ESP32-C6**: Adds Wi-Fi 6 and Thread/Zigbee radio alongside BLE.
 
 ## Other manufacturers

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,7 @@ This guide walks you through creating a Mikro.js project, flashing firmware to a
 - An ESP32 development board
 
 ::: tip Which board should I use?
-Any ESP32, ESP32-C3, ESP32-S3, or ESP32-C6 board should work out of the box. We recommend the [Seeed Studio XIAO ESP32C6](https://www.seeedstudio.com/Seeed-Studio-XIAO-ESP32C6-p-5884.html): it's small, cheap (~$5), has USB-C, and is the primary board Mikro.js is developed and tested against.
+Any ESP32, ESP32-C3, ESP32-S3, ESP32-C5, or ESP32-C6 board should work out of the box. We recommend the [Seeed Studio XIAO ESP32C6](https://www.seeedstudio.com/Seeed-Studio-XIAO-ESP32C6-p-5884.html): it's small, cheap (~$5), has USB-C, and is the primary board Mikro.js is developed and tested against.
 :::
 
 ## Create a project

--- a/packages/@mikrojs/firmware/chips.json
+++ b/packages/@mikrojs/firmware/chips.json
@@ -1,3 +1,3 @@
 {
-  "chips": ["esp32", "esp32c3", "esp32c6", "esp32s3"]
+  "chips": ["esp32", "esp32c3", "esp32c5", "esp32c6", "esp32s3"]
 }

--- a/packages/@mikrojs/firmware/components/mikrojs/mik_http.cpp
+++ b/packages/@mikrojs/firmware/components/mikrojs/mik_http.cpp
@@ -213,8 +213,16 @@ static void mik__http_task(void* arg) {
     {
         esp_err_t err = esp_http_client_open(client, args->req.body_len);
         if (err != ESP_OK) {
-            snprintf(error_buf, sizeof(error_buf), "fetch failed: could not connect to %s",
-                     args->req.url);
+            int sock_errno = esp_http_client_get_errno(client);
+            int tls_code = 0;
+            int tls_flags = 0;
+            esp_err_t last_tls_err =
+                esp_http_client_get_and_clear_last_tls_error(client, &tls_code, &tls_flags);
+            snprintf(error_buf, sizeof(error_buf),
+                     "fetch failed: could not connect to %s (%s, errno=%d, "
+                     "esp_tls=%s, mbedtls=-0x%04x, flags=0x%x)",
+                     args->req.url, esp_err_to_name(err), sock_errno,
+                     esp_err_to_name(last_tls_err), tls_code, tls_flags);
             have_error = true;
             goto cleanup;
         }

--- a/packages/@mikrojs/firmware/sdkconfig.defaults
+++ b/packages/@mikrojs/firmware/sdkconfig.defaults
@@ -93,7 +93,10 @@ CONFIG_VFS_SUPPORT_SELECT=n
 
 # --- Assertions & error strings ---
 CONFIG_COMPILER_OPTIMIZATION_CHECKS_SILENT=y
-CONFIG_ESP_ERR_TO_NAME_LOOKUP=n
+# Keep esp_err_to_name() readable. Costs ~2 KB flash; without this, runtime
+# errors surface as "UNKNOWN ERROR" instead of e.g. ESP_ERR_NO_MEM, which
+# makes diagnosing on-device failures unnecessarily painful.
+CONFIG_ESP_ERR_TO_NAME_LOOKUP=y
 CONFIG_HAL_DEFAULT_ASSERTION_LEVEL=0
 
 # --- lwIP ---

--- a/packages/@mikrojs/firmware/sdkconfig.defaults.esp32c5
+++ b/packages/@mikrojs/firmware/sdkconfig.defaults.esp32c5
@@ -1,0 +1,15 @@
+# ESP32-C5: same console story as C6 (UART primary, USB-Serial/JTAG
+# secondary). See sdkconfig.defaults.esp32c6 for the reasoning around
+# avoiding ESP-IDF's USB-JTAG VFS at boot. mikrojs installs the
+# USB-Serial/JTAG driver itself for REPL/TLV transport; auto-detection
+# latches to whichever interface receives the first byte.
+CONFIG_ESP_CONSOLE_UART_DEFAULT=y
+CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=n
+CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=y
+
+# Enable PSRAM. Quad SPI is the only supported mode on ESP32-C5.
+# IGNORE_NOTFOUND so the same firmware boots on bare C5 modules too,
+# falling back to internal SRAM only.
+CONFIG_SPIRAM=y
+CONFIG_SPIRAM_USE_MALLOC=y
+CONFIG_SPIRAM_IGNORE_NOTFOUND=y

--- a/packages/mikrojs/src/cli/commands/sim/profile.ts
+++ b/packages/mikrojs/src/cli/commands/sim/profile.ts
@@ -120,6 +120,7 @@ export const args = command(
 const CHIP_BUDGETS_KB: Record<string, number> = {
   esp32: 200,
   esp32c3: 180,
+  esp32c5: 240,
   esp32c6: 240,
   esp32s3: 260,
 }

--- a/packages/mikrojs/src/cli/lib/esptool.ts
+++ b/packages/mikrojs/src/cli/lib/esptool.ts
@@ -13,6 +13,7 @@ type Chip =
   | 'esp32h2beta1'
   | 'esp32h2beta2'
   | 'esp32c2'
+  | 'esp32c5'
   | 'esp32c6'
   | 'esp32h2'
 


### PR DESCRIPTION
Validated end-to-end on Seeed XIAO ESP32-C5 with ESP-IDF v6.0.1: GPIO, PSRAM (8 MB), WiFi+BLE coexistence, SNTP, HTTPS fetch, hardware crypto.

C5 sdkconfig.defaults mirrors C6 console (UART primary, USB-Serial/JTAG secondary) and enables PSRAM with IGNORE_NOTFOUND so the same firmware boots on bare modules without PSRAM. No further C5-specific workarounds are needed; the recent PSRAM heap and TLS buffer optimizations in main shrunk the internal-SRAM pressure enough that C5 fits the standard memory model.

Drive-by improvements applied to all chips:
- CONFIG_ESP_ERR_TO_NAME_LOOKUP=y so runtime errors show real names instead of "UNKNOWN ERROR" (about 2 KB flash)
- HTTP fetch errors now include errno, esp_tls error name, and mbedtls return code for actionable on-device diagnostics