### PR TITLE
feat(runtime)!: always restart on uncaught error

### DIFF
--- a/dev/crashloop/README.md
+++ b/dev/crashloop/README.md
@@ -4,7 +4,7 @@ Dev fixture that deploys an app which crash-loops on boot. Used to exercise the 
 
 ## What it does
 
-`app/main.ts` throws an uncaught exception as soon as it runs. `mikro.config.ts` sets `restartOnUncaughtException: true` with a 500ms delay, so the runtime catches the throw and calls `esp_restart()` after the delay. The next boot autoruns the same broken app, throws again, restarts, forever.
+`app/main.ts` throws an uncaught exception as soon as it runs. The runtime always restarts on uncaught exceptions; `mikro.config.ts` shortens the `panicRestartDelay` grace window so the runtime calls `esp_restart()` quickly after the throw. The next boot autoruns the same broken app, throws again, restarts, forever.
 
 Net effect: the device does enter `MIK_StartReplProtocol` briefly between crashes, but it's gone again before a normal `mikro dev` / `mikro deploy` / `mikro clean` can complete its handshake. The crash cycle is short enough that host-side retries alone aren't enough to catch it.
 
@@ -46,7 +46,7 @@ pnpm mikro console --recover   # open REPL on a broken device without deploying
 
 ## The forcible variant
 
