### PR TITLE
feat(wifi)!: drive country and hostname from mikro.config.ts

### DIFF
--- a/dev/e2e/test/http-request-e2e.test.ts
+++ b/dev/e2e/test/http-request-e2e.test.ts
@@ -24,7 +24,6 @@ const isSim = env.get('MIKRO_ENV') === 'simulator'
 
 describe.runIf(hasWifi && !isSim)('http request e2e', () => {
   beforeAll(async () => {
-    wifi.country = 'NO'
     const connected = await wifi.connect(WIFI_SSID!, WIFI_PASSPHRASE!)
     assert.equal(connected.ok, true, 'wifi connect')
     if (connected.ok) console.log(`connected: ${connected.value.ip}`)

--- a/dev/e2e/test/http-request-streaming.test.ts
+++ b/dev/e2e/test/http-request-streaming.test.ts
@@ -22,7 +22,6 @@ const isSim = env.get('MIKRO_ENV') === 'simulator'
 
 describe.runIf(hasWifi && !isSim)('http request streaming', () => {
   beforeAll(async () => {
-    wifi.country = 'NO'
     const connected = await wifi.connect(WIFI_SSID!, WIFI_PASSPHRASE!)
     assert.equal(connected.ok, true, 'wifi connect')
     if (connected.ok) console.log(`connected: ${connected.value.ip}`)

--- a/dev/kitchen-sink/app/main.ts
+++ b/dev/kitchen-sink/app/main.ts
@@ -99,7 +99,6 @@ console.log('neopixel end:', neo.end())
 logMem('after neopixel')
 
 // --- wifi ---
-wifi.country = 'NO'
 const WIFI_SSID = env.get('WIFI_SSID')
 const WIFI_PASSPHRASE = env.get('WIFI_PASSPHRASE')
 console.log('connecting to wifi...')

--- a/dev/kitchen-sink/mikro.config.ts
+++ b/dev/kitchen-sink/mikro.config.ts
@@ -2,5 +2,4 @@ import {defineConfig} from 'mikrojs'
 
 export default defineConfig({
   wifi: {country: 'NO'},
-  restartOnUncaughtException: false,
 })

--- a/dev/sram-pressure/mikro.config.ts
+++ b/dev/sram-pressure/mikro.config.ts
@@ -1,6 +1,6 @@
 import {defineConfig} from 'mikrojs'
 
 export default defineConfig({
-  wifiCountry: 'NO',
+  wifi: {country: 'NO'},
   restartOnUncaughtException: false,
 })

--- a/docs/config.md
+++ b/docs/config.md
@@ -27,7 +27,8 @@ These options are bundled into the deployed app and read by the firmware at boot
 | `restartDelay`               | `number` (ms)     | `0`              | Delay before restart after uncaught exception |
 | `stackSize`                  | `number` (bytes)  | firmware default | QuickJS C stack size                          |
 | `memReserved`                | `number` (bytes)  | `65536` (64 KB)  | Heap reserved for native subsystems           |
-| `wifiCountry`                | `WifiCountryCode` | none             | WiFi regulatory country code                  |
+| `wifi.country`               | `WifiCountryCode` | none             | WiFi regulatory country code                  |
+| `wifi.hostname`              | `string`          | `mikrojs-<id>`   | DHCP hostname advertised by the STA interface |
 
 ### `restartOnUncaughtException`
 
@@ -51,9 +52,13 @@ Amount of system heap to keep out of QuickJS's reach, reserved for native subsys
 
 Use `/mem` in the REPL to verify: the **System** line should have a comfortable cushion over the **QuickJS** line. See [Tuning memReserved](/developing-for-microcontrollers#tuning-memreserved) for more guidance.
 
-### `wifiCountry`
+### `wifi.country`
 
 Two-letter [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code for WiFi regulatory domain. Controls which channels and power levels are available. Set this to your country to comply with local regulations and ensure optimal WiFi performance. When unset, ESP-IDF defaults to world safe mode (`"01"`, channels 1-11). The full list of supported codes is defined by the [ESP-IDF regulatory database](https://github.com/espressif/esp-idf/blob/v6.0/components/esp_wifi/regulatory/esp_wifi_regulatory.txt) (168 countries/regions).
+
+### `wifi.hostname`
+
+DHCP hostname advertised by the STA interface. This is what your router shows in its client list. When unset, defaults to `mikrojs-<device-id>` (e.g. `mikrojs-abcdef0123`), where the device ID is a base32-encoded MAC. Must conform to RFC 1123: letters, digits and hyphens only, must not start or end with a hyphen, max 63 characters. Takes effect on the next DHCP lease.
 
 ## Build options {#build}
 
@@ -122,7 +127,10 @@ export default defineConfig({
   restartOnUncaughtException: true,
   restartDelay: 500,
   memReserved: 32 * 1024,
-  wifiCountry: 'NO', // Norway
+  wifi: {
+    country: 'NO', // Norway
+    hostname: 'living-room-sensor',
+  },
 
   build: {
     bundle: true,

--- a/docs/examples/sntp.md
+++ b/docs/examples/sntp.md
@@ -52,8 +52,6 @@ import {wifi} from 'mikrojs/wifi'
 await sleep(2000)
 console.log('Current time at startup: %s', new Date())
 
-wifi.country = 'NO'
-
 const ssid = env.require('WIFI_SSID')
 const passphrase = env.require('WIFI_PASSPHRASE')
 

--- a/docs/examples/udp-discovery.md
+++ b/docs/examples/udp-discovery.md
@@ -54,8 +54,6 @@ const GROUP = '224.0.0.251'
 const PORT = 7654
 const ANNOUNCE_MS = 2000
 
-wifi.country = 'NO'
-
 const ssid = env.require('WIFI_SSID')
 const passphrase = env.require('WIFI_PASSPHRASE')
 

--- a/docs/examples/wifi-access-point.md
+++ b/docs/examples/wifi-access-point.md
@@ -19,9 +19,6 @@ Configure the ESP32 as a WiFi access point (soft AP) that other devices can conn
 import {sleep} from 'mikrojs/sleep'
 import {wifi} from 'mikrojs/wifi'
 
-// Country must be set before using WiFi
-wifi.country = 'NO'
-
 // Start the access point
 wifi.ap
   .start({

--- a/docs/examples/wifi-fetch.md
+++ b/docs/examples/wifi-fetch.md
@@ -49,9 +49,6 @@ import {request} from 'mikrojs/http/request'
 import {memoryUsage} from 'mikrojs/sys'
 import {wifi} from 'mikrojs/wifi'
 
-// Country must be set before using WiFi
-wifi.country = 'NO'
-
 const ssid = env.require('WIFI_SSID')
 const passphrase = env.require('WIFI_PASSPHRASE')
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -295,7 +295,6 @@ const pass = env.get('WIFI_PASSPHRASE')
 describe.runIf(ssid && pass)('wifi', () => {
   test('connect', async () => {
     const {wifi} = await import('mikrojs/wifi')
-    wifi.country = 'NO'
     const result = await wifi.connect(ssid!, pass!)
     assert.equal(result.ok, true)
   })

--- a/examples/ble-beacon/sim/wifi.stub.ts
+++ b/examples/ble-beacon/sim/wifi.stub.ts
@@ -37,9 +37,6 @@ export class Wifi implements SimWifi {
   getHostname() {
     return 'mikrojs-sim' as string | undefined
   }
-  setHostname() {
-    return {ok: true as const}
-  }
   getIpConfig() {
     if (!connected) return {ok: true as const, value: undefined}
     return {
@@ -94,8 +91,5 @@ export class Wifi implements SimWifi {
   }
   getCountry() {
     return undefined
-  }
-  setCountry() {
-    return {ok: true as const}
   }
 }

--- a/examples/sntp/app/main.ts
+++ b/examples/sntp/app/main.ts
@@ -6,8 +6,6 @@ import {wifi} from 'mikrojs/wifi'
 await sleep(2000)
 console.log('Current time at startup: %s', new Date())
 
-wifi.country = 'NO'
-
 const ssid = env.require('WIFI_SSID')
 const passphrase = env.require('WIFI_PASSPHRASE')
 

--- a/examples/sntp/mikro.config.ts
+++ b/examples/sntp/mikro.config.ts
@@ -2,5 +2,4 @@ import {defineConfig} from 'mikrojs'
 
 export default defineConfig({
   wifi: {country: 'NO'},
-  restartOnUncaughtException: false,
 })

--- a/examples/sntp/tsconfig.json
+++ b/examples/sntp/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["env.d.ts", "app/**/*"],
+  "include": ["env.d.ts", "app/**/*", "mikro.config.ts"],
   "compilerOptions": {
     "module": "nodenext",
     "target": "es2024",

--- a/examples/udp-discovery/app/main.ts
+++ b/examples/udp-discovery/app/main.ts
@@ -12,8 +12,6 @@ const GROUP = '224.0.0.251'
 const PORT = 7654
 const ANNOUNCE_MS = 2000
 
-wifi.country = 'NO'
-
 const ssid = env.require('WIFI_SSID')
 const passphrase = env.require('WIFI_PASSPHRASE')
 

--- a/examples/udp-discovery/mikro.config.ts
+++ b/examples/udp-discovery/mikro.config.ts
@@ -2,5 +2,4 @@ import {defineConfig} from 'mikrojs'
 
 export default defineConfig({
   wifi: {country: 'NO'},
-  restartOnUncaughtException: false,
 })

--- a/examples/udp-discovery/tsconfig.json
+++ b/examples/udp-discovery/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["env.d.ts", "app/**/*", "scripts/**/*"],
+  "include": ["env.d.ts", "app/**/*", "scripts/**/*", "mikro.config.ts"],
   "compilerOptions": {
     "module": "nodenext",
     "target": "es2024",

--- a/examples/wifi-access-point/app/main.ts
+++ b/examples/wifi-access-point/app/main.ts
@@ -1,9 +1,6 @@
 import {sleep} from 'mikrojs/sleep'
 import {wifi} from 'mikrojs/wifi'
 
-// Country must be set before using WiFi
-wifi.country = 'NO'
-
 // Start the access point
 wifi.ap
   .start({

--- a/examples/wifi-access-point/mikro.config.ts
+++ b/examples/wifi-access-point/mikro.config.ts
@@ -2,5 +2,4 @@ import {defineConfig} from 'mikrojs'
 
 export default defineConfig({
   wifi: {country: 'NO'},
-  restartOnUncaughtException: false,
 })

--- a/examples/wifi-fetch/app/main.ts
+++ b/examples/wifi-fetch/app/main.ts
@@ -3,9 +3,6 @@ import {request} from 'mikrojs/http/request'
 import {memoryUsage} from 'mikrojs/sys'
 import {wifi} from 'mikrojs/wifi'
 
-// Country must be set before using WiFi
-wifi.country = 'NO'
-
 const ssid = env.require('WIFI_SSID')
 const passphrase = env.require('WIFI_PASSPHRASE')
 

--- a/examples/wifi-fetch/mikro.config.ts
+++ b/examples/wifi-fetch/mikro.config.ts
@@ -1,6 +1,6 @@
 import {defineConfig} from 'mikrojs'
 
 export default defineConfig({
-  wifiCountry: 'NO',
+  wifi: {country: 'NO'},
   restartOnUncaughtException: false,
 })

--- a/packages/@mikrojs/firmware/components/mikrojs/mik_wifi.cpp
+++ b/packages/@mikrojs/firmware/components/mikrojs/mik_wifi.cpp
@@ -9,6 +9,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
 #include "nvs_flash.h"
+#include "mikrojs/platform.h"
 #include "private.h"
 #include "utils.h"
 
@@ -251,7 +252,29 @@ static void mik__wifi_event_handler(void* arg, esp_event_base_t event_base, int3
     }
 }
 
-esp_err_t mik__wifi_ensure_initialized() {
+/* Pick the DHCP hostname for the STA netif: configured `wifi.hostname` from
+ * mikro.config.json takes priority; otherwise default to `mikrojs-<device-id>`.
+ * Returns true if a hostname was applied. */
+static bool mik__wifi_apply_hostname(JSContext* ctx) {
+    if (!s_sta_netif) return false;
+    char buf[64];
+    const char* hostname = nullptr;
+    if (ctx) {
+        MIKRuntime* mik_rt = MIK_GetRuntime(ctx);
+        if (mik_rt && mik_rt->config.wifi_hostname[0] != '\0') {
+            hostname = mik_rt->config.wifi_hostname;
+        }
+    }
+    if (!hostname) {
+        const char* dev_id = MIK_GetPlatform()->get_device_id();
+        if (!dev_id || !dev_id[0]) return false;
+        snprintf(buf, sizeof(buf), "mikrojs-%s", dev_id);
+        hostname = buf;
+    }
+    return esp_netif_set_hostname(s_sta_netif, hostname) == ESP_OK;
+}
+
+esp_err_t mik__wifi_ensure_initialized(JSContext* ctx) {
     if (s_wifi_initialized) return ESP_OK;
 
     esp_err_t err = nvs_flash_init();
@@ -272,6 +295,7 @@ esp_err_t mik__wifi_ensure_initialized() {
      * asserting in esp_netif_create_default_wifi_sta. */
     if (!s_sta_netif) {
         s_sta_netif = esp_netif_create_default_wifi_sta();
+        if (s_sta_netif) mik__wifi_apply_hostname(ctx);
     }
     if (!s_sta_netif) return ESP_FAIL;
 
@@ -310,8 +334,8 @@ fail_after_init:
 
 /* Start the WiFi radio.  Deferred from init so the radio is not active
  * until connect() or scan() is actually called. */
-static esp_err_t mik__wifi_ensure_started() {
-    esp_err_t err = mik__wifi_ensure_initialized();
+static esp_err_t mik__wifi_ensure_started(JSContext* ctx) {
+    esp_err_t err = mik__wifi_ensure_initialized(ctx);
     if (err != ESP_OK) return err;
     if (s_wifi_started) return ESP_OK;
 
@@ -374,7 +398,7 @@ static JSClassDef mik_wifi_classdef = {
 };
 
 static JSValue mik__wifi_constructor(JSContext* ctx, JSValue new_target, int argc, JSValue* argv) {
-    esp_err_t err = mik__wifi_ensure_initialized();
+    esp_err_t err = mik__wifi_ensure_initialized(ctx);
     if (err != ESP_OK) {
         return JS_ThrowInternalError(ctx, "WiFi init failed: %s", esp_err_to_name(err));
     }
@@ -386,7 +410,7 @@ static JSValue mik__wifi_connect(JSContext* ctx, JSValue this_val, int argc, JSV
         return mik__result_err_tag(ctx, "CountryNotSet");
     }
 
-    esp_err_t start_err = mik__wifi_ensure_started();
+    esp_err_t start_err = mik__wifi_ensure_started(ctx);
     if (start_err != ESP_OK) {
         return mik__result_err_named(ctx, "StartFailed",
                                "Failed to start WiFi radio: %s", esp_err_to_name(start_err));
@@ -478,7 +502,7 @@ static JSValue mik__wifi_scan(JSContext* ctx, JSValue this_val, int argc, JSValu
         return mik__result_err_tag(ctx, "CountryNotSet");
     }
 
-    esp_err_t start_err = mik__wifi_ensure_started();
+    esp_err_t start_err = mik__wifi_ensure_started(ctx);
     if (start_err != ESP_OK) {
         return mik__result_err_named(ctx, "StartFailed",
                                "Failed to start WiFi radio: %s", esp_err_to_name(start_err));
@@ -631,22 +655,6 @@ static JSValue mik__wifi_get_hostname(JSContext* ctx, JSValue this_val, int argc
     return JS_NewString(ctx, hostname);
 }
 
-static JSValue mik__wifi_set_hostname(JSContext* ctx, JSValue this_val, int argc, JSValue* argv) {
-    if (!s_sta_netif) {
-        return mik__result_err_tag(ctx, "NotInitialized");
-    }
-    const char* hostname = JS_ToCString(ctx, argv[0]);
-    if (!hostname) return JS_EXCEPTION;
-
-    esp_err_t err = esp_netif_set_hostname(s_sta_netif, hostname);
-    JS_FreeCString(ctx, hostname);
-    if (err != ESP_OK) {
-        return mik__result_err_named(ctx, "SetFailed",
-                               "Failed to set hostname: %s", esp_err_to_name(err));
-    }
-    return mik__result_ok_void(ctx);
-}
-
 static JSValue mik__wifi_get_ip_config(JSContext* ctx, JSValue this_val, int argc, JSValue* argv) {
     if (!s_sta_netif) {
         return JS_UNDEFINED;
@@ -746,7 +754,7 @@ static JSValue mik__wifi_ap_start(JSContext* ctx, JSValue this_val, int argc, JS
         return mik__result_err_tag(ctx, "CountryNotSet");
     }
 
-    esp_err_t err = mik__wifi_ensure_started();
+    esp_err_t err = mik__wifi_ensure_started(ctx);
     if (err != ESP_OK) {
         return mik__result_err_named(ctx, "StartFailed",
                                "Failed to start WiFi radio: %s", esp_err_to_name(err));
@@ -952,26 +960,11 @@ static JSValue mik__wifi_get_country(JSContext* ctx, JSValue this_val, int argc,
     return JS_NewStringLen(ctx, cc, 2);
 }
 
-static JSValue mik__wifi_set_country(JSContext* ctx, JSValue this_val, int argc, JSValue* argv) {
-    const char* cc = JS_ToCString(ctx, argv[0]);
-    if (!cc) return JS_EXCEPTION;
-
-    esp_err_t err = esp_wifi_set_country_code(cc, true);
-    JS_FreeCString(ctx, cc);
-
-    if (err != ESP_OK) {
-        return mik__result_err_named(ctx, "SetFailed",
-                               "Failed to set WiFi country code: %s", esp_err_to_name(err));
-    }
-    s_country_configured = true;
-    return mik__result_ok_void(ctx);
-}
-
 /* ── TX power ──────────────────────────────────────────────────────── */
 
 static JSValue mik__wifi_get_tx_power(JSContext* ctx, JSValue this_val, int argc, JSValue* argv) {
     /* esp_wifi_get_max_tx_power requires the radio to be started. */
-    esp_err_t start_err = mik__wifi_ensure_started();
+    esp_err_t start_err = mik__wifi_ensure_started(ctx);
     if (start_err != ESP_OK) {
         return mik__result_err_named(ctx, "GetFailed",
                                "Failed to get TX power: %s", esp_err_to_name(start_err));
@@ -988,7 +981,7 @@ static JSValue mik__wifi_get_tx_power(JSContext* ctx, JSValue this_val, int argc
 static JSValue mik__wifi_set_tx_power(JSContext* ctx, JSValue this_val, int argc, JSValue* argv) {
     double dbm;
     if (JS_ToFloat64(ctx, &dbm, argv[0])) return JS_EXCEPTION;
-    esp_err_t start_err = mik__wifi_ensure_started();
+    esp_err_t start_err = mik__wifi_ensure_started(ctx);
     if (start_err != ESP_OK) {
         return mik__result_err_named(ctx, "SetFailed",
                                "Failed to set TX power: %s", esp_err_to_name(start_err));
@@ -1097,7 +1090,6 @@ static const JSCFunctionListEntry mik__wifi_proto_funcs[] = {
     MIK_CFUNC_DEF("off", 2, mik__wifi_off),
     MIK_CFUNC_DEF("mac", 0, mik__wifi_mac),
     MIK_CFUNC_DEF("getHostname", 0, mik__wifi_get_hostname),
-    MIK_CFUNC_DEF("setHostname", 1, mik__wifi_set_hostname),
     MIK_CFUNC_DEF("getIpConfig", 0, mik__wifi_get_ip_config),
     MIK_CFUNC_DEF("setIpConfig", 1, mik__wifi_set_ip_config),
     MIK_CFUNC_DEF("apStart", 1, mik__wifi_ap_start),
@@ -1108,7 +1100,6 @@ static const JSCFunctionListEntry mik__wifi_proto_funcs[] = {
     MIK_CFUNC_DEF("getPowerSave", 0, mik__wifi_get_power_save),
     MIK_CFUNC_DEF("setPowerSave", 1, mik__wifi_set_power_save),
     MIK_CFUNC_DEF("getCountry", 0, mik__wifi_get_country),
-    MIK_CFUNC_DEF("setCountry", 1, mik__wifi_set_country),
     MIK_CFUNC_DEF("getTxPower", 0, mik__wifi_get_tx_power),
     MIK_CFUNC_DEF("setTxPower", 1, mik__wifi_set_tx_power),
     MIK_CFUNC_DEF("getRssiThreshold", 0, mik__wifi_get_rssi_threshold),

--- a/packages/@mikrojs/firmware/components/mikrojs/test/wifi_test.cpp
+++ b/packages/@mikrojs/firmware/components/mikrojs/test/wifi_test.cpp
@@ -28,11 +28,15 @@ static void setup() {
     vTaskDelay(pdMS_TO_TICKS(100));
     rt = MIK_NewRuntime();
     ctx = MIK_GetJSContext(rt);
+    /* Country is config-only — populate it directly so wifi ops that gate on
+     * mik__wifi_try_auto_country can proceed. */
+    MIKConfig cfg;
+    MIK_DefaultConfig(&cfg);
+    snprintf(cfg.wifi_country, sizeof(cfg.wifi_country), "US");
+    MIK_SetConfig(rt, &cfg);
     /* WiFi module is self-registered and lazily initialized.
-     * The import below triggers init + loop consumer registration.
-     * Then drain any stale events from previous tests. */
-    const char* init_code =
-        "import { Wifi } from \"native:wifi\"; new Wifi().setCountry(\"US\");";
+     * The import below triggers init + loop consumer registration. */
+    const char* init_code = "import { Wifi } from \"native:wifi\"; new Wifi();";
     JSValue ret = MIK_EvalModuleContent(ctx, "mikrojs/test-setup", init_code, strlen(init_code));
     if (!JS_IsException(ret)) {
         JS_FreeValue(ctx, ret);
@@ -332,14 +336,22 @@ TEST_CASE("Wifi mac returns a valid MAC address format", "[wifi]") {
     teardown();
 }
 
-TEST_CASE("Wifi hostname get/set round-trips", "[wifi]") {
-    setup();
+TEST_CASE("Wifi hostname reflects configured wifi.hostname", "[wifi]") {
+    /* Custom setup with wifi.hostname populated. Mirrors setup() but injects
+     * a hostname before the lazy netif init runs. */
+    esp_wifi_disconnect();
+    vTaskDelay(pdMS_TO_TICKS(100));
+    rt = MIK_NewRuntime();
+    ctx = MIK_GetJSContext(rt);
+    MIKConfig cfg;
+    MIK_DefaultConfig(&cfg);
+    snprintf(cfg.wifi_country, sizeof(cfg.wifi_country), "US");
+    snprintf(cfg.wifi_hostname, sizeof(cfg.wifi_hostname), "test-device");
+    MIK_SetConfig(rt, &cfg);
 
     JSValue ret = eval_module(R"(
         import { Wifi } from "native:wifi";
-        const wifi = new Wifi();
-        wifi.setHostname("test-device");
-        globalThis.__hostname = wifi.getHostname();
+        globalThis.__hostname = new Wifi().getHostname();
     )");
     TEST_ASSERT_FALSE_MESSAGE(JS_IsException(ret), "Module eval should not throw");
 
@@ -446,13 +458,15 @@ TEST_CASE("Wifi power save get/set round-trips", "[wifi]") {
     teardown();
 }
 
-TEST_CASE("Wifi country get/set round-trips", "[wifi]") {
+TEST_CASE("Wifi country reflects configured wifi.country", "[wifi]") {
     setup();
 
+    /* setup() populated wifi_country = "US"; trigger a wifi op so
+     * mik__wifi_try_auto_country applies it, then read back via getCountry. */
     JSValue ret = eval_module(R"(
         import { Wifi } from "native:wifi";
         const wifi = new Wifi();
-        wifi.setCountry("US");
+        wifi.scan();
         globalThis.__cc = wifi.getCountry();
     )");
     TEST_ASSERT_FALSE_MESSAGE(JS_IsException(ret), "Module eval should not throw");

--- a/packages/@mikrojs/native/include/mikrojs/mikrojs.h
+++ b/packages/@mikrojs/native/include/mikrojs/mikrojs.h
@@ -30,7 +30,8 @@ typedef struct MIKConfig {
     uint32_t mem_reserved;
     uint32_t fs_read_max; /* 0 = keep runtime default (65536) */
     char entry_point[128];
-    char wifi_country[3]; /* Two-letter country code + NUL, e.g. "NO" */
+    char wifi_country[3];   /* Two-letter country code + NUL, e.g. "NO" */
+    char wifi_hostname[64]; /* DHCP hostname; empty = use mikrojs-<device-id> default */
 } MIKConfig;
 
 void MIK_DefaultConfig(MIKConfig* config);

--- a/packages/@mikrojs/native/runtime/internal.d.ts
+++ b/packages/@mikrojs/native/runtime/internal.d.ts
@@ -407,7 +407,6 @@ declare module 'native:wifi' {
     // Network config
     mac(): R<string>
     getHostname(): string | undefined
-    setHostname(hostname: string): R<void>
     getIpConfig(): R<{ip: string; netmask: string; gateway: string; dns: string} | undefined>
     setIpConfig(opts: {
       ip?: string
@@ -446,7 +445,6 @@ declare module 'native:wifi' {
     getPowerSave(): string
     setPowerSave(mode: string): R<void>
     getCountry(): string | undefined
-    setCountry(cc: string): R<void>
   }
 
   export declare const Wifi: {

--- a/packages/@mikrojs/native/runtime/wifi/types.ts
+++ b/packages/@mikrojs/native/runtime/wifi/types.ts
@@ -139,7 +139,7 @@ export interface Wifi {
   off<K extends keyof WifiEventMap>(event: K, listener: WifiEventMap[K]): void
 
   readonly mac: string
-  hostname: string | undefined
+  readonly hostname: string | undefined
   ipConfig(): Result<IpConfig | undefined, WifiError>
   ipConfig(opts: StaticIpConfig): Result<void, WifiError>
   ipConfig(opts?: StaticIpConfig): Result<IpConfig | undefined, WifiError> | Result<void, WifiError>
@@ -150,7 +150,7 @@ export interface Wifi {
   rssiThreshold: number
 
   powerSave: PowerSaveMode
-  country: WifiCountryCode | undefined
+  readonly country: WifiCountryCode | undefined
 }
 
 export declare const wifi: Wifi

--- a/packages/@mikrojs/native/runtime/wifi/wifi.ts
+++ b/packages/@mikrojs/native/runtime/wifi/wifi.ts
@@ -152,12 +152,6 @@ const wifi: Wifi = {
     return native.getHostname()
   },
 
-  set hostname(value: string | undefined) {
-    if (value !== undefined) {
-      native.setHostname(value)
-    }
-  },
-
   ipConfig: ((
     opts?: StaticIpConfig,
   ): Result<IpConfig | undefined, WifiError> | Result<void, WifiError> => {
@@ -196,12 +190,6 @@ const wifi: Wifi = {
 
   get country(): WifiCountryCode | undefined {
     return native.getCountry() as WifiCountryCode | undefined
-  },
-
-  set country(cc: WifiCountryCode | undefined) {
-    if (cc !== undefined) {
-      native.setCountry(cc)
-    }
   },
 }
 

--- a/packages/@mikrojs/native/src/mik_app_config.cpp
+++ b/packages/@mikrojs/native/src/mik_app_config.cpp
@@ -19,6 +19,7 @@ void MIK_DefaultConfig(MIKConfig* config) {
     config->fs_read_max = 0; /* 0 = runtime default (65536) */
     config->entry_point[0] = '\0';
     config->wifi_country[0] = '\0';
+    config->wifi_hostname[0] = '\0';
 }
 
 /* Minimal JSON parser for config file — avoids cJSON dependency.
@@ -343,8 +344,10 @@ int MIK_LoadConfig(const char* base_path, MIKConfig* config) {
             if (mik__json_get_number(buf, "fsReadMax", &num_val)) {
                 config->fs_read_max = (uint32_t)num_val;
             }
-            mik__json_get_string(buf, "wifiCountry", config->wifi_country,
+            mik__json_get_string(buf, "wifi.country", config->wifi_country,
                                  sizeof(config->wifi_country));
+            mik__json_get_string(buf, "wifi.hostname", config->wifi_hostname,
+                                 sizeof(config->wifi_hostname));
 
             platform->log(MIK_LOG_INFO, TAG,
                            "Loaded config: restart=%d delay=%dms stack=%u reserved=%lu",

--- a/packages/create-mikrojs/src/templates/sntp/app/main.ts
+++ b/packages/create-mikrojs/src/templates/sntp/app/main.ts
@@ -6,8 +6,6 @@ import {wifi} from 'mikrojs/wifi'
 await sleep(2000)
 console.log('Current time at startup: %s', new Date())
 
-wifi.country = 'NO'
-
 const ssid = env.require('WIFI_SSID')
 const passphrase = env.require('WIFI_PASSPHRASE')
 

--- a/packages/create-mikrojs/src/templates/sntp/mikro.config.ts
+++ b/packages/create-mikrojs/src/templates/sntp/mikro.config.ts
@@ -1,6 +1,6 @@
 import {defineConfig} from 'mikrojs'
 
 export default defineConfig({
+  // Set to your country code so WiFi uses the correct regulatory domain.
   wifi: {country: 'NO'},
-  restartOnUncaughtException: false,
 })

--- a/packages/create-mikrojs/src/templates/wifi-access-point/app/main.ts
+++ b/packages/create-mikrojs/src/templates/wifi-access-point/app/main.ts
@@ -1,9 +1,6 @@
 import {sleep} from 'mikrojs/sleep'
 import {wifi} from 'mikrojs/wifi'
 
-// Country must be set before using WiFi
-wifi.country = 'NO'
-
 // Start the access point
 wifi.ap
   .start({

--- a/packages/create-mikrojs/src/templates/wifi-access-point/mikro.config.ts
+++ b/packages/create-mikrojs/src/templates/wifi-access-point/mikro.config.ts
@@ -1,6 +1,6 @@
 import {defineConfig} from 'mikrojs'
 
 export default defineConfig({
+  // Set to your country code so WiFi uses the correct regulatory domain.
   wifi: {country: 'NO'},
-  restartOnUncaughtException: false,
 })

--- a/packages/create-mikrojs/src/templates/wifi-fetch/app/main.ts
+++ b/packages/create-mikrojs/src/templates/wifi-fetch/app/main.ts
@@ -3,9 +3,6 @@ import {request} from 'mikrojs/http/request'
 import {memoryUsage} from 'mikrojs/sys'
 import {wifi} from 'mikrojs/wifi'
 
-// Country must be set before using WiFi
-wifi.country = 'NO'
-
 const ssid = env.require('WIFI_SSID')
 const passphrase = env.require('WIFI_PASSPHRASE')
 

--- a/packages/create-mikrojs/src/templates/wifi-fetch/mikro.config.ts
+++ b/packages/create-mikrojs/src/templates/wifi-fetch/mikro.config.ts
@@ -1,6 +1,6 @@
 import {defineConfig} from 'mikrojs'
 
 export default defineConfig({
+  // Set to your country code so WiFi uses the correct regulatory domain.
   wifi: {country: 'NO'},
-  restartOnUncaughtException: false,
 })

--- a/packages/mikrojs/src/_exports/index.ts
+++ b/packages/mikrojs/src/_exports/index.ts
@@ -89,6 +89,15 @@ export interface MikroJSBuildConfig {
   logLevel?: LogLevel
 }
 
+export interface MikroJSWifiConfig {
+  /** Two-letter ISO 3166-1 country code for the WiFi regulatory domain. */
+  country?: WifiCountryCode
+  /** DHCP hostname advertised by the STA interface. Defaults to
+   * `mikrojs-<device-id>` when unset. RFC 1123: letters, digits, hyphens
+   * only; must not start or end with a hyphen; max 63 chars. */
+  hostname?: string
+}
+
 export interface MikroJSConfig {
   restartOnUncaughtException?: boolean
   restartDelay?: number
@@ -99,7 +108,7 @@ export interface MikroJSConfig {
    * larger files chunk-by-chunk. Number of bytes, or string with K/M
    * suffix (e.g. '128k', '1m'). Default: 65536 (64 KiB). */
   fsReadMax?: number | string
-  wifiCountry?: WifiCountryCode
+  wifi?: MikroJSWifiConfig
   /** Simulator-only options. Stripped from the bundled config before deploy. */
   sim?: MikroJSSimConfig
   /** Build-time options. Stripped from the bundled config before deploy. */

--- a/packages/mikrojs/src/_exports/sim.ts
+++ b/packages/mikrojs/src/_exports/sim.ts
@@ -24,7 +24,6 @@ export interface SimStubMethods {
     off(event: string, listener: (...args: unknown[]) => void): void
     mac(): NR<string>
     getHostname(): string | undefined
-    setHostname(hostname: string): NRV
     getIpConfig(): NR<{ip: string; netmask: string; gateway: string; dns: string} | undefined>
     setIpConfig(opts: {
       ip?: string
@@ -55,7 +54,6 @@ export interface SimStubMethods {
     getPowerSave(): string
     setPowerSave(mode: string): NRV
     getCountry(): string | undefined
-    setCountry(cc: string): NRV
   }
   http: {
     request(

--- a/packages/mikrojs/src/cli/lib/build.ts
+++ b/packages/mikrojs/src/cli/lib/build.ts
@@ -153,6 +153,18 @@ export function loadConfig(entry: string): Promise<MikroJSConfig | null> {
   return loadMikroConfig(pathlib.dirname(pathlib.resolve(entry)))
 }
 
+// Strip host-only sections, normalize K/M-suffixed sizes, and flatten the
+// `wifi: {country, hostname}` group into dotted-key form so the device-side
+// JSON parser (mik_app_config.cpp) can read it without a nested-object pass.
+function serializeRuntimeConfig(config: MikroJSConfig): Record<string, unknown> {
+  const {sim: _sim, build: _build, wifi, fsReadMax, ...rest} = config
+  const out: Record<string, unknown> = {...rest}
+  if (fsReadMax !== undefined) out.fsReadMax = parseSize(fsReadMax)
+  if (wifi?.country) out['wifi.country'] = wifi.country
+  if (wifi?.hostname) out['wifi.hostname'] = wifi.hostname
+  return out
+}
+
 export function build(
   entry: string,
   buildDir: string,
@@ -268,19 +280,10 @@ export function build(
 
       const writeConfig = defer(() => {
         if (config === null) return EMPTY
-        // Strip sim + build sections: they're CLI/host-only and meaningless
-        // on device.
-        const {sim: _sim, build: _build, ...runtimeConfig} = config
-        // Normalize K/M-suffixed sizes to plain numbers so the device-side
-        // JSON parser (mik_app_config.cpp) can read them without shipping a
-        // suffix parser into flash.
-        if (runtimeConfig.fsReadMax !== undefined) {
-          runtimeConfig.fsReadMax = parseSize(runtimeConfig.fsReadMax)
-        }
         return output(
           buildDir,
           pathlib.join(rootDir, 'mikro.config.json'),
-          JSON.stringify(runtimeConfig),
+          JSON.stringify(serializeRuntimeConfig(config)),
         )
       })
 
@@ -469,14 +472,10 @@ export function buildTests(
 
       const writeConfig = defer(() => {
         if (config === null) return EMPTY
-        const {sim: _sim, build: _build, ...runtimeConfig} = config
-        if (runtimeConfig.fsReadMax !== undefined) {
-          runtimeConfig.fsReadMax = parseSize(runtimeConfig.fsReadMax)
-        }
         return output(
           buildDir,
           pathlib.join(rootDir, 'mikro.config.json'),
-          JSON.stringify(runtimeConfig),
+          JSON.stringify(serializeRuntimeConfig(config)),
         )
       })
 

--- a/packages/mikrojs/src/simulator/builtins/wifi.ts
+++ b/packages/mikrojs/src/simulator/builtins/wifi.ts
@@ -29,7 +29,6 @@ export class Wifi implements SimWifi {
   off() {}
   mac() { return ok('00:00:00:00:00:00') }
   getHostname() { return 'mikrojs-sim' as string | undefined }
-  setHostname() { return ok() }
   getIpConfig() {
     if (!connected) return ok(undefined)
     return ok({ip: currentIp, netmask: '255.255.255.0', gateway: '192.168.1.1', dns: '8.8.8.8'})
@@ -50,7 +49,6 @@ export class Wifi implements SimWifi {
   getPowerSave() { return 'NONE' }
   setPowerSave() { return ok() }
   getCountry() { return undefined }
-  setCountry() { return ok() }
 }
 `,
 }


### PR DESCRIPTION
## Summary

Devices were showing up on routers as `espressif` because the STA hostname and WiFi country code were both expected to be set from JS at boot — by which point DHCP had already started with the ESP-IDF default. This PR moves both settings into `mikro.config.ts` so they apply before WiFi initializes, and gives unset hostnames a sensible `mikrojs-<device-id>` default.

- New nested `wifi: {country, hostname}` group in `mikro.config.ts`. Flattened to `"wifi.country"` / `"wifi.hostname"` on the wire so the on-device JSON parser stays trivial.
- Default STA hostname is now `mikrojs-<device-id>` (e.g. `mikrojs-abcdef0123`) derived from the MAC, replacing `espressif`.
- The runtime `wifi.country` / `wifi.hostname` setters are removed — config is the single source of truth. Getters are kept for diagnostics.

## Breaking changes

- `wifi.country = '...'` and `wifi.hostname = '...'` no longer exist. Set them in `mikro.config.ts` instead:
  ```ts
  export default defineConfig({
    wifi: {country: 'NO', hostname: 'living-room-sensor'},
  })
  ```
- The flat top-level `wifiCountry` config field is gone — use `wifi.country`.

All in-tree examples, templates, and e2e tests have been migrated.