### PR TITLE
fix(observable): pin operator types so twoslash infers through pipe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,21 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm build:ts
 
+  docs:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+
+      - uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build:docs
+
   lib:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:

--- a/packages/@mikrojs/native/runtime/observable/operators.ts
+++ b/packages/@mikrojs/native/runtime/observable/operators.ts
@@ -17,7 +17,16 @@
  * See `.claude/plans/observable.md` for the full design.
  */
 
-import {Observable} from 'native:observable'
+import {Observable as NativeObservable} from 'native:observable'
+
+import type {Observable as ObservableT} from './types.js'
+
+/* `native:observable` resolves only inside the runtime build; outside
+ * (twoslash, host typecheck without internal.d.ts) it falls back to `any`,
+ * which collapses pipe/operator inference at use sites. Pin the type to the
+ * declared class in `./types.ts` so consumers always see the typed shape. */
+const Observable = NativeObservable as unknown as typeof ObservableT
+type Observable<Ok, Err = never> = ObservableT<Ok, Err>
 
 /* Catch a thrown error and re-throw it on the next tick. The synchronous
  * caller keeps going; the error eventually surfaces as an uncaught


### PR DESCRIPTION
## Summary

- Operators imported `Observable` from `native:observable`, declared in `runtime/internal.d.ts`. Twoslash doesn't load that file, so `Observable` collapsed to `any` during the docs build — which made every `pipe(map(info => …))` example degrade to `unknown` and fail vitepress with `TS18046`. Split the runtime constructor from its declared-class type so the typed shape is always visible (twoslash, host typecheck, on-device runtime all agree).
- Add a `docs` job to `.github/workflows/build.yml` running `pnpm build:docs`. Vitepress/twoslash failures previously only surfaced in the Cloudflare Pages preview, which doesn't gate merges; this makes them block PRs.

## Test plan

- [x] `pnpm --filter docs build` passes locally
- [x] `pnpm typecheck` passes
- [x] Observable unit tests pass
- [x] Full pre-commit (build:cpp, build:ts, knip, test:js, test:lib, lint, fmt) passes
- [x] Confirm new `docs` CI job runs green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)