-If you want a crash loop that doesn't rely on `restartOnUncaughtException`, replace the throw in `app/main.ts` with:
+If you want a crash loop that doesn't rely on the panic-restart path, replace the throw in `app/main.ts` with:
 
 ```ts
 import {restart} from 'mikrojs/sys'

--- a/dev/crashloop/app/main.ts
+++ b/dev/crashloop/app/main.ts
@@ -6,9 +6,9 @@ import {version} from 'mikrojs/sys'
 // import from 'mikrojs/*' here so the module has an import section.
 console.log(`crashloop fixture booting v${version} — this app is designed to crash`)
 
-// Uncaught synchronous throw. With restartOnUncaughtException=true in
-// mikro.config.ts, the runtime catches this and calls esp_restart() after
-// a 500ms delay, so the device enters a tight reboot cycle.
+// Uncaught synchronous throw. The runtime catches this and calls
+// esp_restart() after the panicRestartDelay grace window from
+// mikro.config.ts, so the device enters a tight reboot cycle.
 //
 // Alternative forcible variant (uncomment to bypass the runtime entirely):
 //

--- a/dev/crashloop/mikro.config.ts
+++ b/dev/crashloop/mikro.config.ts
@@ -1,11 +1,10 @@
 import {defineConfig} from 'mikrojs'
 
-// Auto-restart on uncaught exceptions with a short delay. Combined with the
-// deliberate throw in app/main.ts, this puts the device into a tight crash
-// loop where a normal `mikro dev` or `mikro clean` can't land a command
-// between reboots. Only `mikro ... --recover` can break out.
+// Combined with the deliberate throw in app/main.ts, the short panic-restart
+// grace window puts the device into a tight crash loop where a normal
+// `mikro dev` or `mikro clean` can't land a command between reboots. Only
+// `mikro ... --recover` can break out.
 export default defineConfig({
-  restartOnUncaughtException: true,
-  restartDelay: 2000,
+  panicRestartDelay: 2000,
   logFile: {maxSize: 1024},
 })

--- a/dev/e2e/mikro.config.ts
+++ b/dev/e2e/mikro.config.ts
@@ -2,5 +2,4 @@ import {defineConfig} from 'mikrojs'
 
 export default defineConfig({
   wifi: {country: 'NO'},
-  restartOnUncaughtException: false,
 })

--- a/dev/sram-pressure/mikro.config.ts
+++ b/dev/sram-pressure/mikro.config.ts
@@ -2,5 +2,4 @@ import {defineConfig} from 'mikrojs'
 
 export default defineConfig({
   wifi: {country: 'NO'},
-  restartOnUncaughtException: false,
 })

--- a/docs/config.md
+++ b/docs/config.md
@@ -21,26 +21,21 @@ export default defineConfig({
 
 These options are bundled into the deployed app and read by the firmware at boot.
 
-| Option                       | Type                | Default          | Description                                   |
-| ---------------------------- | ------------------- | ---------------- | --------------------------------------------- |
-| `restartOnUncaughtException` | `boolean`           | `false`          | Restart device on uncaught exception          |
-| `restartDelay`               | `number` (ms)       | `0`              | Delay before restart after uncaught exception |
-| `stackSize`                  | `number` (bytes)    | firmware default | QuickJS C stack size                          |
-| `memReserved`                | `number` (bytes)    | `65536` (64 KB)  | Heap reserved for native subsystems           |
-| `wifi.country`               | `WifiCountryCode`   | none             | WiFi regulatory country code                  |
-| `wifi.hostname`              | `string`            | `mikrojs-<id>`   | DHCP hostname advertised by the STA interface |
-| `logFile`                    | `true \| object`    | off              | Enable on-device file logging                 |
-| `logFile.dir`                | `string`            | `'/appfs/logs'`  | Directory the log file lives in               |
-| `logFile.maxSize`            | `number \| string`  | `'64k'`          | Rotate when file exceeds this size            |
-| `logFile.flush`              | `'line' \| 'error'` | `'error'`        | When to flush buffered writes to flash        |
+| Option              | Type                | Default          | Description                                         |
+| ------------------- | ------------------- | ---------------- | --------------------------------------------------- |
+| `panicRestartDelay` | `number` (ms)       | `1000`           | Grace window between uncaught exception and restart |
+| `stackSize`         | `number` (bytes)    | firmware default | QuickJS C stack size                                |
+| `memReserved`       | `number` (bytes)    | `65536` (64 KB)  | Heap reserved for native subsystems                 |
+| `wifi.country`      | `WifiCountryCode`   | none             | WiFi regulatory country code                        |
+| `wifi.hostname`     | `string`            | `mikrojs-<id>`   | DHCP hostname advertised by the STA interface       |
+| `logFile`           | `true \| object`    | off              | Enable on-device file logging                       |
+| `logFile.dir`       | `string`            | `'/appfs/logs'`  | Directory the log file lives in                     |
+| `logFile.maxSize`   | `number \| string`  | `'64k'`          | Rotate when file exceeds this size                  |
+| `logFile.flush`     | `'line' \| 'error'` | `'error'`        | When to flush buffered writes to flash              |
 
-### `restartOnUncaughtException`
+### `panicRestartDelay`
 
-Automatically restart the device when an uncaught exception reaches the top level. Useful for production deployments where you want the device to recover from transient failures. See [Error Handling](/error-handling) for details.
-
-### `restartDelay`
-
-Delay in milliseconds before restarting after an uncaught exception. Only meaningful when `restartOnUncaughtException` is `true`. A small delay (e.g. 500) gives the device breathing room for serial connections before the restart.
+The runtime always restarts the device when an uncaught exception reaches the top level so apps in the field can self-heal. `panicRestartDelay` controls the grace window (in milliseconds) between the exception and the actual `esp_restart()`. During this window the protocol REPL stays responsive so the host can land `mikro deploy` / `mikro clean` / `mikro ... --recover` commands and break a tight crash loop. Longer windows are friendlier to dev iteration; shorter windows make a self-healing device converge faster. See [Error Handling](/error-handling) for details.
 
 ### `stackSize`
 
@@ -170,8 +165,7 @@ All size options accept a number of bytes or a string with K/M suffix (e.g. `'30
 import {defineConfig} from 'mikrojs'
 
 export default defineConfig({
-  restartOnUncaughtException: true,
-  restartDelay: 500,
+  panicRestartDelay: 500,
   memReserved: 32 * 1024,
   wifi: {
     country: 'NO', // Norway

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -221,13 +221,13 @@ import {env} from 'mikrojs/env'
 const ssid = env.require('WIFI_SSID')
 ```
 
-For production deployments, you can set `restartOnUncaughtException: true` in your `mikro.config.ts` to automatically restart the device when an unhandled exception occurs:
+The runtime always restarts the device on an uncaught exception so deployed apps can self-heal. Tune `panicRestartDelay` (the grace window between the exception and the actual reboot) to match your environment — longer for friendlier dev iteration, shorter for faster convergence in the field:
 
 ```ts twoslash
 import {defineConfig} from 'mikrojs'
 
 export default defineConfig({
-  restartOnUncaughtException: true,
+  panicRestartDelay: 500,
 })
 ```
 

--- a/docs/internals/runtime-lifecycle.md
+++ b/docs/internals/runtime-lifecycle.md
@@ -81,8 +81,7 @@ Runtime behavior is controlled by `MIKConfig`:
 
 ```c
 typedef struct MIKConfig {
-    bool restart_on_uncaught_exception;
-    int restart_delay_ms;
+    int panic_restart_delay_ms;
     size_t stack_size;
     uint32_t mem_reserved;
     uint32_t fs_read_max;  // 0 = keep runtime default (65536)
@@ -125,7 +124,7 @@ The runtime can be stopped in several ways:
 - **Uncaught exception**: Detected at the top of each loop iteration
 - **Explicit stop**: `MIK_Stop(mik_rt)` sets `stop_requested`
 
-When `config.restart_on_uncaught_exception` is true, the firmware will recreate the runtime and re-enter the main module after `restart_delay_ms`.
+After an uncaught exception, `MIK_Stop()` records a deadline `panic_restart_delay_ms` in the future on `MIKRuntime.restart_at_us`. `MIK_Loop()` keeps the protocol REPL pumping (no more user JS) until the deadline elapses, then calls `platform->restart()` so the host can land deploy / clean / --recover commands during the grace window.
 
 ## Destruction
 

--- a/examples/wifi-fetch/mikro.config.ts
+++ b/examples/wifi-fetch/mikro.config.ts
@@ -2,5 +2,4 @@ import {defineConfig} from 'mikrojs'
 
 export default defineConfig({
   wifi: {country: 'NO'},
-  restartOnUncaughtException: false,
 })

--- a/packages/@mikrojs/native/include/mikrojs/mikrojs.h
+++ b/packages/@mikrojs/native/include/mikrojs/mikrojs.h
@@ -30,8 +30,7 @@ typedef enum MIKLogFlush {
 } MIKLogFlush;
 
 typedef struct MIKConfig {
-    bool restart_on_uncaught_exception;
-    int restart_delay_ms;
+    int panic_restart_delay_ms;
     size_t stack_size;
     uint32_t mem_reserved;
     uint32_t fs_read_max; /* 0 = keep runtime default (65536) */

--- a/packages/@mikrojs/native/include/mikrojs/private.h
+++ b/packages/@mikrojs/native/include/mikrojs/private.h
@@ -56,6 +56,12 @@ struct MIKRuntime {
     bool is_worker;
     bool freeing;
     bool stop_requested;  /* Set by promise rejection tracker to stop the loop */
+    /* Set by MIK_EnableTestHelpers — the test supervisor wants stop_requested
+     * to bubble up cleanly so it can synthesize a failing-test event and move
+     * to the next file. Without this flag, MIK_Stop would arm a panic-restart
+     * deadline and reboot the whole device mid-manifest on the first async
+     * rejection. */
+    bool test_mode;
     /* Deferred restart deadline (boot_us, 0 = no pending restart). Set by
      * MIK_Stop when an uncaught exception happens with a protocol REPL
      * attached: the serve loop keeps reading commands until the deadline so

--- a/packages/@mikrojs/native/include/mikrojs/private.h
+++ b/packages/@mikrojs/native/include/mikrojs/private.h
@@ -56,6 +56,12 @@ struct MIKRuntime {
     bool is_worker;
     bool freeing;
     bool stop_requested;  /* Set by promise rejection tracker to stop the loop */
+    /* Deferred restart deadline (boot_us, 0 = no pending restart). Set by
+     * MIK_Stop when an uncaught exception happens with a protocol REPL
+     * attached: the serve loop keeps reading commands until the deadline so
+     * the host can still deploy/clean/--recover during the grace window,
+     * then platform->restart() fires from MIK_Loop. */
+    int64_t restart_at_us;
     const char* fs_base_path;
     const char* fs_root;  /* Sandbox root for mikrojs/fs operations (separate from module resolution) */
     size_t fs_limit;      /* Max bytes for fs_root (0 = unlimited) */

--- a/packages/@mikrojs/native/src/mik_app_config.cpp
+++ b/packages/@mikrojs/native/src/mik_app_config.cpp
@@ -12,8 +12,7 @@
 static const char* TAG = "mik_app_config";
 
 void MIK_DefaultConfig(MIKConfig* config) {
-    config->restart_on_uncaught_exception = false;
-    config->restart_delay_ms = 1000;
+    config->panic_restart_delay_ms = 1000;
     config->stack_size = 0;
     config->mem_reserved = 64 * 1024;
     config->fs_read_max = 0; /* 0 = runtime default (65536) */
@@ -26,19 +25,7 @@ void MIK_DefaultConfig(MIKConfig* config) {
 }
 
 /* Minimal JSON parser for config file — avoids cJSON dependency.
- * Only handles the flat object with bool/number fields we need. */
-static bool mik__json_get_bool(const char* json, const char* key, bool* out) {
-    char pattern[128];
-    snprintf(pattern, sizeof(pattern), "\"%s\"", key);
-    const char* p = strstr(json, pattern);
-    if (!p) return false;
-    p += strlen(pattern);
-    while (*p == ' ' || *p == '\t' || *p == ':') p++;
-    if (strncmp(p, "true", 4) == 0) { *out = true; return true; }
-    if (strncmp(p, "false", 5) == 0) { *out = false; return true; }
-    return false;
-}
-
+ * Only handles the flat object with string/number fields we need. */
 static bool mik__json_get_string(const char* json, const char* key, char* out, size_t out_size) {
     char pattern[128];
     snprintf(pattern, sizeof(pattern), "\"%s\"", key);
@@ -329,14 +316,10 @@ int MIK_LoadConfig(const char* base_path, MIKConfig* config) {
         snprintf(path, sizeof(path), "%s/mikro.config.json", app_dir);
         buf = mik__read_json_file(path, &st);
         if (buf) {
-            bool bool_val;
             double num_val;
 
-            if (mik__json_get_bool(buf, "restartOnUncaughtException", &bool_val)) {
-                config->restart_on_uncaught_exception = bool_val;
-            }
-            if (mik__json_get_number(buf, "restartDelay", &num_val)) {
-                config->restart_delay_ms = (int)num_val;
+            if (mik__json_get_number(buf, "panicRestartDelay", &num_val)) {
+                config->panic_restart_delay_ms = (int)num_val;
             }
             if (mik__json_get_number(buf, "stackSize", &num_val)) {
                 config->stack_size = (size_t)num_val;
@@ -363,8 +346,8 @@ int MIK_LoadConfig(const char* base_path, MIKConfig* config) {
             }
 
             platform->log(MIK_LOG_INFO, TAG,
-                           "Loaded config: restart=%d delay=%dms stack=%u reserved=%lu",
-                           config->restart_on_uncaught_exception, config->restart_delay_ms,
+                           "Loaded config: delay=%dms stack=%u reserved=%lu",
+                           config->panic_restart_delay_ms,
                            (unsigned)config->stack_size, (unsigned long)config->mem_reserved);
             free(buf);
         }

--- a/packages/@mikrojs/native/src/mik_console.cpp
+++ b/packages/@mikrojs/native/src/mik_console.cpp
@@ -420,6 +420,7 @@ void mik__console_init(JSContext* ctx, JSValue global_obj) {
  * bindings they'll never use. The mikrojs/test built-in has a console.log
  * fallback for when these globals aren't present. */
 void MIK_EnableTestHelpers(MIKRuntime* mik_rt) {
+    mik_rt->test_mode = true;
     JSContext* ctx = mik_rt->ctx;
     JSValue global_obj = JS_GetGlobalObject(ctx);
     JS_SetPropertyStr(ctx, global_obj, "__testEmit",

--- a/packages/@mikrojs/native/src/mik_repl.cpp
+++ b/packages/@mikrojs/native/src/mik_repl.cpp
@@ -129,8 +129,11 @@ bool mik__proto_read_exact(MIKReplTransport* transport, void* buf, size_t n) {
             }
             /* Microtasks are deferred user JS: settling them re-enters .then
              * handlers that can write to the transport (console.log → MSG_LOG)
-             * or touch the filesystem mid-deploy. Gate on pause too. */
-            if (repl_ctx && !repl_paused) {
+             * or touch the filesystem mid-deploy. Gate on pause too — and
+             * on a pending panic-restart, since the runtime is on its way
+             * out and no further user JS should fire on it. */
+            if (repl_ctx && !repl_paused &&
+                (!repl_mik_rt || repl_mik_rt->restart_at_us == 0)) {
                 mik__execute_jobs(repl_ctx);
             }
             /* A pumped job (e.g. the test runtime's __testFileDone) may

--- a/packages/@mikrojs/native/src/mikrojs.cpp
+++ b/packages/@mikrojs/native/src/mikrojs.cpp
@@ -535,9 +535,10 @@ void mik__execute_jobs(JSContext* ctx) {
 /* main loop which calls the user JS callbacks */
 int MIK_Loop(MIKRuntime* mik_rt) {
     /* Deferred restart (see MIK_Stop): once the grace window elapses, reboot
-     * the device. While we're still in the window, return 0 without running
-     * any more user JS so the protocol serve loop keeps reading host
-     * commands but no further timers/microtasks fire on the dead runtime. */
+     * the device. While we're still in the window, return 0 without pumping
+     * timers/consumers so the protocol serve loop keeps reading host
+     * commands without firing any more user JS on the dead runtime. The
+     * serve loop also skips its microtask drain on this condition. */
     if (mik_rt->restart_at_us > 0) {
         const MIKPlatform* platform = MIK_GetPlatform();
         if (platform->get_boot_us() >= mik_rt->restart_at_us) {
@@ -679,6 +680,13 @@ void MIK_Stop(MIKRuntime* mik_rt) {
     /* A throw inside an interactive REPL eval is a user typo, not an app
      * crash — don't reboot the device. */
     if (mik__repl_is_evaluating()) {
+        return;
+    }
+    /* In test mode, the supervisor wants stop_requested to bubble up so it
+     * can synthesize a failing-test event and move to the next file. Arming
+     * a panic-restart here would reboot the device mid-manifest on the
+     * first async rejection. */
+    if (mik_rt->test_mode) {
         return;
     }
     /* Defer the restart so the host can still issue deploy/clean/--recover

--- a/packages/@mikrojs/native/src/mikrojs.cpp
+++ b/packages/@mikrojs/native/src/mikrojs.cpp
@@ -670,30 +670,25 @@ bool MIK_IsStopRequested(MIKRuntime* mik_rt) {
 
 void MIK_Stop(MIKRuntime* mik_rt) {
     CHECK_NOT_NULL(mik_rt);
+    /* Only firmware (protocol REPL attached) auto-restarts on uncaught
+     * exceptions. Host embedders (Node addon, standalone tests) own their
+     * own process lifecycle and surface errors via the error handler. */
+    if (!MIK_IsReplActive()) {
+        return;
+    }
     /* A throw inside an interactive REPL eval is a user typo, not an app
-     * crash — don't reboot the device. Autorun crashes and async rejections
-     * outside REPL eval still honor restart_on_uncaught_exception. */
+     * crash — don't reboot the device. */
     if (mik__repl_is_evaluating()) {
         return;
     }
-    if (!mik_rt->config.restart_on_uncaught_exception) {
-        return;
+    /* Defer the restart so the host can still issue deploy/clean/--recover
+     * commands during the grace window. The actual platform->restart()
+     * fires from MIK_Loop once the deadline elapses. */
+    if (mik_rt->restart_at_us == 0) {
+        const MIKPlatform* platform = MIK_GetPlatform();
+        mik_rt->restart_at_us =
+            platform->get_boot_us() + (int64_t)mik_rt->config.panic_restart_delay_ms * 1000;
     }
-    const MIKPlatform* platform = MIK_GetPlatform();
-    if (MIK_IsReplActive()) {
-        /* Protocol REPL is attached (firmware): defer the restart so the
-         * host can still issue deploy/clean/--recover commands during the
-         * grace window. The actual platform->restart() fires from
-         * MIK_Loop once the deadline elapses. */
-        if (mik_rt->restart_at_us == 0) {
-            mik_rt->restart_at_us =
-                platform->get_boot_us() + (int64_t)mik_rt->config.restart_delay_ms * 1000;
-        }
-        return;
-    }
-    /* No protocol REPL (host runtime, standalone): block and restart. */
-    usleep(mik_rt->config.restart_delay_ms * 1000);
-    platform->restart();
 }
 
 int mik__load_file(JSContext* ctx, DynBuf* dbuf, const char* filename) {

--- a/packages/@mikrojs/native/src/mikrojs.cpp
+++ b/packages/@mikrojs/native/src/mikrojs.cpp
@@ -145,18 +145,18 @@ static void mik__promise_rejection_tracker(JSContext* ctx, JSValue promise, JSVa
              * are genuine unhandled promise rejections. */
             bool in_promise = !mik__repl_is_evaluating();
             mik__report_uncaught(ctx, reason, in_promise);
-            if (!MIK_IsReplActive()) {
-                /* Notify the error handler (e.g. host bridge) directly.
-                 * Don't JS_Throw here — we're inside a QuickJS callback
-                 * during promise resolution; throwing would corrupt engine
-                 * state and cause mik__execute_jobs to dump the error a
-                 * second time. */
-                if (mik_rt->error_handler_fn) {
-                    mik_rt->error_handler_fn(ctx, reason, mik_rt->error_handler_opaque);
-                }
-                mik_rt->stop_requested = true;
-                MIK_Stop(mik_rt);
+            /* Notify the error handler (e.g. host bridge) directly.
+             * Don't JS_Throw here — we're inside a QuickJS callback
+             * during promise resolution; throwing would corrupt engine
+             * state and cause mik__execute_jobs to dump the error a
+             * second time. MIK_Stop itself gates on whether we're inside
+             * an interactive REPL eval so a typo at the prompt doesn't
+             * reboot the device. */
+            if (mik_rt->error_handler_fn) {
+                mik_rt->error_handler_fn(ctx, reason, mik_rt->error_handler_opaque);
             }
+            mik_rt->stop_requested = true;
+            MIK_Stop(mik_rt);
             return;
         }
 
@@ -534,6 +534,17 @@ void mik__execute_jobs(JSContext* ctx) {
 
 /* main loop which calls the user JS callbacks */
 int MIK_Loop(MIKRuntime* mik_rt) {
+    /* Deferred restart (see MIK_Stop): once the grace window elapses, reboot
+     * the device. While we're still in the window, return 0 without running
+     * any more user JS so the protocol serve loop keeps reading host
+     * commands but no further timers/microtasks fire on the dead runtime. */
+    if (mik_rt->restart_at_us > 0) {
+        const MIKPlatform* platform = MIK_GetPlatform();
+        if (platform->get_boot_us() >= mik_rt->restart_at_us) {
+            platform->restart();
+        }
+        return 0;
+    }
     if (mik_rt->stop_requested) {
         return 1;
     }
@@ -659,15 +670,30 @@ bool MIK_IsStopRequested(MIKRuntime* mik_rt) {
 
 void MIK_Stop(MIKRuntime* mik_rt) {
     CHECK_NOT_NULL(mik_rt);
-    if (MIK_IsReplActive()) {
+    /* A throw inside an interactive REPL eval is a user typo, not an app
+     * crash — don't reboot the device. Autorun crashes and async rejections
+     * outside REPL eval still honor restart_on_uncaught_exception. */
+    if (mik__repl_is_evaluating()) {
+        return;
+    }
+    if (!mik_rt->config.restart_on_uncaught_exception) {
         return;
     }
     const MIKPlatform* platform = MIK_GetPlatform();
-    if (mik_rt->config.restart_on_uncaught_exception) {
-        printf("Restarting in %d ms...\n", mik_rt->config.restart_delay_ms);
-        usleep(mik_rt->config.restart_delay_ms * 1000);
-        platform->restart();
+    if (MIK_IsReplActive()) {
+        /* Protocol REPL is attached (firmware): defer the restart so the
+         * host can still issue deploy/clean/--recover commands during the
+         * grace window. The actual platform->restart() fires from
+         * MIK_Loop once the deadline elapses. */
+        if (mik_rt->restart_at_us == 0) {
+            mik_rt->restart_at_us =
+                platform->get_boot_us() + (int64_t)mik_rt->config.restart_delay_ms * 1000;
+        }
+        return;
     }
+    /* No protocol REPL (host runtime, standalone): block and restart. */
+    usleep(mik_rt->config.restart_delay_ms * 1000);
+    platform->restart();
 }
 
 int mik__load_file(JSContext* ctx, DynBuf* dbuf, const char* filename) {

--- a/packages/@mikrojs/native/test/app_config_test.cpp
+++ b/packages/@mikrojs/native/test/app_config_test.cpp
@@ -179,13 +179,12 @@ TEST_CASE("MIK_LoadConfig reads mikro.config.json settings" * doctest::test_suit
     auto dir = make_temp_dir();
     write_file(dir + "/package.json", R"({"name": "test", "main": "./main.js"})");
     write_file(dir + "/mikro.config.json",
-               R"({"restartOnUncaughtException": true, "restartDelay": 5000, "stackSize": 32768, "memReserved": 131072})");
+               R"({"panicRestartDelay": 5000, "stackSize": 32768, "memReserved": 131072})");
 
     MIKConfig config;
     MIK_LoadConfig(dir.c_str(), &config);
 
-    CHECK(config.restart_on_uncaught_exception);
-    CHECK_EQ(5000, config.restart_delay_ms);
+    CHECK_EQ(5000, config.panic_restart_delay_ms);
     CHECK_EQ(32768, (int)config.stack_size);
     CHECK_EQ((uint32_t)131072, config.mem_reserved);
 

--- a/packages/mikrojs/src/_exports/index.ts
+++ b/packages/mikrojs/src/_exports/index.ts
@@ -119,8 +119,12 @@ export interface MikroJSLogFileOptions {
 }
 
 export interface MikroJSConfig {
-  restartOnUncaughtException?: boolean
-  restartDelay?: number
+  /** Grace window (in ms) between an uncaught exception and the
+   * subsequent device restart. The protocol REPL stays responsive to
+   * deploy / clean / --recover commands during this window — long enough
+   * lets the host break a tight crash loop, short enough keeps the device
+   * converging when no one is watching. Default: `1000`. */
+  panicRestartDelay?: number
   stackSize?: number
   memReserved?: number
   /** Maximum size in bytes for a single readFile() call. Files larger than


### PR DESCRIPTION
Fixes various issues with restarting on panics/uncaught exceptions

BREAKING CHANGE: restartOnUncaughtException is removed. Restart on uncaught exceptions is now default behavior. `restartDelay` is renamed to `panicRestartDelay`.