### PR TITLE
fix(repl): suspend microtasks while paused so user JS can't race deploy

### DIFF
--- a/packages/@mikrojs/native/src/mik_repl.cpp
+++ b/packages/@mikrojs/native/src/mik_repl.cpp
@@ -104,7 +104,10 @@ bool mik__proto_read_exact(MIKReplTransport* transport, void* buf, size_t n) {
                     return false;
                 }
             }
-            if (repl_ctx) {
+            /* Microtasks are deferred user JS: settling them re-enters .then
+             * handlers that can write to the transport (console.log → MSG_LOG)
+             * or touch the filesystem mid-deploy. Gate on pause too. */
+            if (repl_ctx && !repl_paused) {
                 mik__execute_jobs(repl_ctx);
             }
             /* A pumped job (e.g. the test runtime's __testFileDone) may
@@ -1109,12 +1112,14 @@ void MIK_ProtocolServeLoop(void) {
             }
         }
 
-        /* Pump event loop between commands (skip timers/callbacks when paused,
-         * but always run microtasks so promises can settle) */
+        /* Pump event loop between commands. Skip both timers/callbacks AND
+         * microtasks when paused — draining microtasks runs user .then
+         * handlers, which can interleave MSG_LOG output with deploy traffic
+         * or race the staged-file swap. */
         if (repl_mik_rt && !repl_paused) {
             MIK_Loop(repl_mik_rt);
         }
-        if (ctx) {
+        if (ctx && !repl_paused) {
             mik__execute_jobs(ctx);
         }
     }


### PR DESCRIPTION
`CMD_RUNTIME_PAUSE` was meant to freeze user JS for the duration of a deploy so it couldn't (a) interleave `MSG_LOG` output with TLV traffic on the transport or (b) touch the filesystem while the staged-file swap was in flight. But the protocol read loop and between-frames pump in `mik_repl.cpp` kept calling `mik__execute_jobs(ctx)` unconditionally — and microtasks are deferred user JS. A pending `Promise.then` handler could still call `console.log` mid-upload, write to the fs, or kick off more native work.

This patch gates `mik__execute_jobs` on `!repl_paused` at both sites. The REPL's own promise-spinning eval path already bailed on pause separately (`mik_repl.cpp:243`, "Promise detached"), so no regression there.

Queued microtasks drain immediately on resume, the same way queued timers and loop-consumer callbacks already did.
