### PR TITLE
feat(create-mikrojs): scaffold with TS only, mikro.config.ts and prettier defaults

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -5,6 +5,7 @@
     "packages/@mikrojs/native/deps/",
     "packages/@mikrojs/quickjs/deps/",
     "packages/@mikrojs/analyze-imports/test/*",
+    "packages/create-mikrojs/src/templates/",
     "pack-test/",
     "**/CHANGELOG.md"
   ],

--- a/knip.ts
+++ b/knip.ts
@@ -27,6 +27,13 @@ const config = {
     'packages/@mikrojs/analyze-imports': {
       ignore: ['test/unit/**', 'test/symlink/**', 'dist/**'],
     },
+    'packages/create-mikrojs': {
+      // eslint, prettier, typescript-eslint, @mikrojs/eslint-plugin are
+      // invoked by scaffold.test.ts via node_modules/.bin paths (to lint
+      // and format-check scaffolded projects), not via JS imports — knip
+      // can't see them.
+      ignoreDependencies: ['@mikrojs/eslint-plugin', 'eslint', 'prettier', 'typescript-eslint'],
+    },
     'packages/@repo/releaser': {
       // bin/releaser.js is auto-detected from package.json bin. The .ts is
       // invoked via tsx from the shim and dispatches to all command modules.

--- a/packages/create-mikrojs/package.json
+++ b/packages/create-mikrojs/package.json
@@ -56,8 +56,12 @@
     "type-fest": "^5.6.0"
   },
   "devDependencies": {
+    "@mikrojs/eslint-plugin": "workspace:*",
     "@types/node": "catalog:node24",
-    "typescript": "^6.0.3"
+    "eslint": "catalog:",
+    "prettier": "^3.4.0",
+    "typescript": "^6.0.3",
+    "typescript-eslint": "catalog:"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/packages/create-mikrojs/src/index.ts
+++ b/packages/create-mikrojs/src/index.ts
@@ -87,16 +87,6 @@ async function main(config: InferValue<typeof args>): Promise<void> {
     process.exit(0)
   }
 
-  const typescript = await p.confirm({
-    message: 'Use TypeScript?',
-    initialValue: true,
-  })
-
-  if (p.isCancel(typescript)) {
-    p.cancel('Cancelled.')
-    process.exit(0)
-  }
-
   const targetDir = path.resolve(process.cwd(), projectName)
   const isCwd = targetDir === process.cwd()
   const pkgName = isCwd ? path.basename(targetDir) : projectName
@@ -118,7 +108,6 @@ async function main(config: InferValue<typeof args>): Promise<void> {
     template,
     projectName: pkgName,
     mikrojsVersion: pkg.version,
-    typescript,
     templatesDir,
     pkgManager: pm,
   })

--- a/packages/create-mikrojs/src/inspect.ts
+++ b/packages/create-mikrojs/src/inspect.ts
@@ -32,7 +32,6 @@ scaffold({
   template,
   projectName: 'my-project',
   mikrojsVersion: '0.0.0',
-  typescript: true,
   templatesDir,
   pkgManager: 'npm',
 })

--- a/packages/create-mikrojs/src/scaffold.test.ts
+++ b/packages/create-mikrojs/src/scaffold.test.ts
@@ -1,5 +1,5 @@
 import {execFileSync} from 'node:child_process'
-import {existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync} from 'node:fs'
+import {mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync} from 'node:fs'
 import {tmpdir} from 'node:os'
 import path from 'node:path'
 import {fileURLToPath} from 'node:url'
@@ -30,116 +30,93 @@ describe.each(TEMPLATES)('template: $name', ({name}) => {
     rmSync(tempDir, {recursive: true, force: true})
   })
 
-  describe('with typescript', () => {
-    beforeEach(() => {
-      scaffold({
-        targetDir,
-        template: name,
-        projectName: 'test-project',
-        mikrojsVersion: '0.0.0',
-        typescript: true,
-        templatesDir,
-        pkgManager: 'npm',
-      })
-    })
-
-    it('creates package.json with correct fields', () => {
-      const pkg = JSON.parse(readFileSync(path.join(targetDir, 'package.json'), 'utf-8'))
-      expect(pkg.name).toBe('test-project')
-      expect(pkg.type).toBe('module')
-      expect(pkg.main).toBe('./app/main.ts')
-      expect(pkg.dependencies.mikrojs).toBe('^0.0.0')
-      expect(pkg.devDependencies.typescript).toBeDefined()
-      expect(pkg.scripts.lint).toBe('eslint .')
-      expect(pkg.scripts.typecheck).toBe('tsc --noEmit --pretty')
-      expect(pkg.scripts.dev).toBeUndefined()
-      expect(pkg.scripts.flash).toBeUndefined()
-      expect(pkg.engines).toBeUndefined()
-    })
-
-    it('creates tsconfig.json with mikrojs runtime types', () => {
-      const tsconfig = JSON.parse(readFileSync(path.join(targetDir, 'tsconfig.json'), 'utf-8'))
-      expect(tsconfig.compilerOptions.types).toContain('mikrojs/runtime')
-      expect(tsconfig.include).toContain('app/**/*')
-    })
-
-    it('creates .gitignore', () => {
-      const content = readFileSync(path.join(targetDir, '.gitignore'), 'utf-8')
-      expect(content).toContain('node_modules')
-      expect(content).toContain('.mikro')
-    })
-
-    it('creates .editorconfig', () => {
-      const content = readFileSync(path.join(targetDir, '.editorconfig'), 'utf-8')
-      expect(content).toContain('root = true')
-      expect(content).toContain('indent_style')
-    })
-
-    it('creates eslint.config.js with mikrojs plugin', () => {
-      const content = readFileSync(path.join(targetDir, 'eslint.config.js'), 'utf-8')
-      expect(content).toContain('@mikrojs/eslint-plugin')
-      const pkg = JSON.parse(readFileSync(path.join(targetDir, 'package.json'), 'utf-8'))
-      expect(pkg.devDependencies.eslint).toBeDefined()
-      expect(pkg.devDependencies['@mikrojs/eslint-plugin']).toBeDefined()
-    })
-
-    it('creates app/main.ts', () => {
-      const content = readFileSync(path.join(targetDir, 'app', 'main.ts'), 'utf-8')
-      expect(content.length).toBeGreaterThan(0)
-    })
-
-    it('type-checks against mikrojs types', () => {
-      // Symlink the workspace mikrojs package so tsc can resolve types
-      const nodeModules = path.join(targetDir, 'node_modules')
-      mkdirSync(nodeModules, {recursive: true})
-      symlinkSync(mikrojsPkgDir, path.join(nodeModules, 'mikrojs'))
-
-      // Symlink any extra dependencies needed for this template
-      const extras = EXTRA_TYPE_DEPS[name]
-      if (extras) {
-        for (const [pkg, pkgPath] of Object.entries(extras)) {
-          const dest = path.join(nodeModules, pkg)
-          mkdirSync(path.dirname(dest), {recursive: true})
-          symlinkSync(pkgPath, dest)
-        }
-      }
-
-      execFileSync(tscBin, ['--noEmit'], {
-        cwd: targetDir,
-        stdio: 'pipe',
-        env: {...process.env, NODE_OPTIONS: ''},
-      })
+  beforeEach(() => {
+    scaffold({
+      targetDir,
+      template: name,
+      projectName: 'test-project',
+      mikrojsVersion: '0.0.0',
+      templatesDir,
+      pkgManager: 'npm',
     })
   })
 
-  describe('without typescript', () => {
-    beforeEach(() => {
-      scaffold({
-        targetDir,
-        template: name,
-        projectName: 'test-project',
-        mikrojsVersion: '0.0.0',
-        typescript: false,
-        templatesDir,
-        pkgManager: 'npm',
-      })
-    })
+  it('creates package.json with correct fields', () => {
+    const pkg = JSON.parse(readFileSync(path.join(targetDir, 'package.json'), 'utf-8'))
+    expect(pkg.name).toBe('test-project')
+    expect(pkg.type).toBe('module')
+    expect(pkg.main).toBe('./app/main.ts')
+    expect(pkg.dependencies.mikrojs).toBe('^0.0.0')
+    expect(pkg.devDependencies.typescript).toBeDefined()
+    expect(pkg.devDependencies.prettier).toBeDefined()
+    expect(pkg.scripts.lint).toBe('eslint .')
+    expect(pkg.scripts.typecheck).toBe('tsc --noEmit --pretty')
+    expect(pkg.scripts.format).toBe('prettier --write .')
+    expect(pkg.scripts['format:check']).toBe('prettier --check .')
+    expect(pkg.scripts.dev).toBeUndefined()
+    expect(pkg.scripts.flash).toBeUndefined()
+    expect(pkg.engines).toBeUndefined()
+  })
 
-    it('does not include typescript in devDependencies', () => {
-      const pkg = JSON.parse(readFileSync(path.join(targetDir, 'package.json'), 'utf-8'))
-      expect(pkg.devDependencies).toBeUndefined()
-    })
+  it('creates tsconfig.json with mikrojs runtime types', () => {
+    const tsconfig = JSON.parse(readFileSync(path.join(targetDir, 'tsconfig.json'), 'utf-8'))
+    expect(tsconfig.compilerOptions.types).toContain('mikrojs/runtime')
+    expect(tsconfig.include).toContain('app/**/*')
+    expect(tsconfig.include).toContain('mikro.config.ts')
+  })
 
-    it('does not create tsconfig.json', () => {
-      expect(existsSync(path.join(targetDir, 'tsconfig.json'))).toBe(false)
-    })
+  it('creates .gitignore', () => {
+    const content = readFileSync(path.join(targetDir, '.gitignore'), 'utf-8')
+    expect(content).toContain('node_modules')
+    expect(content).toContain('.mikro')
+  })
 
-    it('does not create eslint config', () => {
-      expect(existsSync(path.join(targetDir, 'eslint.config.js'))).toBe(false)
-    })
+  it('creates .editorconfig', () => {
+    const content = readFileSync(path.join(targetDir, '.editorconfig'), 'utf-8')
+    expect(content).toContain('root = true')
+    expect(content).toContain('indent_style')
+  })
 
-    it('still creates .editorconfig', () => {
-      expect(existsSync(path.join(targetDir, '.editorconfig'))).toBe(true)
+  it('creates eslint.config.js with mikrojs plugin', () => {
+    const content = readFileSync(path.join(targetDir, 'eslint.config.js'), 'utf-8')
+    expect(content).toContain('@mikrojs/eslint-plugin')
+    const pkg = JSON.parse(readFileSync(path.join(targetDir, 'package.json'), 'utf-8'))
+    expect(pkg.devDependencies.eslint).toBeDefined()
+    expect(pkg.devDependencies['@mikrojs/eslint-plugin']).toBeDefined()
+  })
+
+  it('creates app/main.ts', () => {
+    const content = readFileSync(path.join(targetDir, 'app', 'main.ts'), 'utf-8')
+    expect(content.length).toBeGreaterThan(0)
+  })
+
+  it('creates mikro.config.ts with defineConfig', () => {
+    const content = readFileSync(path.join(targetDir, 'mikro.config.ts'), 'utf-8')
+    expect(content).toContain("from 'mikrojs'")
+    expect(content).toContain('defineConfig')
+    expect(content).toContain('https://mikrojs.dev/config')
+  })
+
+  it('type-checks against mikrojs types', () => {
+    // Symlink the workspace mikrojs package so tsc can resolve types
+    const nodeModules = path.join(targetDir, 'node_modules')
+    mkdirSync(nodeModules, {recursive: true})
+    symlinkSync(mikrojsPkgDir, path.join(nodeModules, 'mikrojs'))
+
+    // Symlink any extra dependencies needed for this template
+    const extras = EXTRA_TYPE_DEPS[name]
+    if (extras) {
+      for (const [pkg, pkgPath] of Object.entries(extras)) {
+        const dest = path.join(nodeModules, pkg)
+        mkdirSync(path.dirname(dest), {recursive: true})
+        symlinkSync(pkgPath, dest)
+      }
+    }
+
+    execFileSync(tscBin, ['--noEmit'], {
+      cwd: targetDir,
+      stdio: 'pipe',
+      env: {...process.env, NODE_OPTIONS: ''},
     })
   })
 })

--- a/packages/create-mikrojs/src/scaffold.test.ts
+++ b/packages/create-mikrojs/src/scaffold.test.ts
@@ -12,10 +12,46 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const templatesDir = __dirname + '/templates'
 const mikrojsPkgDir = path.resolve(__dirname, '..', '..', 'mikrojs')
 const createMikrojsPkgDir = path.resolve(__dirname, '..')
-const tscBin = path.resolve(createMikrojsPkgDir, 'node_modules', '.bin', 'tsc')
+const workspaceRoot = path.resolve(__dirname, '..', '..', '..')
+const cmNodeModules = path.resolve(createMikrojsPkgDir, 'node_modules')
 
-// Extra packages needed for type-checking specific templates
+const tscBin = path.resolve(cmNodeModules, '.bin', 'tsc')
+const eslintBin = path.resolve(cmNodeModules, '.bin', 'eslint')
+const prettierBin = path.resolve(cmNodeModules, '.bin', 'prettier')
+
+// Packages the scaffolded project's eslint/prettier/tsc need to resolve.
+// Paths point at the workspace install so the test doesn't actually
+// install anything into the temp project.
+const DEPS_TO_LINK: ReadonlyArray<readonly [src: string, dst: string]> = [
+  [mikrojsPkgDir, 'mikrojs'],
+  [path.join(cmNodeModules, 'eslint'), 'eslint'],
+  [path.join(cmNodeModules, 'prettier'), 'prettier'],
+  [path.join(cmNodeModules, 'typescript'), 'typescript'],
+  [path.join(cmNodeModules, 'typescript-eslint'), 'typescript-eslint'],
+  [path.join(cmNodeModules, '@mikrojs/eslint-plugin'), '@mikrojs/eslint-plugin'],
+  [path.join(workspaceRoot, 'node_modules/@eslint/js'), '@eslint/js'],
+]
+
+// Extra packages needed for specific templates beyond DEPS_TO_LINK.
 const EXTRA_TYPE_DEPS: Record<string, Record<string, string>> = {}
+
+function installDeps(targetDir: string, name: string) {
+  const nodeModules = path.join(targetDir, 'node_modules')
+  mkdirSync(nodeModules, {recursive: true})
+  for (const [src, rel] of DEPS_TO_LINK) {
+    const dst = path.join(nodeModules, rel)
+    mkdirSync(path.dirname(dst), {recursive: true})
+    symlinkSync(src, dst)
+  }
+  const extras = EXTRA_TYPE_DEPS[name]
+  if (extras) {
+    for (const [pkg, pkgPath] of Object.entries(extras)) {
+      const dst = path.join(nodeModules, pkg)
+      mkdirSync(path.dirname(dst), {recursive: true})
+      symlinkSync(pkgPath, dst)
+    }
+  }
+}
 
 describe.each(TEMPLATES)('template: $name', ({name}) => {
   let tempDir: string
@@ -92,28 +128,32 @@ describe.each(TEMPLATES)('template: $name', ({name}) => {
 
   it('creates mikro.config.ts with defineConfig', () => {
     const content = readFileSync(path.join(targetDir, 'mikro.config.ts'), 'utf-8')
-    expect(content).toContain("from 'mikrojs'")
+    expect(content).toContain('from "mikrojs"')
     expect(content).toContain('defineConfig')
     expect(content).toContain('https://mikrojs.dev/config')
   })
 
   it('type-checks against mikrojs types', () => {
-    // Symlink the workspace mikrojs package so tsc can resolve types
-    const nodeModules = path.join(targetDir, 'node_modules')
-    mkdirSync(nodeModules, {recursive: true})
-    symlinkSync(mikrojsPkgDir, path.join(nodeModules, 'mikrojs'))
-
-    // Symlink any extra dependencies needed for this template
-    const extras = EXTRA_TYPE_DEPS[name]
-    if (extras) {
-      for (const [pkg, pkgPath] of Object.entries(extras)) {
-        const dest = path.join(nodeModules, pkg)
-        mkdirSync(path.dirname(dest), {recursive: true})
-        symlinkSync(pkgPath, dest)
-      }
-    }
-
+    installDeps(targetDir, name)
     execFileSync(tscBin, ['--noEmit'], {
+      cwd: targetDir,
+      stdio: 'pipe',
+      env: {...process.env, NODE_OPTIONS: ''},
+    })
+  })
+
+  it('passes eslint', () => {
+    installDeps(targetDir, name)
+    execFileSync(eslintBin, ['--max-warnings=0', '.'], {
+      cwd: targetDir,
+      stdio: 'pipe',
+      env: {...process.env, NODE_OPTIONS: ''},
+    })
+  })
+
+  it('passes prettier --check', () => {
+    installDeps(targetDir, name)
+    execFileSync(prettierBin, ['--check', '.'], {
       cwd: targetDir,
       stdio: 'pipe',
       env: {...process.env, NODE_OPTIONS: ''},

--- a/packages/create-mikrojs/src/scaffold.ts
+++ b/packages/create-mikrojs/src/scaffold.ts
@@ -11,6 +11,7 @@ import {editorconfig} from './templates/_common/editorconfig.js'
 import {envExample} from './templates/_common/env-example.js'
 import {eslintConfig} from './templates/_common/eslint-config.js'
 import {gitignore} from './templates/_common/gitignore.js'
+import {mikroConfig} from './templates/_common/mikro-config.js'
 import {packageJson} from './templates/_common/package-json.js'
 import {readme} from './templates/_common/readme.js'
 import {tsconfig} from './templates/_common/tsconfig.js'
@@ -112,21 +113,12 @@ export interface ScaffoldOptions {
   template: string
   projectName: string
   mikrojsVersion: string
-  typescript?: boolean
   templatesDir: string
   pkgManager: PkgManager
 }
 
 export function scaffold(options: ScaffoldOptions) {
-  const {
-    targetDir,
-    template,
-    projectName,
-    mikrojsVersion,
-    typescript = true,
-    templatesDir,
-    pkgManager,
-  } = options
+  const {targetDir, template, projectName, mikrojsVersion, templatesDir, pkgManager} = options
 
   // Create project directory
   fs.mkdirSync(targetDir, {recursive: true})
@@ -141,29 +133,29 @@ export function scaffold(options: ScaffoldOptions) {
     JSON.stringify(
       packageJson(projectName, {
         dependencies: {...dependencies, mikrojs: `^${mikrojsVersion}`},
-        devDependencies: typescript
-          ? {
-              ...devDependencies,
-              ...eslintDevDependencies,
-              '@mikrojs/eslint-plugin': `^${mikrojsVersion}`,
-            }
-          : undefined,
-        typescript,
+        devDependencies: {
+          ...devDependencies,
+          ...eslintDevDependencies,
+          '@mikrojs/eslint-plugin': `^${mikrojsVersion}`,
+        },
       }),
       null,
       2,
     ) + '\n',
   )
-  if (typescript) {
-    const hasEnvDts = fs.existsSync(path.join(targetDir, 'env.d.ts'))
-    const tsconfigWithIncludes = hasEnvDts
-      ? {...tsconfig, include: ['env.d.ts', ...(tsconfig.include ?? [])]}
-      : tsconfig
-    fs.writeFileSync(
-      path.join(targetDir, 'tsconfig.json'),
-      JSON.stringify(tsconfigWithIncludes, null, 2) + '\n',
-    )
-    fs.writeFileSync(path.join(targetDir, 'eslint.config.js'), eslintConfig)
+  const hasEnvDts = fs.existsSync(path.join(targetDir, 'env.d.ts'))
+  const tsconfigWithIncludes = hasEnvDts
+    ? {...tsconfig, include: ['env.d.ts', ...(tsconfig.include ?? [])]}
+    : tsconfig
+  fs.writeFileSync(
+    path.join(targetDir, 'tsconfig.json'),
+    JSON.stringify(tsconfigWithIncludes, null, 2) + '\n',
+  )
+  fs.writeFileSync(path.join(targetDir, 'eslint.config.js'), eslintConfig)
+  // Write a default mikro.config.ts unless the template ships its own.
+  const mikroConfigPath = path.join(targetDir, 'mikro.config.ts')
+  if (!fs.existsSync(mikroConfigPath)) {
+    fs.writeFileSync(mikroConfigPath, mikroConfig)
   }
   fs.writeFileSync(path.join(targetDir, '.editorconfig'), editorconfig)
   fs.writeFileSync(path.join(targetDir, '.gitignore'), gitignore)

--- a/packages/create-mikrojs/src/scaffold.ts
+++ b/packages/create-mikrojs/src/scaffold.ts
@@ -13,8 +13,9 @@ import {eslintConfig} from './templates/_common/eslint-config.js'
 import {gitignore} from './templates/_common/gitignore.js'
 import {mikroConfig} from './templates/_common/mikro-config.js'
 import {packageJson} from './templates/_common/package-json.js'
+import {prettierConfig} from './templates/_common/prettier-config.js'
 import {readme} from './templates/_common/readme.js'
-import {tsconfig} from './templates/_common/tsconfig.js'
+import {tsconfigJson} from './templates/_common/tsconfig.js'
 
 interface TemplateMeta {
   name: string
@@ -144,14 +145,12 @@ export function scaffold(options: ScaffoldOptions) {
     ) + '\n',
   )
   const hasEnvDts = fs.existsSync(path.join(targetDir, 'env.d.ts'))
-  const tsconfigWithIncludes = hasEnvDts
-    ? {...tsconfig, include: ['env.d.ts', ...(tsconfig.include ?? [])]}
-    : tsconfig
   fs.writeFileSync(
     path.join(targetDir, 'tsconfig.json'),
-    JSON.stringify(tsconfigWithIncludes, null, 2) + '\n',
+    tsconfigJson(hasEnvDts ? ['env.d.ts'] : []),
   )
   fs.writeFileSync(path.join(targetDir, 'eslint.config.js'), eslintConfig)
+  fs.writeFileSync(path.join(targetDir, '.prettierrc.json'), prettierConfig)
   // Write a default mikro.config.ts unless the template ships its own.
   const mikroConfigPath = path.join(targetDir, 'mikro.config.ts')
   if (!fs.existsSync(mikroConfigPath)) {

--- a/packages/create-mikrojs/src/templates/_common/dependencies.ts
+++ b/packages/create-mikrojs/src/templates/_common/dependencies.ts
@@ -5,6 +5,7 @@ export const dependencies = {
 } satisfies PackageJson['dependencies']
 
 export const devDependencies = {
+  prettier: '^3.4.0',
   typescript: '^6.0.3',
 } satisfies PackageJson['devDependencies']
 

--- a/packages/create-mikrojs/src/templates/_common/eslint-config.ts
+++ b/packages/create-mikrojs/src/templates/_common/eslint-config.ts
@@ -1,11 +1,17 @@
 export const eslintConfig = `\
-import js from '@eslint/js'
-import mikrojs from '@mikrojs/eslint-plugin'
-import tseslint from 'typescript-eslint'
+import js from "@eslint/js";
+import mikrojs from "@mikrojs/eslint-plugin";
+import tseslint from "typescript-eslint";
 
 export default [
   js.configs.recommended,
   ...tseslint.configs.recommended,
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    languageOptions: {
+      parserOptions: { projectService: true },
+    },
+  },
   ...mikrojs.configs.recommended,
-]
+];
 `

--- a/packages/create-mikrojs/src/templates/_common/mikro-config.ts
+++ b/packages/create-mikrojs/src/templates/_common/mikro-config.ts
@@ -1,5 +1,5 @@
-export const mikroConfig = `import {defineConfig} from 'mikrojs'
+export const mikroConfig = `import { defineConfig } from "mikrojs";
 
 // Project configuration. See https://mikrojs.dev/config for all options.
-export default defineConfig({})
+export default defineConfig({});
 `

--- a/packages/create-mikrojs/src/templates/_common/mikro-config.ts
+++ b/packages/create-mikrojs/src/templates/_common/mikro-config.ts
@@ -1,0 +1,5 @@
+export const mikroConfig = `import {defineConfig} from 'mikrojs'
+
+// Project configuration. See https://mikrojs.dev/config for all options.
+export default defineConfig({})
+`

--- a/packages/create-mikrojs/src/templates/_common/package-json.ts
+++ b/packages/create-mikrojs/src/templates/_common/package-json.ts
@@ -5,12 +5,9 @@ export function packageJson(
   {
     devDependencies,
     dependencies,
-    typescript,
   }: {
     dependencies?: PackageJson['devDependencies']
     devDependencies?: PackageJson['dependencies']
-    /** Include the tsc predeploy hook. */
-    typescript?: boolean
   } = {},
 ) {
   return {
@@ -19,22 +16,16 @@ export function packageJson(
     private: true,
     type: 'module',
     main: './app/main.ts',
-    ...(typescript
-      ? {
-          scripts: {
-            lint: 'eslint .',
-            typecheck: 'tsc --noEmit --pretty',
-          },
-        }
-      : {}),
+    scripts: {
+      format: 'prettier --write .',
+      'format:check': 'prettier --check .',
+      lint: 'eslint .',
+      typecheck: 'tsc --noEmit --pretty',
+    },
     dependencies: dependencies as {},
     devDependencies: devDependencies as {},
-    ...(typescript
-      ? {
-          mikrojs: {
-            predeploy: ['tsc --noEmit --pretty'],
-          },
-        }
-      : {}),
+    mikrojs: {
+      predeploy: ['tsc --noEmit --pretty'],
+    },
   } satisfies PackageJson
 }

--- a/packages/create-mikrojs/src/templates/_common/prettier-config.ts
+++ b/packages/create-mikrojs/src/templates/_common/prettier-config.ts
@@ -1,0 +1,4 @@
+export const prettierConfig = `{
+  "printWidth": 100
+}
+`

--- a/packages/create-mikrojs/src/templates/_common/tsconfig.ts
+++ b/packages/create-mikrojs/src/templates/_common/tsconfig.ts
@@ -1,7 +1,7 @@
 import type {TsConfigJson} from 'type-fest'
 
 export const tsconfig: TsConfigJson = {
-  include: ['app/**/*'],
+  include: ['mikro.config.ts', 'app/**/*'],
   compilerOptions: {
     module: 'nodenext',
     target: 'es2024',

--- a/packages/create-mikrojs/src/templates/_common/tsconfig.ts
+++ b/packages/create-mikrojs/src/templates/_common/tsconfig.ts
@@ -1,27 +1,33 @@
-import type {TsConfigJson} from 'type-fest'
+export function tsconfigJson(extraIncludes: readonly string[] = []): string {
+  const includes = [...extraIncludes, 'mikro.config.ts', 'app/**/*']
+  return `{
+  "include": ${inlineStringArray(includes)},
+  "compilerOptions": {
+    "module": "nodenext",
+    "target": "es2024",
+    "lib": ${inlineStringArray(['es2024'])},
+    "noEmit": true,
+    "types": ${inlineStringArray(['mikrojs/runtime'])},
+    "sourceMap": true,
+    "noUncheckedIndexedAccess": true,
+    "allowUnreachableCode": false,
+    "erasableSyntaxOnly": true,
+    "strict": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noUncheckedSideEffectImports": true,
+    "moduleDetection": "force",
+    "jsx": "preserve",
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  }
+}
+`
+}
 
-export const tsconfig: TsConfigJson = {
-  include: ['mikro.config.ts', 'app/**/*'],
-  compilerOptions: {
-    module: 'nodenext',
-    target: 'es2024',
-    lib: ['es2024'],
-    noEmit: true,
-    types: ['mikrojs/runtime'],
-    sourceMap: true,
-    noUncheckedIndexedAccess: true,
-    allowUnreachableCode: false,
-    erasableSyntaxOnly: true,
-    strict: true,
-    verbatimModuleSyntax: true,
-    isolatedModules: true,
-    noUncheckedSideEffectImports: true,
-    moduleDetection: 'force',
-    jsx: 'preserve',
-    skipLibCheck: true,
-    noFallthroughCasesInSwitch: true,
-    noUnusedLocals: true,
-    forceConsistentCasingInFileNames: true,
-    resolveJsonModule: true,
-  },
+function inlineStringArray(items: readonly string[]): string {
+  return `[${items.map((s) => JSON.stringify(s)).join(', ')}]`
 }

--- a/packages/create-mikrojs/src/templates/blank/app/main.ts
+++ b/packages/create-mikrojs/src/templates/blank/app/main.ts
@@ -1,3 +1,3 @@
-import {board, version} from 'mikrojs/sys'
+import { board, version } from "mikrojs/sys";
 
-console.log(`Hello World from MikroJS v${version} (${board.name}@${board.chip}@${board.revision})`)
+console.log(`Hello World from MikroJS v${version} (${board.name}@${board.chip}@${board.revision})`);

--- a/packages/create-mikrojs/src/templates/blinky/app/main.ts
+++ b/packages/create-mikrojs/src/templates/blinky/app/main.ts
@@ -1,18 +1,18 @@
-import {digitalWrite, pinMode} from 'mikrojs/pin'
-import {sleep} from 'mikrojs/sleep'
+import { digitalWrite, pinMode } from "mikrojs/pin";
+import { sleep } from "mikrojs/sleep";
 
-let value: 0 | 1 = 0
+let value: 0 | 1 = 0;
 // GPIO 15 is the built-in LED on XIAO ESP32C6. Replace with your board's LED pin.
-const PIN = 15
+const PIN = 15;
 
-pinMode(PIN, 'OUTPUT').orPanic('Failed to configure LED pin')
+pinMode(PIN, "OUTPUT").orPanic("Failed to configure LED pin");
 
 while (true) {
-  value = value === 0 ? 1 : 0
-  const writeResult = digitalWrite(PIN, value)
+  value = value === 0 ? 1 : 0;
+  const writeResult = digitalWrite(PIN, value);
   if (!writeResult.ok) {
-    console.error('Write pin failed: %s', writeResult.error.name)
+    console.error("Write pin failed: %s", writeResult.error.name);
   }
 
-  await sleep(1000)
+  await sleep(1000);
 }

--- a/packages/create-mikrojs/src/templates/neopixel/app/color.ts
+++ b/packages/create-mikrojs/src/templates/neopixel/app/color.ts
@@ -1,23 +1,23 @@
 /** Convert HSV (h: 0–360, s: 0–1, v: 0–1) to RGB tuple */
 export function hsv(h: number, s: number, v: number): [r: number, g: number, b: number] {
-  h = h % 360
-  const max = v * 255
-  const min = max * (1 - s)
-  const sector = Math.floor(h / 60)
-  const adj = ((max - min) * (h % 60)) / 60
+  h = h % 360;
+  const max = v * 255;
+  const min = max * (1 - s);
+  const sector = Math.floor(h / 60);
+  const adj = ((max - min) * (h % 60)) / 60;
 
   switch (sector) {
     case 0:
-      return [max, min + adj, min]
+      return [max, min + adj, min];
     case 1:
-      return [max - adj, max, min]
+      return [max - adj, max, min];
     case 2:
-      return [min, max, min + adj]
+      return [min, max, min + adj];
     case 3:
-      return [min, max - adj, max]
+      return [min, max - adj, max];
     case 4:
-      return [min + adj, min, max]
+      return [min + adj, min, max];
     default:
-      return [max, min, max - adj]
+      return [max, min, max - adj];
   }
 }

--- a/packages/create-mikrojs/src/templates/neopixel/app/main.ts
+++ b/packages/create-mikrojs/src/templates/neopixel/app/main.ts
@@ -1,24 +1,24 @@
-import {NeoPixel} from 'mikrojs/neopixel'
+import { NeoPixel } from "mikrojs/neopixel";
 
-import {breathe} from './patterns/breathe.js'
-import {colorWipe} from './patterns/color-wipe.js'
-import {comet} from './patterns/comet.js'
-import {rainbow} from './patterns/rainbow.js'
-import {sparkle} from './patterns/sparkle.js'
+import { breathe } from "./patterns/breathe.js";
+import { colorWipe } from "./patterns/color-wipe.js";
+import { comet } from "./patterns/comet.js";
+import { rainbow } from "./patterns/rainbow.js";
+import { sparkle } from "./patterns/sparkle.js";
 
-const PIN = 8
-const NUM_LEDS = 24
-const BRIGHTNESS = 1
-const PATTERN_DURATION = 8000
+const PIN = 8;
+const NUM_LEDS = 24;
+const BRIGHTNESS = 1;
+const PATTERN_DURATION = 8000;
 
-const pixels = new NeoPixel(PIN, {count: NUM_LEDS})
+const pixels = new NeoPixel(PIN, { count: NUM_LEDS });
 
-const patterns = [rainbow, comet, breathe, sparkle, colorWipe]
+const patterns = [rainbow, comet, breathe, sparkle, colorWipe];
 
 while (true) {
   for (const pattern of patterns) {
-    ;(await pattern(pixels, NUM_LEDS, BRIGHTNESS, PATTERN_DURATION)).orPanic(
+    (await pattern(pixels, NUM_LEDS, BRIGHTNESS, PATTERN_DURATION)).orPanic(
       `NeoPixel pattern ${pattern.name} failed`,
-    )
+    );
   }
 }

--- a/packages/create-mikrojs/src/templates/neopixel/app/patterns/breathe.ts
+++ b/packages/create-mikrojs/src/templates/neopixel/app/patterns/breathe.ts
@@ -1,22 +1,22 @@
-import type {NeoPixel} from 'mikrojs/neopixel'
-import {ok} from 'mikrojs/result'
-import {sleep} from 'mikrojs/sleep'
+import type { NeoPixel } from "mikrojs/neopixel";
+import { ok } from "mikrojs/result";
+import { sleep } from "mikrojs/sleep";
 
-import {hsv} from '../color.js'
+import { hsv } from "../color.js";
 
 /** Breathe: all LEDs pulse a single color in and out */
 export async function breathe(pixels: NeoPixel, numLeds: number, brightness: number, ms: number) {
-  const end = Date.now() + ms
-  let t = 0
+  const end = Date.now() + ms;
+  let t = 0;
   while (Date.now() < end) {
-    const v = ((Math.sin(t) + 1) / 2) * brightness
-    const [r, g, b] = hsv(30, 1, v)
-    const fillResult = pixels.fill(r, g, b)
-    if (!fillResult.ok) return fillResult
-    const showResult = pixels.show()
-    if (!showResult.ok) return showResult
-    t += 0.06
-    await sleep(20)
+    const v = ((Math.sin(t) + 1) / 2) * brightness;
+    const [r, g, b] = hsv(30, 1, v);
+    const fillResult = pixels.fill(r, g, b);
+    if (!fillResult.ok) return fillResult;
+    const showResult = pixels.show();
+    if (!showResult.ok) return showResult;
+    t += 0.06;
+    await sleep(20);
   }
-  return ok(undefined)
+  return ok(undefined);
 }

--- a/packages/create-mikrojs/src/templates/neopixel/app/patterns/color-wipe.ts
+++ b/packages/create-mikrojs/src/templates/neopixel/app/patterns/color-wipe.ts
@@ -1,8 +1,8 @@
-import type {NeoPixel} from 'mikrojs/neopixel'
-import {ok} from 'mikrojs/result'
-import {sleep} from 'mikrojs/sleep'
+import type { NeoPixel } from "mikrojs/neopixel";
+import { ok } from "mikrojs/result";
+import { sleep } from "mikrojs/sleep";
 
-import {hsv} from '../color.js'
+import { hsv } from "../color.js";
 
 /** Color wipe: fill pixels one by one, then clear one by one */
 export async function colorWipe(pixels: NeoPixel, numLeds: number, brightness: number, ms: number) {
@@ -10,26 +10,26 @@ export async function colorWipe(pixels: NeoPixel, numLeds: number, brightness: n
     hsv(0, 1, brightness),
     hsv(120, 1, brightness),
     hsv(240, 1, brightness),
-  ]
-  const end = Date.now() + ms
-  let ci = 0
+  ];
+  const end = Date.now() + ms;
+  let ci = 0;
   while (Date.now() < end) {
-    const [r, g, b] = colors[ci % colors.length]!
+    const [r, g, b] = colors[ci % colors.length]!;
     for (let i = 0; i < numLeds; i++) {
-      const pixelResult = pixels.setPixel(i, r, g, b)
-      if (!pixelResult.ok) return pixelResult
-      const showResult = pixels.show()
-      if (!showResult.ok) return showResult
-      await sleep(25)
+      const pixelResult = pixels.setPixel(i, r, g, b);
+      if (!pixelResult.ok) return pixelResult;
+      const showResult = pixels.show();
+      if (!showResult.ok) return showResult;
+      await sleep(25);
     }
     for (let i = 0; i < numLeds; i++) {
-      const pixelResult = pixels.setPixel(i, 0, 0, 0)
-      if (!pixelResult.ok) return pixelResult
-      const showResult = pixels.show()
-      if (!showResult.ok) return showResult
-      await sleep(25)
+      const pixelResult = pixels.setPixel(i, 0, 0, 0);
+      if (!pixelResult.ok) return pixelResult;
+      const showResult = pixels.show();
+      if (!showResult.ok) return showResult;
+      await sleep(25);
     }
-    ci++
+    ci++;
   }
-  return ok(undefined)
+  return ok(undefined);
 }

--- a/packages/create-mikrojs/src/templates/neopixel/app/patterns/comet.ts
+++ b/packages/create-mikrojs/src/templates/neopixel/app/patterns/comet.ts
@@ -1,29 +1,29 @@
-import type {NeoPixel} from 'mikrojs/neopixel'
-import {ok} from 'mikrojs/result'
-import {sleep} from 'mikrojs/sleep'
+import type { NeoPixel } from "mikrojs/neopixel";
+import { ok } from "mikrojs/result";
+import { sleep } from "mikrojs/sleep";
 
-import {hsv} from '../color.js'
+import { hsv } from "../color.js";
 
 /** Comet: a bright head with a fading tail orbits the ring */
 export async function comet(pixels: NeoPixel, numLeds: number, brightness: number, ms: number) {
-  const TAIL_LEN = 8
-  const end = Date.now() + ms
-  let pos = 0
+  const TAIL_LEN = 8;
+  const end = Date.now() + ms;
+  let pos = 0;
   while (Date.now() < end) {
-    const fillResult = pixels.fill(0, 0, 0)
-    if (!fillResult.ok) return fillResult
+    const fillResult = pixels.fill(0, 0, 0);
+    if (!fillResult.ok) return fillResult;
     for (let i = 0; i < TAIL_LEN; i++) {
-      const idx = (pos - i + numLeds) % numLeds
-      const fade = 1 - i / TAIL_LEN
-      const v = fade * fade * brightness
-      const [r, g, b] = hsv(200, 1, v)
-      const pixelResult = pixels.setPixel(idx, r, g, b)
-      if (!pixelResult.ok) return pixelResult
+      const idx = (pos - i + numLeds) % numLeds;
+      const fade = 1 - i / TAIL_LEN;
+      const v = fade * fade * brightness;
+      const [r, g, b] = hsv(200, 1, v);
+      const pixelResult = pixels.setPixel(idx, r, g, b);
+      if (!pixelResult.ok) return pixelResult;
     }
-    const showResult = pixels.show()
-    if (!showResult.ok) return showResult
-    pos = (pos + 1) % numLeds
-    await sleep(40)
+    const showResult = pixels.show();
+    if (!showResult.ok) return showResult;
+    pos = (pos + 1) % numLeds;
+    await sleep(40);
   }
-  return ok(undefined)
+  return ok(undefined);
 }

--- a/packages/create-mikrojs/src/templates/neopixel/app/patterns/rainbow.ts
+++ b/packages/create-mikrojs/src/templates/neopixel/app/patterns/rainbow.ts
@@ -1,24 +1,24 @@
-import type {NeoPixel} from 'mikrojs/neopixel'
-import {ok} from 'mikrojs/result'
-import {sleep} from 'mikrojs/sleep'
+import type { NeoPixel } from "mikrojs/neopixel";
+import { ok } from "mikrojs/result";
+import { sleep } from "mikrojs/sleep";
 
-import {hsv} from '../color.js'
+import { hsv } from "../color.js";
 
 /** Rainbow: rotate a full spectrum around the ring */
 export async function rainbow(pixels: NeoPixel, numLeds: number, brightness: number, ms: number) {
-  const end = Date.now() + ms
-  let offset = 0
+  const end = Date.now() + ms;
+  let offset = 0;
   while (Date.now() < end) {
     for (let i = 0; i < numLeds; i++) {
-      const hue = ((i * 360) / numLeds + offset) % 360
-      const [r, g, b] = hsv(hue, 1, brightness)
-      const pixelResult = pixels.setPixel(i, r, g, b)
-      if (!pixelResult.ok) return pixelResult
+      const hue = ((i * 360) / numLeds + offset) % 360;
+      const [r, g, b] = hsv(hue, 1, brightness);
+      const pixelResult = pixels.setPixel(i, r, g, b);
+      if (!pixelResult.ok) return pixelResult;
     }
-    const showResult = pixels.show()
-    if (!showResult.ok) return showResult
-    offset = (offset + 5) % 360
-    await sleep(30)
+    const showResult = pixels.show();
+    if (!showResult.ok) return showResult;
+    offset = (offset + 5) % 360;
+    await sleep(30);
   }
-  return ok()
+  return ok();
 }

--- a/packages/create-mikrojs/src/templates/neopixel/app/patterns/sparkle.ts
+++ b/packages/create-mikrojs/src/templates/neopixel/app/patterns/sparkle.ts
@@ -1,25 +1,25 @@
-import type {NeoPixel} from 'mikrojs/neopixel'
-import {ok} from 'mikrojs/result'
-import {sleep} from 'mikrojs/sleep'
+import type { NeoPixel } from "mikrojs/neopixel";
+import { ok } from "mikrojs/result";
+import { sleep } from "mikrojs/sleep";
 
-import {hsv} from '../color.js'
+import { hsv } from "../color.js";
 
 /** Sparkle: random pixels flash white on a dim background */
 export async function sparkle(pixels: NeoPixel, numLeds: number, brightness: number, ms: number) {
-  const end = Date.now() + ms
+  const end = Date.now() + ms;
   while (Date.now() < end) {
-    const [br, bg, bb] = hsv(270, 0.8, brightness * 0.15)
-    const fillResult = pixels.fill(br, bg, bb)
-    if (!fillResult.ok) return fillResult
+    const [br, bg, bb] = hsv(270, 0.8, brightness * 0.15);
+    const fillResult = pixels.fill(br, bg, bb);
+    if (!fillResult.ok) return fillResult;
     for (let s = 0; s < 3; s++) {
-      const idx = Math.floor(Math.random() * numLeds)
-      const v = brightness * (0.5 + Math.random() * 0.5) * 255
-      const pixelResult = pixels.setPixel(idx, v, v, v)
-      if (!pixelResult.ok) return pixelResult
+      const idx = Math.floor(Math.random() * numLeds);
+      const v = brightness * (0.5 + Math.random() * 0.5) * 255;
+      const pixelResult = pixels.setPixel(idx, v, v, v);
+      if (!pixelResult.ok) return pixelResult;
     }
-    const showResult = pixels.show()
-    if (!showResult.ok) return showResult
-    await sleep(60)
+    const showResult = pixels.show();
+    if (!showResult.ok) return showResult;
+    await sleep(60);
   }
-  return ok()
+  return ok();
 }

--- a/packages/create-mikrojs/src/templates/pwm-led/app/main.ts
+++ b/packages/create-mikrojs/src/templates/pwm-led/app/main.ts
@@ -1,21 +1,21 @@
-import {Pwm} from 'mikrojs/pwm'
+import { Pwm } from "mikrojs/pwm";
 
 // GPIO 15 is the built-in LED on XIAO ESP32C6. Replace with your board's LED pin.
-const LED_PIN = 15
+const LED_PIN = 15;
 
-const led = new Pwm(LED_PIN, {freq: 50, duty: 0})
+const led = new Pwm(LED_PIN, { freq: 50, duty: 0 });
 
 // Breathe: smoothly fade in and out forever
 while (true) {
-  const fadeIn = await led.fade(1.0, 1000)
+  const fadeIn = await led.fade(1.0, 1000);
   if (!fadeIn.ok) {
-    console.error('Fade in failed: %s', fadeIn.error.name)
-    break
+    console.error("Fade in failed: %s", fadeIn.error.name);
+    break;
   }
 
-  const fadeOut = await led.fade(0.0, 1000)
+  const fadeOut = await led.fade(0.0, 1000);
   if (!fadeOut.ok) {
-    console.error('Fade out failed: %s', fadeOut.error.name)
-    break
+    console.error("Fade out failed: %s", fadeOut.error.name);
+    break;
   }
 }

--- a/packages/create-mikrojs/src/templates/rtc-counter/app/main.ts
+++ b/packages/create-mikrojs/src/templates/rtc-counter/app/main.ts
@@ -1,20 +1,22 @@
-import {rtcStorage} from 'mikrojs/kv/rtc'
-import * as s from 'mikrojs/schema'
-import {deepSleep, sleep} from 'mikrojs/sleep'
+import { rtcStorage } from "mikrojs/kv/rtc";
+import * as s from "mikrojs/schema";
+import { deepSleep, sleep } from "mikrojs/sleep";
 
 // Read the wake counter from RTC memory (survives deep sleep).
 // optional() because the key may not exist on first boot.
-const count = rtcStorage.createValue('count', {schema: s.optional(s.number())})
+const count = rtcStorage.createValue("count", {
+  schema: s.optional(s.number()),
+});
 
-console.log(`Wake #${count.get() ?? 0}`)
-console.log(`RTC memory: ${rtcStorage.info().used}/${rtcStorage.info().total} bytes used`)
+console.log(`Wake #${count.get() ?? 0}`);
+console.log(`RTC memory: ${rtcStorage.info().used}/${rtcStorage.info().total} bytes used`);
 
 // Increment and store back
-count.update((n) => (n ?? 0) + 1).orPanic('failed to store count')
+count.update((n) => (n ?? 0) + 1).orPanic("failed to store count");
 
-console.log('Waiting for a few seconds before going to deep sleep...')
-await sleep(5000)
+console.log("Waiting for a few seconds before going to deep sleep...");
+await sleep(5000);
 
 // Sleep for 15 seconds, then wake up again
-console.log('Going to deep sleep for 15s...')
-deepSleep(15000)
+console.log("Going to deep sleep for 15s...");
+deepSleep(15000);

--- a/packages/create-mikrojs/src/templates/sntp/app/main.ts
+++ b/packages/create-mikrojs/src/templates/sntp/app/main.ts
@@ -1,30 +1,32 @@
-import {env} from 'mikrojs/env'
-import {sleep} from 'mikrojs/sleep'
-import {sntp} from 'mikrojs/sntp'
-import {wifi} from 'mikrojs/wifi'
+import { env } from "mikrojs/env";
+import { sleep } from "mikrojs/sleep";
+import { sntp } from "mikrojs/sntp";
+import { wifi } from "mikrojs/wifi";
 
-await sleep(2000)
-console.log('Current time at startup: %s', new Date())
+await sleep(2000);
+console.log("Current time at startup: %s", new Date());
 
-const ssid = env.require('WIFI_SSID')
-const passphrase = env.require('WIFI_PASSPHRASE')
+const ssid = env.require("WIFI_SSID");
+const passphrase = env.require("WIFI_PASSPHRASE");
 
 // Connect to WiFi
-console.log(`Connecting to ${ssid}...`)
-const connectResult = await wifi.connect(ssid, passphrase)
+console.log(`Connecting to ${ssid}...`);
+const connectResult = await wifi.connect(ssid, passphrase);
 if (!connectResult.ok) {
-  console.error('WiFi connect failed: %s', connectResult.error.name)
+  console.error("WiFi connect failed: %s", connectResult.error.name);
 } else {
-  console.log('Connected! IP: %s', connectResult.value.ip)
+  console.log("Connected! IP: %s", connectResult.value.ip);
 
   // One-shot time sync
-  console.log('Syncing time...')
-  const syncResult = await sntp.sync({timezone: 'CET-1CEST,M3.5.0,M10.5.0/3'})
+  console.log("Syncing time...");
+  const syncResult = await sntp.sync({
+    timezone: "CET-1CEST,M3.5.0,M10.5.0/3",
+  });
   if (!syncResult.ok) {
-    console.error('SNTP sync failed: %s', syncResult.error.name)
+    console.error("SNTP sync failed: %s", syncResult.error.name);
   } else {
-    console.log('Time synced: %s', syncResult.value.time)
-    console.log('Current time: %s', new Date())
+    console.log("Time synced: %s", syncResult.value.time);
+    console.log("Current time: %s", new Date());
   }
 }
 

--- a/packages/create-mikrojs/src/templates/sntp/env.d.ts
+++ b/packages/create-mikrojs/src/templates/sntp/env.d.ts
@@ -1,4 +1,4 @@
 declare interface ImportMetaEnv {
-  WIFI_SSID: string
-  WIFI_PASSPHRASE: string
+  WIFI_SSID: string;
+  WIFI_PASSPHRASE: string;
 }

--- a/packages/create-mikrojs/src/templates/sntp/mikro.config.ts
+++ b/packages/create-mikrojs/src/templates/sntp/mikro.config.ts
@@ -1,5 +1,6 @@
 import {defineConfig} from 'mikrojs'
 
+// Project configuration. See https://mikrojs.dev/config for all options.
 export default defineConfig({
   // Set to your country code so WiFi uses the correct regulatory domain.
   wifi: {country: 'NO'},

--- a/packages/create-mikrojs/src/templates/sntp/mikro.config.ts
+++ b/packages/create-mikrojs/src/templates/sntp/mikro.config.ts
@@ -1,7 +1,7 @@
-import {defineConfig} from 'mikrojs'
+import { defineConfig } from "mikrojs";
 
 // Project configuration. See https://mikrojs.dev/config for all options.
 export default defineConfig({
   // Set to your country code so WiFi uses the correct regulatory domain.
-  wifi: {country: 'NO'},
-})
+  wifi: { country: "NO" },
+});

--- a/packages/create-mikrojs/src/templates/wifi-access-point/app/main.ts
+++ b/packages/create-mikrojs/src/templates/wifi-access-point/app/main.ts
@@ -1,37 +1,37 @@
-import {sleep} from 'mikrojs/sleep'
-import {wifi} from 'mikrojs/wifi'
+import { sleep } from "mikrojs/sleep";
+import { wifi } from "mikrojs/wifi";
 
 // Start the access point
 wifi.ap
   .start({
-    ssid: 'MikroJS-AP',
-    passphrase: 'hello1234',
+    ssid: "MikroJS-AP",
+    passphrase: "hello1234",
     channel: 6,
     maxConnections: 4,
   })
-  .orPanic('Failed to start access point')
+  .orPanic("Failed to start access point");
 
-console.log('Access point started')
-console.log('SSID: MikroJS-AP')
-console.log('IP: %s', wifi.ap.ip)
+console.log("Access point started");
+console.log("SSID: MikroJS-AP");
+console.log("IP: %s", wifi.ap.ip);
 
 // Log when stations connect/disconnect
 wifi.ap.onStationConnect.subscribe((info) => {
-  console.log('Station connected: %s', info.mac)
-})
+  console.log("Station connected: %s", info.mac);
+});
 
 wifi.ap.onStationDisconnect.subscribe((info) => {
-  console.log('Station disconnected: %s', info.mac)
-})
+  console.log("Station disconnected: %s", info.mac);
+});
 
 // Periodically print connected stations
 while (true) {
-  await sleep(10000)
-  const stations = wifi.ap.stations
+  await sleep(10000);
+  const stations = wifi.ap.stations;
   if (stations.length > 0) {
-    console.log(`Connected stations (${stations.length}):`)
+    console.log(`Connected stations (${stations.length}):`);
     for (const sta of stations) {
-      console.log(`  ${sta.mac} (RSSI: ${sta.rssi})`)
+      console.log(`  ${sta.mac} (RSSI: ${sta.rssi})`);
     }
   }
 }

--- a/packages/create-mikrojs/src/templates/wifi-access-point/mikro.config.ts
+++ b/packages/create-mikrojs/src/templates/wifi-access-point/mikro.config.ts
@@ -1,5 +1,6 @@
 import {defineConfig} from 'mikrojs'
 
+// Project configuration. See https://mikrojs.dev/config for all options.
 export default defineConfig({
   // Set to your country code so WiFi uses the correct regulatory domain.
   wifi: {country: 'NO'},

--- a/packages/create-mikrojs/src/templates/wifi-access-point/mikro.config.ts
+++ b/packages/create-mikrojs/src/templates/wifi-access-point/mikro.config.ts
@@ -1,7 +1,7 @@
-import {defineConfig} from 'mikrojs'
+import { defineConfig } from "mikrojs";
 
 // Project configuration. See https://mikrojs.dev/config for all options.
 export default defineConfig({
   // Set to your country code so WiFi uses the correct regulatory domain.
-  wifi: {country: 'NO'},
-})
+  wifi: { country: "NO" },
+});

--- a/packages/create-mikrojs/src/templates/wifi-fetch/app/main.ts
+++ b/packages/create-mikrojs/src/templates/wifi-fetch/app/main.ts
@@ -1,32 +1,32 @@
-import {env} from 'mikrojs/env'
-import {request} from 'mikrojs/http/request'
-import {memoryUsage} from 'mikrojs/sys'
-import {wifi} from 'mikrojs/wifi'
+import { env } from "mikrojs/env";
+import { request } from "mikrojs/http/request";
+import { memoryUsage } from "mikrojs/sys";
+import { wifi } from "mikrojs/wifi";
 
-const ssid = env.require('WIFI_SSID')
-const passphrase = env.require('WIFI_PASSPHRASE')
+const ssid = env.require("WIFI_SSID");
+const passphrase = env.require("WIFI_PASSPHRASE");
 
 // Connect to WiFi
-console.log(`Connecting to ${ssid}...`)
-const connectResult = await wifi.connect(ssid, passphrase)
+console.log(`Connecting to ${ssid}...`);
+const connectResult = await wifi.connect(ssid, passphrase);
 if (!connectResult.ok) {
-  console.error('WiFi connect failed: %s', connectResult.error.name)
+  console.error("WiFi connect failed: %s", connectResult.error.name);
 } else {
-  console.log('Connected! IP: %s', connectResult.value.ip)
+  console.log("Connected! IP: %s", connectResult.value.ip);
 
   // Request JSON from an API
-  const result = await request('https://jsonplaceholder.typicode.com/posts/1')
+  const result = await request("https://jsonplaceholder.typicode.com/posts/1");
   if (result.ok) {
     if (!result.value.ok) {
-      console.error(`HTTP error: ${result.value.status}`)
+      console.error(`HTTP error: ${result.value.status}`);
     } else {
-      const data = await result.value.json()
-      console.log('Fetched post: %o', data)
+      const data = await result.value.json();
+      console.log("Fetched post: %o", data);
     }
   } else {
-    console.error('Request failed: %s', result.error.name)
+    console.error("Request failed: %s", result.error.name);
   }
 }
 
-const mem = memoryUsage()
-console.log('free heap: %dKB', (mem.heapTotal - mem.heapUsed) / 1000)
+const mem = memoryUsage();
+console.log("free heap: %dKB", (mem.heapTotal - mem.heapUsed) / 1000);

--- a/packages/create-mikrojs/src/templates/wifi-fetch/env.d.ts
+++ b/packages/create-mikrojs/src/templates/wifi-fetch/env.d.ts
@@ -1,4 +1,4 @@
 declare interface ImportMetaEnv {
-  WIFI_SSID: string
-  WIFI_PASSPHRASE: string
+  WIFI_SSID: string;
+  WIFI_PASSPHRASE: string;
 }

--- a/packages/create-mikrojs/src/templates/wifi-fetch/mikro.config.ts
+++ b/packages/create-mikrojs/src/templates/wifi-fetch/mikro.config.ts
@@ -1,5 +1,6 @@
 import {defineConfig} from 'mikrojs'
 
+// Project configuration. See https://mikrojs.dev/config for all options.
 export default defineConfig({
   // Set to your country code so WiFi uses the correct regulatory domain.
   wifi: {country: 'NO'},

--- a/packages/create-mikrojs/src/templates/wifi-fetch/mikro.config.ts
+++ b/packages/create-mikrojs/src/templates/wifi-fetch/mikro.config.ts
@@ -1,7 +1,7 @@
-import {defineConfig} from 'mikrojs'
+import { defineConfig } from "mikrojs";
 
 // Project configuration. See https://mikrojs.dev/config for all options.
 export default defineConfig({
   // Set to your country code so WiFi uses the correct regulatory domain.
-  wifi: {country: 'NO'},
-})
+  wifi: { country: "NO" },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -482,12 +482,24 @@ importers:
         specifier: ^5.6.0
         version: 5.6.0
     devDependencies:
+      '@mikrojs/eslint-plugin':
+        specifier: workspace:*
+        version: link:../@mikrojs/eslint-plugin
       '@types/node':
         specifier: catalog:node24
         version: 24.12.2
+      eslint:
+        specifier: 'catalog:'
+        version: 10.3.0(jiti@2.7.0)
+      prettier:
+        specifier: ^3.4.0
+        version: 3.8.3
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      typescript-eslint:
+        specifier: 'catalog:'
+        version: 8.59.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3)
 
   packages/mikrojs:
     dependencies:
@@ -4813,6 +4825,11 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   proc-log@6.1.0:
     resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
@@ -9776,6 +9793,8 @@ snapshots:
       - ts-toolbelt
 
   prelude-ls@1.2.1: {}
+
+  prettier@3.8.3: {}
 
   proc-log@6.1.0: {}
 


### PR DESCRIPTION
- Drop the "Use TypeScript?" prompt
- Scaffold every project with a mikro.config.ts (default empty, linking to https://mikrojs.dev/config) so users have a discoverable hook.
- Add prettier + format scripts so a fresh project has a formatter wired up out of the box.