### PR TITLE
ci(workflows): drop blacksmith for github-hosted runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   packages:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
 
@@ -23,7 +23,7 @@ jobs:
       - run: pnpm build:ts
 
   docs:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
 
@@ -38,7 +38,7 @@ jobs:
       - run: pnpm build:docs
 
   lib:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
 

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   create-or-update:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: read # for `releaser plan` to look up the merged PR's head ref

--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -34,7 +34,7 @@ jobs:
     if: >-
       github.event_name != 'pull_request'
       || contains(github.event.pull_request.labels.*.name, 'firmware')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     outputs:
       chips: ${{ steps.read.outputs.chips }}
     steps:
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         target: ${{ fromJSON(needs.setup.outputs.chips) }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     container: espressif/idf:v6.0.1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
 

--- a/.github/workflows/memory-bench-backfill.yml
+++ b/.github/workflows/memory-bench-backfill.yml
@@ -29,7 +29,7 @@ concurrency:
 
 jobs:
   backfill:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 360
     steps:
       - name: Checkout main (for bench-site source)

--- a/.github/workflows/memory-bench.yml
+++ b/.github/workflows/memory-bench.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   bench:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ permissions:
 
 jobs:
   plan:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: read # for `releaser plan` to read PR + commit data
@@ -92,7 +92,7 @@ jobs:
           - os: ubuntu-24.04
             platform: linux
             arch: x64
-          - os: blacksmith-4vcpu-ubuntu-2404-arm
+          - os: ubuntu-24.04-arm
             platform: linux
             arch: arm64
     runs-on: ${{ matrix.os }}
@@ -127,7 +127,7 @@ jobs:
   firmware-setup:
     needs: plan
     if: needs.plan.outputs.should_run == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     outputs:
       chips: ${{ steps.read.outputs.chips }}
     steps:
@@ -142,7 +142,7 @@ jobs:
       fail-fast: false
       matrix:
         target: ${{ fromJSON(needs.firmware-setup.outputs.chips) }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     container: espressif/idf:v6.0.1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -161,9 +161,6 @@ jobs:
   publish:
     needs: [plan, build-prebuilds, build-firmware]
     if: needs.plan.outputs.should_run == 'true'
-    # npm provenance requires a GitHub-hosted runner; self-hosted (blacksmith)
-    # runners are rejected by sigstore verification with "Unsupported GitHub
-    # Actions runner environment".
     runs-on: ubuntu-latest
     permissions:
       contents: write # for `releaser tag` (push tag in release mode)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
 

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   main:
     name: Validate PR title
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # ratchet:amannn/action-semantic-pull-request@v6.1.1
         env:


### PR DESCRIPTION
- Switch all workflows back to GitHub-hosted runners: `blacksmith-4vcpu-ubuntu-2404` → `ubuntu-24.04`, ARM variant → `ubuntu-24.04-arm`.
- Drop the now-stale comment on the `publish` job that explained why it stayed on `ubuntu-latest` (it was contrasted against blacksmith).
