### PR TITLE
revert: fix(firmware): halve TLS inbound buffer to free internal SRAM

### DIFF
--- a/packages/@mikrojs/firmware/sdkconfig.defaults
+++ b/packages/@mikrojs/firmware/sdkconfig.defaults
@@ -132,13 +132,3 @@ CONFIG_MBEDTLS_ECP_DP_BP512R1_ENABLED=n
 CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN=y
 CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_CROSS_SIGNED_VERIFY=y
 
-# TLS record buffers must come from internal SRAM. The ESP-IDF default for
-# the inbound buffer is 16 KB, which competes with QuickJS heap allocations
-# for contiguous internal SRAM and causes HTTPS handshake failures (error
-# 0x7002) on apps with significant retained JS state. Halving it to 8 KB
-# leaves enough room for typical TLS records (handshake fragments are well
-# under 4 KB; modern servers rarely send >4 KB application records, and
-# mbedTLS will fragment larger records). The outbound buffer was already
-# 4 KB via CONFIG_MBEDTLS_ASYMMETRIC_CONTENT_LEN=y.
-CONFIG_MBEDTLS_SSL_IN_CONTENT_LEN=8192
-


### PR DESCRIPTION
This reverts commit 8269c3f61a48999a3948c8e05d6e6e3d82b69558.

The 8 KB inbound buffer breaks HTTPS to TLS 1.3 servers that send larger records: we don't advertise record_size_limit (RFC 8449, CONFIG_MBEDTLS_SSL_RECORD_SIZE_LIMIT is unset), so servers legally send up to 16 KB and mbedTLS rejects with -0x0087 (MBEDTLS_ERR_SSL_BAD_INPUT_DATA).