### PR TITLE
feat(config): reject mikrojs/* imports in mikro.config.ts

### DIFF
--- a/packages/@mikrojs/eslint-plugin/src/index.ts
+++ b/packages/@mikrojs/eslint-plugin/src/index.ts
@@ -1,3 +1,4 @@
+import {noDeviceImportsInConfig} from './rules/no-device-imports-in-config.js'
 import {noDotCatch} from './rules/no-dot-catch.js'
 import {noEval} from './rules/no-eval.js'
 import {noIntl} from './rules/no-intl.js'
@@ -23,6 +24,7 @@ const plugin = {
     'no-intl': noIntl,
     'no-temporal': noTemporal,
     'no-sparse-arrays': noSparseArrays,
+    'no-device-imports-in-config': noDeviceImportsInConfig,
   },
   configs: {} as Record<string, unknown[]>,
 }
@@ -47,6 +49,7 @@ Object.assign(plugin.configs, {
         '@mikrojs/no-intl': 'error',
         '@mikrojs/no-temporal': 'error',
         '@mikrojs/no-sparse-arrays': 'warn',
+        '@mikrojs/no-device-imports-in-config': 'error',
       },
     },
   ],

--- a/packages/@mikrojs/eslint-plugin/src/rules/no-device-imports-in-config.test.ts
+++ b/packages/@mikrojs/eslint-plugin/src/rules/no-device-imports-in-config.test.ts
@@ -1,0 +1,58 @@
+import {RuleTester} from '@typescript-eslint/rule-tester'
+import {afterAll, describe, it} from 'vitest'
+
+import {noDeviceImportsInConfig} from './no-device-imports-in-config.js'
+
+RuleTester.afterAll = afterAll
+RuleTester.describe = describe
+RuleTester.it = it
+
+const ruleTester = new RuleTester()
+
+ruleTester.run('no-device-imports-in-config', noDeviceImportsInConfig, {
+  valid: [
+    {
+      code: "import {defineConfig} from 'mikrojs'",
+      filename: 'mikro.config.ts',
+    },
+    {
+      code: "import * as fs from 'node:fs'",
+      filename: 'mikro.config.ts',
+    },
+    {
+      code: "import {pin} from 'mikrojs/pin'",
+      filename: 'app.ts',
+    },
+    {
+      code: "import {wifi} from 'mikrojs/wifi'\nimport {pin} from 'mikrojs/pin'",
+      filename: 'src/main.ts',
+    },
+  ],
+  invalid: [
+    {
+      code: "import {pin} from 'mikrojs/pin'",
+      filename: 'mikro.config.ts',
+      errors: [{messageId: 'noDeviceImport'}],
+    },
+    {
+      code: "import {wifi} from 'mikrojs/wifi'",
+      filename: 'mikro.config.js',
+      errors: [{messageId: 'noDeviceImport'}],
+    },
+    {
+      code: "const m = await import('mikrojs/pin')",
+      filename: 'mikro.config.ts',
+      errors: [{messageId: 'noDeviceImport'}],
+    },
+    {
+      code: "export {pin} from 'mikrojs/pin'",
+      filename: 'mikro.config.ts',
+      errors: [{messageId: 'noDeviceImport'}],
+    },
+    {
+      code: "export * from 'mikrojs/wifi'",
+      filename: 'mikro.config.ts',
+      errors: [{messageId: 'noDeviceImport'}],
+    },
+  ],
+})

--- a/packages/@mikrojs/eslint-plugin/src/rules/no-device-imports-in-config.ts
+++ b/packages/@mikrojs/eslint-plugin/src/rules/no-device-imports-in-config.ts
@@ -1,0 +1,70 @@
+import {ESLintUtils, type TSESTree} from '@typescript-eslint/utils'
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/mikrojs/mikrojs/blob/main/docs/rules/${name}.md`,
+)
+
+const DEFAULT_CONFIG_FILES = ['mikro.config.ts', 'mikro.config.js']
+
+type Options = [{configFiles?: string[]}]
+
+export const noDeviceImportsInConfig = createRule<Options, 'noDeviceImport'>({
+  name: 'no-device-imports-in-config',
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow on-device module imports (mikrojs/*) in build-time config files. These run in Node, not on-device.',
+    },
+    messages: {
+      noDeviceImport:
+        'Cannot import on-device module "{{source}}" in a build-time config file. Only the bare `mikrojs` import is allowed here; `mikrojs/*` subpaths are device-only.',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          configFiles: {
+            type: 'array',
+            items: {type: 'string'},
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  defaultOptions: [{}],
+  create(context, [options]) {
+    const configFiles = options.configFiles ?? DEFAULT_CONFIG_FILES
+    const filename = context.filename
+    const lastSep = Math.max(filename.lastIndexOf('/'), filename.lastIndexOf('\\'))
+    const basename = lastSep >= 0 ? filename.slice(lastSep + 1) : filename
+    if (!configFiles.includes(basename)) {
+      return {}
+    }
+
+    function check(source: TSESTree.StringLiteral | null | undefined, node: TSESTree.Node) {
+      if (!source || typeof source.value !== 'string') return
+      if (source.value.startsWith('mikrojs/')) {
+        context.report({node, messageId: 'noDeviceImport', data: {source: source.value}})
+      }
+    }
+
+    return {
+      ImportDeclaration(node) {
+        check(node.source, node)
+      },
+      ImportExpression(node) {
+        if (node.source.type === 'Literal' && typeof node.source.value === 'string') {
+          check(node.source as TSESTree.StringLiteral, node)
+        }
+      },
+      ExportNamedDeclaration(node) {
+        if (node.source) check(node.source, node)
+      },
+      ExportAllDeclaration(node) {
+        check(node.source, node)
+      },
+    }
+  },
+})

--- a/packages/mikrojs/src/cli/lib/loadMikroConfig.ts
+++ b/packages/mikrojs/src/cli/lib/loadMikroConfig.ts
@@ -17,6 +17,17 @@ export async function loadMikroConfig(startDir: string): Promise<MikroJSConfig |
     if (existsSync(configPath)) {
       const source = await readFile(configPath, 'utf-8')
       let code = stripTypeScriptTypes(source, {mode: 'strip'})
+      // Backstop for the no-device-imports-in-config lint rule: device modules
+      // (mikrojs/*) can't resolve from a data: URL anyway, so fail with a
+      // clear message instead of an opaque module-not-found error.
+      const deviceImports = [...code.matchAll(/['"](mikrojs\/[^'"]+)['"]/g)].map((m) => m[1])
+      if (deviceImports.length > 0) {
+        const unique = [...new Set(deviceImports)]
+        throw new Error(
+          `${configPath}: cannot import on-device modules (${unique.join(', ')}) in a build-time config file. ` +
+            `Only the bare 'mikrojs' import is allowed here; mikrojs/* subpaths are device-only.`,
+        )
+      }
       code = code.replace(
         /import\s*\{[^}]*\}\s*from\s*['"]mikrojs['"]\s*;?/,
         'const defineConfig = (c) => c;',


### PR DESCRIPTION
## Summary

`mikro.config.ts` is a build-time file: it runs in Node, gets evaluated as a data: URL, and produces the JSON the firmware reads. Today nothing stops a user from writing `import {wifi} from 'mikrojs/wifi'` in there: it type-checks fine (it's a valid subpath of the `mikrojs` package), but at config-load time it fails with an opaque "Cannot find module" error.

This PR enforces the existing convention with two coordinated layers:

- **ESLint rule** `@mikrojs/no-device-imports-in-config` (added to `recommended`, error level): flags any `mikrojs/*` import (including dynamic `import()` and re-exports) in files matching `mikro.config.{ts,js}`. The bare `mikrojs` import remains allowed. The `configFiles` option lets users extend the matched-filename list (e.g. for `vitest.config.ts`).
- **Loader guard** in `loadMikroConfig`: regex backstop that scans the type-stripped source for `mikrojs/*` literals before evaluation, and throws a clear error naming the file and the offending imports. Catches the case for users who skip lint.