### PR TITLE
refactor(runtime)!: yield Result from streaming APIs

### DIFF
--- a/dev/e2e/test/fs.test.ts
+++ b/dev/e2e/test/fs.test.ts
@@ -258,7 +258,8 @@ describe('fs: readStream', () => {
     const decoder = new TextDecoder()
     let out = ''
     for await (const chunk of r.value) {
-      out += decoder.decode(chunk)
+      assert.ok(chunk)
+      out += decoder.decode(chunk.value)
     }
     assert.equal(out, payload)
   })
@@ -271,7 +272,8 @@ describe('fs: readStream', () => {
     assert.ok(r)
     const lines: string[] = []
     for await (const line of splitLines(decodeUtf8(r.value))) {
-      lines.push(line)
+      assert.ok(line)
+      lines.push(line.value)
     }
     assert.deepEqual(lines, ['one', 'two', 'three'])
   })

--- a/dev/e2e/test/http-request-e2e.test.heap-baseline.json
+++ b/dev/e2e/test/http-request-e2e.test.heap-baseline.json
@@ -3,7 +3,7 @@
     "heapDelta": 3101
   },
   "esp32c6": {
-    "heapDelta": 3613
+    "heapDelta": 3101
   },
   "simulator": {
     "heapDelta": 432

--- a/dev/e2e/test/http-request-e2e.test.ts
+++ b/dev/e2e/test/http-request-e2e.test.ts
@@ -46,7 +46,8 @@ describe.runIf(hasWifi && !isSim)('http request e2e', () => {
     assert.equal(result.value.status, 200)
     assert.truthy(result.value.ok, 'response.ok reflects 2xx')
     const body = await result.value.json()
-    assert.type(body, 'object')
+    assert.ok(body)
+    assert.type(body.value, 'object')
   })
 
   test('GET returns a non-empty body as bytes', async () => {
@@ -54,7 +55,8 @@ describe.runIf(hasWifi && !isSim)('http request e2e', () => {
     assert.ok(result)
 
     const bytes = await result.value.bytes()
-    assert.equal(bytes.length, 1024, `expected 1024 bytes, got ${bytes.length}`)
+    assert.ok(bytes)
+    assert.equal(bytes.value.length, 1024, `expected 1024 bytes, got ${bytes.value.length}`)
   })
 
   test('non-2xx status surfaces as response.ok=false with body still readable', async () => {
@@ -109,9 +111,11 @@ describe.runIf(hasWifi && !isSim)('http request e2e', () => {
     })
     assert.ok(result)
     assert.equal(result.value.status, 200)
-    const body = (await result.value.json()) as {json: {hello: string; n: number}}
-    assert.equal(body.json.hello, 'mikro')
-    assert.equal(body.json.n, 42)
+    const body = await result.value.json()
+    assert.ok(body)
+    const parsed = body.value as {json: {hello: string; n: number}}
+    assert.equal(parsed.json.hello, 'mikro')
+    assert.equal(parsed.json.n, 42)
   })
 
   test(

--- a/dev/e2e/test/http-request-streaming.test.heap-baseline.json
+++ b/dev/e2e/test/http-request-streaming.test.heap-baseline.json
@@ -3,7 +3,7 @@
     "heapDelta": 2722
   },
   "esp32c6": {
-    "heapDelta": 3234
+    "heapDelta": 2722
   },
   "simulator": {
     "heapDelta": 432

--- a/dev/e2e/test/http-request-streaming.test.ts
+++ b/dev/e2e/test/http-request-streaming.test.ts
@@ -43,7 +43,8 @@ describe.runIf(hasWifi && !isSim)('http request streaming', () => {
       let total = 0
       let chunks = 0
       for await (const c of result.value.body) {
-        total += c.length
+        assert.ok(c)
+        total += c.value.length
         chunks++
       }
       assert.equal(total, 16384, 'all bytes received via stream')
@@ -62,7 +63,8 @@ describe.runIf(hasWifi && !isSim)('http request streaming', () => {
       assert.ok(result)
       let lineCount = 0
       for await (const line of splitLines(decodeUtf8(result.value.body))) {
-        if (line.length > 0) lineCount++
+        assert.ok(line)
+        if (line.value.length > 0) lineCount++
       }
       assert.truthy(lineCount >= 5, `received ${lineCount} lines (expected >= 5)`)
     },

--- a/dev/e2e/test/modules-network.test.heap-baseline.json
+++ b/dev/e2e/test/modules-network.test.heap-baseline.json
@@ -3,7 +3,7 @@
     "heapDelta": 45050
   },
   "esp32c6": {
-    "heapDelta": 40748
+    "heapDelta": 47135
   },
   "simulator": {
     "heapDelta": 61212

--- a/dev/e2e/test/modules.test.heap-baseline.json
+++ b/dev/e2e/test/modules.test.heap-baseline.json
@@ -3,7 +3,7 @@
     "heapDelta": 31242
   },
   "esp32c6": {
-    "heapDelta": 30450
+    "heapDelta": 31242
   },
   "simulator": {
     "heapDelta": 54916

--- a/dev/e2e/test/observable.test.heap-baseline.json
+++ b/dev/e2e/test/observable.test.heap-baseline.json
@@ -1,5 +1,8 @@
 {
   "esp32c5": {
     "heapDelta": 4473
+  },
+  "esp32c6": {
+    "heapDelta": 4473
   }
 }

--- a/dev/e2e/test/result.test.ts
+++ b/dev/e2e/test/result.test.ts
@@ -1,4 +1,4 @@
-import {defineError, err, ok} from 'mikrojs/result'
+import {err, matchError, ok} from 'mikrojs/result'
 import {assert, describe, test} from 'mikrojs/test'
 
 describe('result', () => {
@@ -84,18 +84,20 @@ describe('result', () => {
     assert.throws(() => err('bad').orPanic('panicked'))
   })
 
-  test('defineError creates error factories', () => {
-    const MyError = defineError('MyError', {
-      NotFound: (id: string) => ({id}),
-      Invalid: (reason: string) => ({reason}),
+  test('matchError dispatches on name with exhaustive handlers', () => {
+    type E = {name: 'NotFound'; id: string} | {name: 'Invalid'; reason: string}
+    const e1: E = {name: 'NotFound', id: 'abc'}
+    const out1 = matchError(e1, {
+      NotFound: (e) => `missing:${e.id}`,
+      Invalid: (e) => `bad:${e.reason}`,
     })
+    assert.equal(out1, 'missing:abc')
 
-    const e1 = MyError.NotFound('abc')
-    assert.equal(e1.name, 'NotFound')
-    assert.equal(e1.id, 'abc')
-
-    const e2 = MyError.Invalid('too short')
-    assert.equal(e2.name, 'Invalid')
-    assert.equal(e2.reason, 'too short')
+    const e2: E = {name: 'Invalid', reason: 'too short'}
+    const out2 = matchError(e2, {
+      NotFound: (e) => `missing:${e.id}`,
+      Invalid: (e) => `bad:${e.reason}`,
+    })
+    assert.equal(out2, 'bad:too short')
   })
 })

--- a/dev/e2e/test/udp.test.heap-baseline.json
+++ b/dev/e2e/test/udp.test.heap-baseline.json
@@ -3,6 +3,6 @@
     "heapDelta": -352
   },
   "esp32c6": {
-    "heapDelta": -832
+    "heapDelta": -352
   }
 }

--- a/dev/e2e/test/wifi-e2e.test.heap-baseline.json
+++ b/dev/e2e/test/wifi-e2e.test.heap-baseline.json
@@ -3,7 +3,7 @@
     "heapDelta": 46031
   },
   "esp32c6": {
-    "heapDelta": 41217
+    "heapDelta": 48116
   },
   "simulator": {
     "heapDelta": 61769

--- a/dev/kitchen-sink/app/main.ts
+++ b/dev/kitchen-sink/app/main.ts
@@ -8,7 +8,7 @@ import {rtcStorage} from 'mikrojs/kv/rtc'
 import {NeoPixel} from 'mikrojs/neopixel'
 import {analogRead, digitalRead, digitalWrite, pinMode} from 'mikrojs/pin'
 import {Pwm} from 'mikrojs/pwm'
-import {defineError, err, ok} from 'mikrojs/result'
+import {err, matchError, ok} from 'mikrojs/result'
 import * as s from 'mikrojs/schema'
 import {sleep} from 'mikrojs/sleep'
 import {sntp} from 'mikrojs/sntp'
@@ -36,7 +36,7 @@ console.log('kv:', typeof nvsStorage, typeof rtcStorage)
 console.log('neopixel:', typeof NeoPixel)
 console.log('pin:', typeof pinMode, typeof digitalWrite, typeof digitalRead, typeof analogRead)
 console.log('pwm:', typeof Pwm)
-console.log('result:', typeof ok, typeof err, typeof defineError)
+console.log('result:', typeof ok, typeof err, typeof matchError)
 console.log('schema:', typeof s.string, typeof s.object, typeof s.parse)
 console.log('sleep:', typeof sleep)
 console.log('sntp:', typeof sntp)

--- a/docs/api/fs.md
+++ b/docs/api/fs.md
@@ -56,10 +56,10 @@ Read a file as a stream of byte chunks.
 function readStream(
   path: string,
   options?: {chunkSize?: number},
-): Result<AsyncIterable<Uint8Array>, FSError>
+): Result<AsyncIterable<Result<Uint8Array, FSError>>, FSError>
 ```
 
-The Result wraps the initial open. Mid-stream read errors reject the iterator. The underlying handle closes on EOF, error, or early consumer break.
+The outer `Result` wraps the initial `open`. Once iterating, each yielded item is itself a `Result<Uint8Array, FSError>`: ok-wrapped chunks on success, a single terminal err item if a mid-stream read fails. The underlying handle closes on EOF, error, or early consumer break.
 
 Composes with `mikrojs/stream` for text and line processing:
 
@@ -69,7 +69,11 @@ import {decodeUtf8, splitLines} from 'mikrojs/stream'
 // ---cut---
 const stream = readStream('/data/events.log').orPanic('log missing')
 for await (const line of splitLines(decodeUtf8(stream))) {
-  console.log(line)
+  if (!line.ok) {
+    console.error(`read failed: ${line.error.name}`)
+    break
+  }
+  console.log(line.value)
 }
 ```
 

--- a/docs/api/http-request.md
+++ b/docs/api/http-request.md
@@ -32,6 +32,11 @@ if (!result.ok) {
 const response = result.value
 console.log('Status: %d', response.status)
 const data = await response.json()
+if (!data.ok) {
+  console.error('Body decode failed: %s', data.error.name)
+  return
+}
+console.log(data.value)
 ```
 
 ::: tip Result vs response.ok
@@ -52,6 +57,11 @@ if (!result.value.ok) {
   return
 }
 const data = await result.value.json()
+if (!data.ok) {
+  // Body drain or JSON.parse failed mid-stream
+  return
+}
+console.log(data.value)
 ```
 
 :::
@@ -111,18 +121,18 @@ interface Response {
   readonly redirected: boolean
   readonly headers: [string, string][]
   readonly ok: boolean // true if status is 200-299
-  readonly body: AsyncIterable<Uint8Array>
+  readonly body: AsyncIterable<Result<Uint8Array, RequestError>>
 
   get(name: string): string | undefined
   getAll(name: string): string[]
-  text(): Promise<string>
-  json(): Promise<unknown>
-  bytes(): Promise<Uint8Array>
+  text(): Promise<Result<string, RequestError>>
+  json(): Promise<Result<unknown, RequestError>>
+  bytes(): Promise<Result<Uint8Array, RequestError>>
   close(): Promise<void>
 }
 ```
 
-`get` and `getAll` look up headers case-insensitively. `text()`, `json()`, `bytes()`, and `body` are single-shot: calling more than one drains the body and a second call throws [`BodyConsumedError`](#bodyconsumederror).
+`get` and `getAll` look up headers case-insensitively. `text()`, `json()`, `bytes()`, and `body` are single-shot: calling more than one drains the body and a second call throws [`BodyConsumedError`](#bodyconsumederror). Each method returns a `Result` so mid-stream network drops, aborts, or (for `json()`) JSON parse failures stay inside the Result chain instead of throwing.
 
 ::: warning Always close responses you don't read
 Every response you don't drain with `text()`, `json()`, `bytes()`, or a `for await` loop needs an explicit `await response.close()`. Skipping this keeps memory tied up until the device reboots, and eventually new requests will fail with [`TooManyPending`](#requesterror).
@@ -143,6 +153,7 @@ Returned by `request` and any custom transport built on top of `mikrojs/http/hel
 | `InvalidResponse` | `message: string`             | Response was malformed or couldn't be parsed                 |
 | `Aborted`         | `message: string`             | Request was cancelled via timeout or `AbortSignal`           |
 | `TooManyPending`  | —                             | Transport's in-flight request slots are full                 |
+| `InvalidJson`     | `message: string`             | `Response.json()` drained the body but `JSON.parse` failed   |
 
 ### BodyConsumedError
 
@@ -172,7 +183,7 @@ export const request: Request = async (url, opts = {}) => {
       url,
       redirected: false,
       headers: raw.value.headers,
-      body: raw.value.body, // AsyncIterable<Uint8Array>
+      body: raw.value.body, // AsyncIterable<Result<Uint8Array, RequestError>>
     }),
   )
 }

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -24,7 +24,7 @@ import {request} from 'mikrojs/http/request'
 | Module                            | Description                                      |
 | --------------------------------- | ------------------------------------------------ |
 | [env](/api/env)                   | Environment variables: `require`, `get`, `has`   |
-| [result](/api/result)             | `Result` type, `ok()`, `err()`, `defineError()`  |
+| [result](/api/result)             | `Result` type, `ok()`, `err()`, `matchError()`   |
 | [schema](/api/schema)             | Runtime type validation with type inference      |
 | [pin](/api/pin)                   | GPIO: digital read/write, analog read            |
 | [pwm](/api/pwm)                   | Pulse-width modulation                           |

--- a/docs/api/kv.md
+++ b/docs/api/kv.md
@@ -159,9 +159,10 @@ Default: `() => undefined`.
 
 Errors returned by `set()` and `update()`, or passed to `onReadError`:
 
-| Variant            | When                                        |
-| ------------------ | ------------------------------------------- |
-| `StorageFull`      | RTC memory or NVS partition is full         |
-| `EncodeFailed`     | Value is not [CBOR](/api/cbor)-encodable    |
-| `WriteFailed`      | NVS open/commit failed (hardware error)     |
-| `ValidationFailed` | Schema validation failed (has `path` field) |
+| Variant            | When                                                          |
+| ------------------ | ------------------------------------------------------------- |
+| `StorageFull`      | RTC memory or NVS partition is full                           |
+| `EncodeFailed`     | Value is not [CBOR](/api/cbor)-encodable                      |
+| `WriteFailed`      | NVS open/commit failed (hardware error)                       |
+| `ValidationFailed` | Schema validation failed (has `path` field)                   |
+| `Unknown`          | Native code returned an error not in the curated set (`code`) |

--- a/docs/api/result.md
+++ b/docs/api/result.md
@@ -6,7 +6,7 @@ description: Result type for typed error handling
 # result
 
 ```ts twoslash
-import {ok, err, defineError} from 'mikrojs/result'
+import {ok, err, matchError} from 'mikrojs/result'
 import type {Result, OkResult, ErrResult} from 'mikrojs/result'
 ```
 
@@ -49,25 +49,45 @@ result.ok // false
 result.error // {name: 'NotFound'}
 ```
 
-### defineError()
+### matchError()
 
-Defines a set of named error variants. Each variant is a factory function that produces a tagged error object.
+Exhaustive dispatch on a tagged error's `name` field. The handler map must cover every variant or TypeScript fails the call site at compile time.
 
 ```ts
-function defineError<D>(name: string, variants: D): ErrorConstructors<D>
+function matchError<E extends {name: string}, R>(
+  error: E,
+  handlers: {[K in E['name']]: (error: Extract<E, {name: K}>) => R},
+): R
 ```
 
 ```ts twoslash
-import {defineError} from 'mikrojs/result'
+type SensorError = {name: 'ReadFailed'; message: string} | {name: 'NotConnected'}
 // ---cut---
-const SensorError = defineError('SensorError', {
-  ReadFailed: (message: string) => ({message}),
-  NotConnected: () => ({}),
-})
+import {matchError} from 'mikrojs/result'
 
-const e = SensorError.ReadFailed('timeout')
-// {name: 'ReadFailed', message: 'timeout'}
+declare const e: SensorError
+const summary = matchError(e, {
+  ReadFailed: (e) => `read failed: ${e.message}`,
+  NotConnected: () => 'sensor not connected',
+})
 ```
+
+## Defining a typed error union
+
+Mikro.js modules expose their failures as tagged unions on `name`. The recommended pattern is a const factory object plus a `ReturnType` extraction:
+
+```ts twoslash
+const SensorError = {
+  ReadFailed: (message: string) => ({name: 'ReadFailed', message}) as const,
+  NotConnected: () => ({name: 'NotConnected'}) as const,
+}
+type SensorError = ReturnType<(typeof SensorError)[keyof typeof SensorError]>
+
+// Usage: `err(SensorError.ReadFailed('timeout'))` yields
+// ErrResult<{name: 'ReadFailed'; message: string}>
+```
+
+The factory is plain JS — no runtime indirection, no closure overhead beyond the variant functions themselves. Inline `err({name: 'X' as const, ...})` literals are fine too when a variant only has one or two call sites.
 
 ## Result methods
 
@@ -161,20 +181,4 @@ Use this when failure is truly unrecoverable (e.g., during setup).
 
 ```ts
 type Result<T, E> = OkResult<T> | ErrResult<E>
-```
-
-### ErrorOf\<T\>
-
-Utility type that extracts the union of error shapes from an error constructor object (returned by `defineError`).
-
-```ts twoslash
-import {defineError} from 'mikrojs/result'
-import type {ErrorOf} from 'mikrojs/result'
-const SensorError = defineError('SensorError', {
-  ReadFailed: (message: string) => ({message}),
-  NotConnected: () => ({}),
-})
-// ---cut---
-type MyError = ErrorOf<typeof SensorError>
-// {name: 'ReadFailed'; message: string} | {name: 'NotConnected'}
 ```

--- a/docs/api/uart.md
+++ b/docs/api/uart.md
@@ -22,10 +22,14 @@ uart.begin().orPanic('UART init failed')
 // Write data
 uart.write(new Uint8Array([0x41, 0x54, 0x0d, 0x0a])).orPanic('write failed')
 
-// Read data (async iterator)
+// Read data (async iterator of Result<Uint8Array, UartError>)
 const reader = uart.read().orPanic('read failed')
 for await (const chunk of reader) {
-  console.log('received: %s', new TextDecoder().decode(chunk))
+  if (!chunk.ok) {
+    console.error('uart read failed: %s', chunk.error.name)
+    break
+  }
+  console.log('received: %s', new TextDecoder().decode(chunk.value))
   break
 }
 
@@ -96,12 +100,12 @@ Write bytes to the TX pin. Blocks until all bytes are written to the FIFO. Only 
 ### uart.read()
 
 ```ts
-read(): Result<AsyncIterable<Uint8Array>, UartError>
+read(): Result<AsyncIterable<Result<Uint8Array, UartError>>, UartError>
 ```
 
-Start reading from the RX pin. Returns an `AsyncIterable` that yields `Uint8Array` chunks as data arrives. Only available when `rx` was provided in the constructor.
+Start reading from the RX pin. The outer Result wraps the initial open. The iterable yields `Result<Uint8Array, UartError>`: ok-wrapped chunks on success, a single terminal err item if the port becomes unavailable mid-iteration (e.g. `end()` was called). Only available when `rx` was provided in the constructor.
 
-Each iteration yields whatever bytes have accumulated in the receive buffer since the last read. Chunk boundaries do not correspond to message boundaries; higher-level framing (line splitting, packet parsing) is the caller's responsibility.
+Each yielded chunk contains whatever bytes have accumulated in the receive buffer since the last read. Chunk boundaries do not correspond to message boundaries; higher-level framing (line splitting, packet parsing) is the caller's responsibility.
 
 Only one reader can be active at a time. Calling `read()` while another reader is active returns an `AlreadyReading` error. Breaking out of the `for await` loop cleanly closes the reader, and `read()` can be called again.
 
@@ -113,7 +117,11 @@ uart.begin().orPanic('UART init failed')
 const reader = uart.read().orPanic('read failed')
 
 for await (const chunk of reader) {
-  const text = new TextDecoder().decode(chunk)
+  if (!chunk.ok) {
+    console.error('uart read failed: %s', chunk.error.name)
+    break
+  }
+  const text = new TextDecoder().decode(chunk.value)
   console.log(text)
   if (text.includes('OK')) break // break is safe, read() can be called again
 }
@@ -133,7 +141,7 @@ interface UartTx {
 
 ```ts
 interface UartRx {
-  read(): Result<AsyncIterable<Uint8Array>, UartError>
+  read(): Result<AsyncIterable<Result<Uint8Array, UartError>>, UartError>
 }
 ```
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -106,7 +106,6 @@ The most common pattern is checking and returning early:
 ```ts twoslash
 import {ok, err, type Result} from 'mikrojs/result'
 import {analogRead, type PinError} from 'mikrojs/pin'
-import {defineError, type ErrorOf} from 'mikrojs/result'
 declare const PublishError: {
   NetworkError: (message: string) => {name: 'NetworkError'; message: string}
 }
@@ -173,27 +172,28 @@ const message = analogRead(34).match({
 
 ## Defining errors
 
-Mikro.js modules define their errors using `defineError`:
+Mikro.js modules define their errors as tagged unions, keyed on `name`. The recommended shape is a const factory object plus a `ReturnType` extraction:
 
 ```ts twoslash
-import {defineError, type ErrorOf} from 'mikrojs/result'
+const SensorError = {
+  NotConnected: () => ({name: 'NotConnected'}) as const,
+  ReadFailed: (message: string) => ({name: 'ReadFailed', message}) as const,
+  OutOfRange: (value: number, min: number, max: number) =>
+    ({name: 'OutOfRange', value, min, max}) as const,
+}
 
-const SensorError = defineError('SensorError', {
-  NotConnected: () => ({}),
-  ReadFailed: (message: string) => ({message}),
-  OutOfRange: (value: number, min: number, max: number) => ({value, min, max}),
-})
-
-type SensorError = ErrorOf<typeof SensorError>
+type SensorError = ReturnType<(typeof SensorError)[keyof typeof SensorError]>
 ```
 
 This gives you:
 
 - **Constructor functions:** `SensorError.ReadFailed("timeout")` creates `{name: "ReadFailed", message: "timeout"}`
 - **A union type:** `SensorError` is `{name: "NotConnected"} | {name: "ReadFailed", message: string} | {name: "OutOfRange", value: number, min: number, max: number}`
-- **Exhaustive switching:** TypeScript enforces that you handle every variant in a `switch` block
+- **Exhaustive switching:** TypeScript enforces that you handle every variant in a `switch` block, or via [`matchError`](/api/result#matcherror)
 
 Errors are plain objects; no class hierarchies, no prototypes. They're cheap to create and easy to log over serial.
+
+For variants with only one or two call sites, an inline `err({name: 'X' as const, ...})` literal is fine — the factory pattern is just discoverability over the same shape.
 
 ## What about exceptions?
 
@@ -247,7 +247,7 @@ Other rules flag `throw`, `try/catch`, `Promise.reject()`, and `.catch()` to kee
 ## Quick reference
 
 ```ts
-import {ok, err, defineError, type Result, type ErrorOf} from 'mikrojs/result'
+import {ok, err, matchError, type Result} from 'mikrojs/result'
 
 // Check a result
 if (result.ok) {
@@ -290,11 +290,11 @@ switch (result.error.name) {
 }
 
 // Define custom errors
-const MyError = defineError('MyError', {
-  NotFound: (id: string) => ({id}),
-  Timeout: (ms: number) => ({ms}),
-})
-type MyError = ErrorOf<typeof MyError>
+const MyError = {
+  NotFound: (id: string) => ({name: 'NotFound', id}) as const,
+  Timeout: (ms: number) => ({name: 'Timeout', ms}) as const,
+}
+type MyError = ReturnType<(typeof MyError)[keyof typeof MyError]>
 
 // Use in function signatures
 function myFunction(): Result<string, MyError> {

--- a/docs/examples/uart.md
+++ b/docs/examples/uart.md
@@ -38,7 +38,11 @@ if (!reader.ok) {
   // Give data a moment to loop back
   await sleep(1000)
   for await (const chunk of reader.value) {
-    console.log('Received: %s', new TextDecoder().decode(chunk))
+    if (!chunk.ok) {
+      console.error('UART read error: %s', chunk.error.name)
+      break
+    }
+    console.log('Received: %s', new TextDecoder().decode(chunk.value))
   }
 }
 
@@ -54,7 +58,7 @@ console.log('Done!')
 
 3. **Writing.** `uart.write()` sends a `Uint8Array`. Use `TextEncoder` to convert strings to bytes.
 
-4. **Reading.** `uart.read()` returns an async iterator that yields `Uint8Array` chunks as they arrive. The `for await` loop processes each chunk. Use `TextDecoder` to convert bytes back to strings.
+4. **Reading.** `uart.read()` returns an async iterator that yields [`Result<Uint8Array, UartError>`](/api/result) items. Check `.ok` before reading `.value`; a non-ok chunk (e.g. port closed mid-read) is the iterator's terminal signal. Use `TextDecoder` to convert bytes back to strings.
 
 5. **Loopback test.** With TX wired to RX, the message you send is immediately received. This is a simple way to verify UART works before connecting to an actual peripheral.
 

--- a/docs/examples/wifi-fetch.md
+++ b/docs/examples/wifi-fetch.md
@@ -67,7 +67,11 @@ if (!connectResult.ok) {
       console.error(`HTTP error: ${result.value.status}`)
     } else {
       const data = await result.value.json()
-      console.log('Fetched post: %o', data)
+      if (!data.ok) {
+        console.error(`Body decode failed: ${data.error.name}`)
+      } else {
+        console.log('Fetched post: %o', data.value)
+      }
     }
   } else {
     console.error('Request failed: %s', result.error.name)

--- a/examples/uart/app/main.ts
+++ b/examples/uart/app/main.ts
@@ -20,7 +20,11 @@ if (!reader.ok) {
   // Give data a moment to loop back
   await sleep(1000)
   for await (const chunk of reader.value) {
-    console.log('Received: %s', new TextDecoder().decode(chunk))
+    if (!chunk.ok) {
+      console.error('UART read error: %s', chunk.error.name)
+      break
+    }
+    console.log('Received: %s', new TextDecoder().decode(chunk.value))
   }
 }
 

--- a/examples/wifi-fetch/app/main.ts
+++ b/examples/wifi-fetch/app/main.ts
@@ -21,7 +21,11 @@ if (!connectResult.ok) {
       console.error(`HTTP error: ${result.value.status}`)
     } else {
       const data = await result.value.json()
-      console.log('Fetched post: %o', data)
+      if (!data.ok) {
+        console.error(`Body decode failed: ${data.error.name}`)
+      } else {
+        console.log('Fetched post: %o', data.value)
+      }
     }
   } else {
     console.error('Request failed: %s', result.error.name)

--- a/packages/@mikrojs/firmware/components/mikrojs/mik_http.cpp
+++ b/packages/@mikrojs/firmware/components/mikrojs/mik_http.cpp
@@ -668,15 +668,39 @@ static JSValue mik__http_next_message(JSContext* ctx, JSValue this_val, int argc
     return promise;
 }
 
+/* Forward decl: defined further down, called here so pendingCount() drains
+ * result_queue before reading the counter. */
+void mik__http_consume(JSContext* ctx);
+
 /* pendingCount() — number of in-flight requests whose terminal message has
  * not yet been consumed. Useful for tests that want to verify cancel+drain
- * freed a slot without relying on heap-headroom for a follow-up request. */
+ * freed a slot without relying on heap-headroom for a follow-up request.
+ *
+ * Drains result_queue first via the consume loop. Without this, a request
+ * whose native task has already posted its terminal message but whose
+ * message hasn't been processed by the next event-loop tick reads as
+ * "still pending" — even though it'd drop microseconds later. Surfaced
+ * as an intermittent "in-flight HTTP request at teardown" warning when
+ * the test harness reads pendingCount() synchronously right after the
+ * last awaited test step. */
 static JSValue mik__http_pending_count(JSContext* ctx, JSValue this_val, int argc,
                                        JSValue* argv) {
     MIKRuntime* mik_rt = MIK_GetRuntime(ctx);
     CHECK_NOT_NULL(mik_rt);
     if (!mik__http_st(mik_rt)) return JS_NewUint32(ctx, 0);
-    return JS_NewUint32(ctx, mik__http_st(mik_rt)->pending_count);
+    mik__http_consume(ctx);
+    /* Exclude explicitly-cancelled entries. JS has signalled intent to
+     * release; the entry stays alive only until the native task wakes
+     * from a blocking call (TLS handshake, DNS) and posts its terminal
+     * message. That's not a leak — counting it as one fires false
+     * "in-flight HTTP at teardown" warnings on tests that abort or
+     * time out a request and exit before the native task has noticed. */
+    MIKHttpState* state = mik__http_st(mik_rt);
+    uint32_t live = 0;
+    for (size_t i = 0; i < state->pending_count; i++) {
+        if (!state->pending[i].js_cancelled) live++;
+    }
+    return JS_NewUint32(ctx, live);
 }
 
 /* cancel(id) — signal a pending request to abort */

--- a/packages/@mikrojs/firmware/components/mikrojs/mik_uart.cpp
+++ b/packages/@mikrojs/firmware/components/mikrojs/mik_uart.cpp
@@ -260,6 +260,7 @@ struct MIKUartIterState {
      * iterator could outlive its parent Uart, leading to a UAF here. */
     MIKUartState* uart;
     JSValue uart_jsval;
+    bool ended;  // sticky: once true, next() returns {done:true} immediately
 };
 
 static void mik__uart_iter_finalizer(JSRuntime* rt, JSValue val) {
@@ -286,7 +287,24 @@ static JSClassDef mik_uart_iter_class = {
     .gc_mark = mik__uart_iter_gc_mark,
 };
 
-/* Try to read available data and return {done: false, value: Uint8Array} synchronously */
+/* Build {done:false, value: Result<Uint8Array, UartError>} wrapper. Takes
+ * ownership of the inner Result value. */
+static JSValue mik__uart_iter_yield(JSContext* ctx, JSValue inner_result) {
+    JSValue out = JS_NewObject(ctx);
+    JS_DefinePropertyValueStr(ctx, out, "done", JS_FALSE, JS_PROP_C_W_E);
+    JS_DefinePropertyValueStr(ctx, out, "value", inner_result, JS_PROP_C_W_E);
+    return out;
+}
+
+static JSValue mik__uart_iter_done(JSContext* ctx) {
+    JSValue out = JS_NewObject(ctx);
+    JS_DefinePropertyValueStr(ctx, out, "done", JS_TRUE, JS_PROP_C_W_E);
+    JS_DefinePropertyValueStr(ctx, out, "value", JS_UNDEFINED, JS_PROP_C_W_E);
+    return out;
+}
+
+/* Try to read available data and return {done:false, value: ok(Uint8Array)}
+ * synchronously, or JS_UNDEFINED if no data is buffered yet. */
 static JSValue mik__uart_try_read(JSContext* ctx, MIKUartState* s) {
     size_t buffered = 0;
     uart_get_buffered_data_len(s->port, &buffered);
@@ -302,18 +320,27 @@ static JSValue mik__uart_try_read(JSContext* ctx, MIKUartState* s) {
     }
 
     JSValue arr = MIK_NewUint8Array(ctx, buf, read);
-    JSValue result = JS_NewObject(ctx);
-    JS_DefinePropertyValueStr(ctx, result, "done", JS_FALSE, JS_PROP_C_W_E);
-    JS_DefinePropertyValueStr(ctx, result, "value", arr, JS_PROP_C_W_E);
-    return result;
+    return mik__uart_iter_yield(ctx, mik__result_ok(ctx, arr));
 }
 
 static JSValue js_uart_iter_next(JSContext* ctx, JSValue this_val, int argc, JSValue* argv) {
     auto* it = static_cast<MIKUartIterState*>(JS_GetOpaque2(ctx, this_val, mik_uart_iter_class_id));
     if (!it || !it->uart) return JS_ThrowInternalError(ctx, "invalid uart iterator");
+
+    if (it->ended) {
+        JSValue done_result = mik__uart_iter_done(ctx);
+        return MIK_NewResolvedPromise(ctx, 1, &done_result);
+    }
+
     MIKUartState* s = it->uart;
 
-    if (!s->begun) return JS_Throw(ctx, JS_NewString(ctx, "UART not started"));
+    /* If end() has invalidated the underlying port, surface NotStarted as
+     * a single err item and mark the iterator done. */
+    if (!s->begun) {
+        it->ended = true;
+        JSValue err_yield = mik__uart_iter_yield(ctx, mik__result_err_tag(ctx, "NotStarted"));
+        return MIK_NewResolvedPromise(ctx, 1, &err_yield);
+    }
 
     /* Try synchronous read first */
     JSValue sync_result = mik__uart_try_read(ctx, s);
@@ -468,9 +495,7 @@ void mik__uart_consume(JSContext* ctx) {
         }
 
         JSValue arr = MIK_NewUint8Array(ctx, buf, read_bytes);
-        JSValue result = JS_NewObject(ctx);
-        JS_DefinePropertyValueStr(ctx, result, "done", JS_FALSE, JS_PROP_C_W_E);
-        JS_DefinePropertyValueStr(ctx, result, "value", arr, JS_PROP_C_W_E);
+        JSValue result = mik__uart_iter_yield(ctx, mik__result_ok(ctx, arr));
         MIK_ResolvePromise(ctx, &s->read_promise, 1, &result);
         MIK_ClearPromise(ctx, &s->read_promise);
     }

--- a/packages/@mikrojs/native/runtime/fs/fs.ts
+++ b/packages/@mikrojs/native/runtime/fs/fs.ts
@@ -1,4 +1,4 @@
-import {ok} from 'mikrojs/result'
+import {err, ok} from 'mikrojs/result'
 import * as native from 'native:fs'
 
 import type {Result} from '../result/types.js'
@@ -61,28 +61,26 @@ export const exists = native.exists
 export function readStream(
   path: string,
   options?: ReadStreamOptions,
-): Result<AsyncIterable<Uint8Array>, FSError> {
+): Result<AsyncIterable<Result<Uint8Array, FSError>>, FSError> {
   const openResult = native.open(path)
   if (!openResult.ok) return openResult
   const fh = openResult.value
   const chunkSize = options?.chunkSize ?? 512
 
-  async function* iterate(): AsyncIterable<Uint8Array> {
+  async function* iterate(): AsyncIterable<Result<Uint8Array, FSError>> {
     try {
       while (true) {
         const r = fh.read(chunkSize)
         if (!r.ok) {
           // Handle-level errors (BadFileDescriptor, Unknown) don't carry a
-          // path from the native side. All other variants include `path`
-          // when emitted by path-level ops — but fh.read doesn't have the
-          // path, so we decorate here to preserve the original readStream
-          // context.
+          // path from the native side. Path-aware variants are decorated
+          // here so consumers see the original readStream context.
           const e = r.error
-          if (e.name === 'BadFileDescriptor' || e.name === 'Unknown') throw e
-          throw {...e, path}
+          yield e.name === 'BadFileDescriptor' || e.name === 'Unknown' ? err(e) : err({...e, path})
+          return
         }
         if (r.value === undefined) break
-        yield r.value
+        yield ok(r.value)
       }
     } finally {
       fh.close()

--- a/packages/@mikrojs/native/runtime/fs/types.ts
+++ b/packages/@mikrojs/native/runtime/fs/types.ts
@@ -79,8 +79,8 @@ export interface ReadStreamOptions {
 
 /**
  * Open a file as a stream of byte chunks. Returns a Result because the
- * initial open can fail; once iterating, mid-stream read errors propagate
- * via rejected promises from `next()`.
+ * initial open can fail; once iterating, mid-stream read errors arrive
+ * as a final `err(...)` item and end the stream.
  *
  * Compose with `mikrojs/stream` helpers (`decodeUtf8`, `splitLines`) for
  * text/line streams. Closes the underlying handle on EOF, mid-stream
@@ -89,4 +89,4 @@ export interface ReadStreamOptions {
 export declare function readStream(
   path: string,
   options?: ReadStreamOptions,
-): Result<AsyncIterable<Uint8Array>, FSError>
+): Result<AsyncIterable<Result<Uint8Array, FSError>>, FSError>

--- a/packages/@mikrojs/native/runtime/http/__test__/helpers.test.ts
+++ b/packages/@mikrojs/native/runtime/http/__test__/helpers.test.ts
@@ -1,6 +1,8 @@
+import {ok} from 'mikrojs/result'
 import {describe, expect, it} from 'vitest'
 
-import {BodyConsumedError, makeResponse, prepareBody} from '../helpers.js'
+import type {Result} from '../../result/types.js'
+import {BodyConsumedError, makeResponse, prepareBody, type RequestError} from '../helpers.js'
 
 describe('prepareBody', () => {
   it('defaults to null body with empty headers', () => {
@@ -39,10 +41,10 @@ describe('prepareBody', () => {
   })
 })
 
-function bodyFromBytes(bytes: Uint8Array): AsyncIterable<Uint8Array> {
+function bodyFromBytes(bytes: Uint8Array): AsyncIterable<Result<Uint8Array, RequestError>> {
   return {
     async *[Symbol.asyncIterator]() {
-      if (bytes.length > 0) yield bytes
+      if (bytes.length > 0) yield ok(bytes)
     },
   }
 }
@@ -120,7 +122,7 @@ describe('makeResponse', () => {
     expect(r.getAll('x-missing')).toEqual([])
   })
 
-  it('text() decodes body', async () => {
+  it('text() decodes body and returns ok result', async () => {
     const r = makeResponse({
       status: 200,
       statusText: '',
@@ -129,14 +131,16 @@ describe('makeResponse', () => {
       headers: [],
       body: bodyFromBytes(new TextEncoder().encode('hei mikro')),
     })
-    expect(await r.text()).toBe('hei mikro')
+    const text = await r.text()
+    expect(text.ok).toBe(true)
+    if (text.ok) expect(text.value).toBe('hei mikro')
   })
 
   it('bytes() drains multi-chunk body into a single Uint8Array', async () => {
     const chunks = [new Uint8Array([1, 2]), new Uint8Array([3, 4]), new Uint8Array([5])]
-    const body: AsyncIterable<Uint8Array> = {
+    const body: AsyncIterable<Result<Uint8Array, RequestError>> = {
       async *[Symbol.asyncIterator]() {
-        for (const c of chunks) yield c
+        for (const c of chunks) yield ok(c)
       },
     }
     const r = makeResponse({
@@ -148,14 +152,15 @@ describe('makeResponse', () => {
       body,
     })
     const merged = await r.bytes()
-    expect(Array.from(merged)).toEqual([1, 2, 3, 4, 5])
+    expect(merged.ok).toBe(true)
+    if (merged.ok) expect(Array.from(merged.value)).toEqual([1, 2, 3, 4, 5])
   })
 
   it('text() decodes multi-chunk UTF-8 with split codepoints', async () => {
-    const body: AsyncIterable<Uint8Array> = {
+    const body: AsyncIterable<Result<Uint8Array, RequestError>> = {
       async *[Symbol.asyncIterator]() {
-        yield new Uint8Array([0x68, 0xc3])
-        yield new Uint8Array([0xa9, 0x6c, 0x6c, 0x6f])
+        yield ok(new Uint8Array([0x68, 0xc3]))
+        yield ok(new Uint8Array([0xa9, 0x6c, 0x6c, 0x6f]))
       },
     }
     const r = makeResponse({
@@ -166,14 +171,16 @@ describe('makeResponse', () => {
       headers: [],
       body,
     })
-    expect(await r.text()).toBe('héllo')
+    const text = await r.text()
+    expect(text.ok).toBe(true)
+    if (text.ok) expect(text.value).toBe('héllo')
   })
 
   it('body yields every chunk exactly once via iteration', async () => {
-    const body: AsyncIterable<Uint8Array> = {
+    const body: AsyncIterable<Result<Uint8Array, RequestError>> = {
       async *[Symbol.asyncIterator]() {
-        yield new Uint8Array([1])
-        yield new Uint8Array([2, 3])
+        yield ok(new Uint8Array([1]))
+        yield ok(new Uint8Array([2, 3]))
       },
     }
     const r = makeResponse({
@@ -185,8 +192,39 @@ describe('makeResponse', () => {
       body,
     })
     const collected: number[] = []
-    for await (const chunk of r.body) collected.push(...chunk)
+    for await (const chunk of r.body) {
+      expect(chunk.ok).toBe(true)
+      if (chunk.ok) collected.push(...chunk.value)
+    }
     expect(collected).toEqual([1, 2, 3])
+  })
+
+  it('json() returns parsed Result on valid JSON', async () => {
+    const r = makeResponse({
+      status: 200,
+      statusText: '',
+      url: '',
+      redirected: false,
+      headers: [],
+      body: bodyFromBytes(new TextEncoder().encode('{"a":1}')),
+    })
+    const result = await r.json()
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.value).toEqual({a: 1})
+  })
+
+  it('json() returns InvalidJson err on malformed payload', async () => {
+    const r = makeResponse({
+      status: 200,
+      statusText: '',
+      url: '',
+      redirected: false,
+      headers: [],
+      body: bodyFromBytes(new TextEncoder().encode('{not json')),
+    })
+    const result = await r.json()
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.name).toBe('InvalidJson')
   })
 
   it('throws BodyConsumed when text() is called twice', async () => {

--- a/packages/@mikrojs/native/runtime/http/__test__/native.test.ts
+++ b/packages/@mikrojs/native/runtime/http/__test__/native.test.ts
@@ -1,7 +1,7 @@
 import {err, ok} from 'mikrojs/result'
 import {describe, expect, it} from 'vitest'
 
-import type {RequestError} from '../helpers.js'
+import {RequestError} from '../helpers.js'
 import {createRequestFromNative, type NativeHttpModule} from '../native.js'
 
 /* ── Fake native:http builder ──────────────────────────────────────── */
@@ -82,7 +82,7 @@ function createFakeNative(script: FakeScript): NativeHttpModule & {cancelCalls: 
       const hr = headersCancelResolvers.get(id)
       if (hr) {
         headersCancelResolvers.delete(id)
-        hr(err({name: 'Aborted' as const, message: 'cancelled'}) as HeadersResult)
+        hr(err(RequestError.Aborted('cancelled')) as HeadersResult)
       }
       void Promise.resolve().then(() =>
         deliver(id, {kind: 'error', cancelled: true, message: 'cancelled'}),
@@ -105,7 +105,9 @@ describe('createRequestFromNative', () => {
     expect(result.ok).toBe(true)
     if (result.ok) {
       expect(result.value.status).toBe(200)
-      expect(await result.value.text()).toBe('hello')
+      const text = await result.value.text()
+      expect(text.ok).toBe(true)
+      if (text.ok) expect(text.value).toBe('hello')
     }
   })
 
@@ -124,7 +126,10 @@ describe('createRequestFromNative', () => {
     expect(result.ok).toBe(true)
     if (result.ok) {
       const collected: number[] = []
-      for await (const chunk of result.value.body) collected.push(...chunk)
+      for await (const chunk of result.value.body) {
+        expect(chunk.ok).toBe(true)
+        if (chunk.ok) collected.push(...chunk.value)
+      }
       expect(collected).toEqual([1, 2, 3, 4, 5])
     }
   })
@@ -143,14 +148,15 @@ describe('createRequestFromNative', () => {
     expect(result.ok).toBe(true)
     if (result.ok) {
       for await (const chunk of result.value.body) {
-        expect(chunk[0]).toBe(1)
+        expect(chunk.ok).toBe(true)
+        if (chunk.ok) expect(chunk.value[0]).toBe(1)
         break
       }
       expect(native.cancelCalls.length).toBe(1)
     }
   })
 
-  it('surfaces network errors mid-stream as iterator rejection with message', async () => {
+  it('yields a Network err item mid-stream when transport reports error', async () => {
     const native = createFakeNative({
       messages: [
         {kind: 'chunk', data: new Uint8Array([1, 2])},
@@ -163,17 +169,20 @@ describe('createRequestFromNative', () => {
     expect(result.ok).toBe(true)
     if (result.ok) {
       const pulled: number[] = []
-      await expect(async () => {
-        for await (const chunk of result.value.body) pulled.push(...chunk)
-      }).rejects.toMatchObject({name: 'Network', message: 'connection reset by peer'})
+      let finalErr: RequestError | undefined
+      for await (const chunk of result.value.body) {
+        if (chunk.ok) pulled.push(...chunk.value)
+        else finalErr = chunk.error
+      }
       expect(pulled).toEqual([1, 2])
+      expect(finalErr).toMatchObject({name: 'Network', message: 'connection reset by peer'})
     }
   })
 
   it('returns TooManyPending when native layer rejects at start', async () => {
     const native = createFakeNative({
       messages: [],
-      startError: {name: 'TooManyPending'},
+      startError: RequestError.TooManyPending(),
     })
     const request = createRequestFromNative(native)
 
@@ -185,7 +194,7 @@ describe('createRequestFromNative', () => {
   it('surfaces ERROR-before-HEADERS as a Network failure at the request() level', async () => {
     const native = createFakeNative({
       messages: [],
-      headersError: {name: 'Network', message: 'DNS resolution failed'},
+      headersError: RequestError.Network('DNS resolution failed'),
     })
     const request = createRequestFromNative(native)
 
@@ -202,7 +211,7 @@ describe('createRequestFromNative', () => {
   it('maps pre-headers cancelled error to Aborted', async () => {
     const native = createFakeNative({
       messages: [],
-      headersError: {name: 'Aborted', message: 'cancelled'},
+      headersError: RequestError.Aborted('cancelled'),
     })
     const request = createRequestFromNative(native)
 
@@ -252,19 +261,19 @@ describe('createRequestFromNative', () => {
     expect(result.ok).toBe(true)
     if (result.ok) {
       const pulled: number[] = []
+      let finalErr: RequestError | undefined
       const promise = (async () => {
-        try {
-          for await (const c of result.value.body) pulled.push(...c)
-        } catch (e) {
-          return e
+        for await (const c of result.value.body) {
+          if (c.ok) pulled.push(...c.value)
+          else finalErr = c.error
         }
       })()
       await Promise.resolve()
       await Promise.resolve()
       controller.abort()
-      const thrown = await promise
+      await promise
       expect(native.cancelCalls.length).toBeGreaterThan(0)
-      expect(thrown).toMatchObject({name: 'Aborted'})
+      expect(finalErr).toMatchObject({name: 'Aborted'})
     }
   })
 
@@ -275,11 +284,11 @@ describe('createRequestFromNative', () => {
     const result = await request('https://example.test/', {timeoutMs: 10})
     expect(result.ok).toBe(true)
     if (result.ok) {
-      await expect(async () => {
-        for await (const _ of result.value.body) {
-          /* drain */
-        }
-      }).rejects.toMatchObject({name: 'Aborted'})
+      let finalErr: RequestError | undefined
+      for await (const c of result.value.body) {
+        if (!c.ok) finalErr = c.error
+      }
+      expect(finalErr).toMatchObject({name: 'Aborted'})
       expect(native.cancelCalls.length).toBe(1)
     }
   })

--- a/packages/@mikrojs/native/runtime/http/helpers.ts
+++ b/packages/@mikrojs/native/runtime/http/helpers.ts
@@ -3,7 +3,9 @@
 // LTE modem over UART) implement the `Request` type directly and reuse
 // `prepareBody` + `makeResponse` for the boring parts.
 
-import type {Result} from 'mikrojs/result'
+import {err, ok} from 'mikrojs/result'
+
+import type {Result} from '../result/types.js'
 
 export interface RequestOptions {
   method?: string
@@ -25,21 +27,24 @@ export interface Response {
   headers: [string, string][]
   ok: boolean
   /**
-   * Response body as an async iterable of chunks. Single-shot: after any of
-   * `body`, `text()`, `bytes()`, or `json()` has started draining, calling
-   * another consumer throws `BodyConsumedError`.
+   * Response body as an async iterable of byte chunks. Iteration yields
+   * `Result<Uint8Array, RequestError>` so mid-stream failures (network
+   * drop, abort, timeout) compose with the rest of the Result-based API.
+   * Single-shot: after any of `body`, `text()`, `bytes()`, or `json()`
+   * has started draining, the next consumer call throws
+   * `BodyConsumedError`.
    */
-  body: AsyncIterable<Uint8Array>
+  body: AsyncIterable<Result<Uint8Array, RequestError>>
   /** First matching header value, case-insensitive, or undefined if absent. */
   get(name: string): string | undefined
   /** All matching header values in order, case-insensitive. Empty array if absent. */
   getAll(name: string): string[]
   /** Drain body as a UTF-8 string. Throws `BodyConsumedError` on second consumer call. */
-  text(): Promise<string>
+  text(): Promise<Result<string, RequestError>>
   /** Drain body and parse as JSON. Throws `BodyConsumedError` on second consumer call. */
-  json(): Promise<unknown>
+  json(): Promise<Result<unknown, RequestError>>
   /** Drain body to a single `Uint8Array`. Throws `BodyConsumedError` on second consumer call. */
-  bytes(): Promise<Uint8Array>
+  bytes(): Promise<Result<Uint8Array, RequestError>>
   /**
    * Cancel the request and release any native resources. Safe to call after
    * the body has been consumed (no-op). Safe to call multiple times.
@@ -63,16 +68,11 @@ export const RequestError = {
   Aborted: (message: string) => ({name: 'Aborted', message}) as const,
   /** Transport is at its concurrent-request cap. Retry after in-flight requests settle. */
   TooManyPending: () => ({name: 'TooManyPending'}) as const,
+  /** Body drained but JSON.parse rejected the payload. */
+  InvalidJson: (message: string) => ({name: 'InvalidJson', message}) as const,
 }
 
-export type RequestError =
-  | ReturnType<typeof RequestError.Hardware>
-  | ReturnType<typeof RequestError.Network>
-  | ReturnType<typeof RequestError.Timeout>
-  | ReturnType<typeof RequestError.BodyTooLarge>
-  | ReturnType<typeof RequestError.InvalidResponse>
-  | ReturnType<typeof RequestError.Aborted>
-  | ReturnType<typeof RequestError.TooManyPending>
+export type RequestError = ReturnType<(typeof RequestError)[keyof typeof RequestError]>
 
 export class BodyConsumedError extends Error {
   readonly name = 'BodyConsumed'
@@ -99,9 +99,9 @@ export function prepareBody(opts: RequestOptions): {
 }
 
 /**
- * Wrap a transport's raw response (async-iterable body) into the public
- * `Response` shape with `text()`/`json()`/`bytes()`/`get()`/`getAll()`/`close()`
- * and a single-shot body claim.
+ * Wrap a transport's raw response (Result-yielding async-iterable body) into
+ * the public `Response` shape with `text()`/`json()`/`bytes()`/`get()`/
+ * `getAll()`/`close()` and a single-shot body claim.
  */
 export function makeResponse(raw: {
   status: number
@@ -109,7 +109,7 @@ export function makeResponse(raw: {
   url: string
   redirected: boolean
   headers: [string, string][]
-  body: AsyncIterable<Uint8Array>
+  body: AsyncIterable<Result<Uint8Array, RequestError>>
 }): Response {
   let consumed = false
   const claim = () => {
@@ -117,7 +117,7 @@ export function makeResponse(raw: {
     consumed = true
   }
 
-  const body: AsyncIterable<Uint8Array> = {
+  const body: AsyncIterable<Result<Uint8Array, RequestError>> = {
     [Symbol.asyncIterator]() {
       claim()
       return raw.body[Symbol.asyncIterator]()
@@ -153,7 +153,13 @@ export function makeResponse(raw: {
     },
     json: async () => {
       claim()
-      return JSON.parse(await drainAsText(raw.body))
+      const text = await drainAsText(raw.body)
+      if (!text.ok) return text
+      try {
+        return ok(JSON.parse(text.value))
+      } catch (e) {
+        return err(RequestError.InvalidJson(e instanceof Error ? e.message : String(e)))
+      }
     },
     bytes: async () => {
       claim()
@@ -177,29 +183,35 @@ function normalizeHeaders(
   return out
 }
 
-async function drain(source: AsyncIterable<Uint8Array>): Promise<Uint8Array> {
+async function drain(
+  source: AsyncIterable<Result<Uint8Array, RequestError>>,
+): Promise<Result<Uint8Array, RequestError>> {
   const parts: Uint8Array[] = []
   let total = 0
-  for await (const chunk of source) {
-    parts.push(chunk)
-    total += chunk.length
+  for await (const r of source) {
+    if (!r.ok) return r
+    parts.push(r.value)
+    total += r.value.length
   }
-  if (parts.length === 1) return parts[0]!
+  if (parts.length === 1) return ok(parts[0]!)
   const out = new Uint8Array(total)
   let offset = 0
   for (const p of parts) {
     out.set(p, offset)
     offset += p.length
   }
-  return out
+  return ok(out)
 }
 
-async function drainAsText(source: AsyncIterable<Uint8Array>): Promise<string> {
+async function drainAsText(
+  source: AsyncIterable<Result<Uint8Array, RequestError>>,
+): Promise<Result<string, RequestError>> {
   const decoder = new TextDecoder()
   let out = ''
-  for await (const chunk of source) {
-    out += decoder.decode(chunk, {stream: true})
+  for await (const r of source) {
+    if (!r.ok) return r
+    out += decoder.decode(r.value, {stream: true})
   }
   out += decoder.decode()
-  return out
+  return ok(out)
 }

--- a/packages/@mikrojs/native/runtime/http/native.ts
+++ b/packages/@mikrojs/native/runtime/http/native.ts
@@ -92,10 +92,10 @@ export function createRequestFromNative(native: NativeHttpModule): Request {
     const {status, headers: responseHeaders} = headersResult.value
 
     let done = false
-    const rawBody: AsyncIterable<Uint8Array> = {
+    const rawBody: AsyncIterable<Result<Uint8Array, RequestError>> = {
       [Symbol.asyncIterator]() {
         return {
-          async next() {
+          async next(): Promise<IteratorResult<Result<Uint8Array, RequestError>>> {
             if (done) return {done: true, value: undefined}
             let msg
             try {
@@ -103,19 +103,28 @@ export function createRequestFromNative(native: NativeHttpModule): Request {
             } catch (e) {
               done = true
               cleanup()
-              throw e
+              const message = e instanceof Error ? e.message : String(e)
+              return {done: false, value: err(RequestError.Network(message))}
             }
             if (msg.kind === 'chunk') {
-              return {done: false, value: msg.data}
+              return {done: false, value: ok(msg.data)}
             }
             done = true
             cleanup()
             if (msg.kind === 'end') return {done: true, value: undefined}
             /* error */
             if (msg.cancelled) {
-              throw RequestError.Aborted(msg.message || String(options.signal?.reason ?? 'aborted'))
+              return {
+                done: false,
+                value: err(
+                  RequestError.Aborted(msg.message || String(options.signal?.reason ?? 'aborted')),
+                ),
+              }
             }
-            throw RequestError.Network(msg.message || 'HTTP request failed')
+            return {
+              done: false,
+              value: err(RequestError.Network(msg.message || 'HTTP request failed')),
+            }
           },
           async return() {
             if (!done) {

--- a/packages/@mikrojs/native/runtime/internal.d.ts
+++ b/packages/@mikrojs/native/runtime/internal.d.ts
@@ -318,8 +318,8 @@ declare module 'native:uart' {
 
     read(): Result<
       {
-        next(): Promise<IteratorResult<Uint8Array>>
-        return(): Promise<IteratorResult<Uint8Array>>
+        next(): Promise<IteratorResult<Result<Uint8Array, UartError>>>
+        return(): Promise<IteratorResult<Result<Uint8Array, UartError>>>
       },
       UartError
     >

--- a/packages/@mikrojs/native/runtime/kv/shared.ts
+++ b/packages/@mikrojs/native/runtime/kv/shared.ts
@@ -1,4 +1,4 @@
-import {defineError, err, ok} from 'mikrojs/result'
+import {err, ok} from 'mikrojs/result'
 // Typed loosely to avoid deep type instantiation from Infer<S> in parse's generics.
 // Type safety is provided by the storage interface overloads in types.ts.
 import {parse as _parse} from 'mikrojs/schema'
@@ -8,12 +8,14 @@ import type {NativeError} from '../result/types.js'
 type ParseResult = {ok: true; value: unknown} | {ok: false; error: {message: string; path: string}}
 const parse = _parse as unknown as (schema: unknown, value: unknown) => ParseResult
 
-export const KVError = defineError('KVError', {
-  StorageFull: (message: string) => ({message}),
-  EncodeFailed: (message: string) => ({message}),
-  WriteFailed: (message: string) => ({message}),
-  ValidationFailed: (message: string, path: string) => ({message, path}),
-})
+export const KVError = {
+  StorageFull: (message: string) => ({name: 'StorageFull', message}) as const,
+  EncodeFailed: (message: string) => ({name: 'EncodeFailed', message}) as const,
+  WriteFailed: (message: string) => ({name: 'WriteFailed', message}) as const,
+  ValidationFailed: (message: string, path: string) =>
+    ({name: 'ValidationFailed', message, path}) as const,
+  Unknown: (code: number, message: string) => ({name: 'Unknown', code, message}) as const,
+}
 
 /* Error codes from errors.h (MIK_ERR_BASE + 0xD0..0xD4) */
 const KV_INVALID_KEY = 0x80d0
@@ -43,7 +45,7 @@ function mapKvError(e: NativeError) {
     case KV_WRITE:
       return KVError.WriteFailed(e.message)
     default:
-      throw new Error(`unexpected native kv error: code=0x${e.code.toString(16)}`)
+      return KVError.Unknown(e.code, e.message)
   }
 }
 

--- a/packages/@mikrojs/native/runtime/kv/types.ts
+++ b/packages/@mikrojs/native/runtime/kv/types.ts
@@ -55,6 +55,7 @@ export type KVError =
   | {name: 'EncodeFailed'; message: string}
   | {name: 'WriteFailed'; message: string}
   | {name: 'ValidationFailed'; message: string; path: string}
+  | {name: 'Unknown'; code: number; message: string}
 
 export type KVOptions<S> =
   | {

--- a/packages/@mikrojs/native/runtime/reader/reader.ts
+++ b/packages/@mikrojs/native/runtime/reader/reader.ts
@@ -9,12 +9,19 @@
  * lazy-load efficiency.
  */
 
+import {err, ok} from 'mikrojs/result'
+
+import type {Result} from '../result/types.js'
+
+export type ReaderError = {name: 'Timeout'; ms: number} | {name: 'StreamClosed'}
+
 /**
- * A buffered byte reader over an async iterator of byte chunks.
+ * A buffered byte reader over a Result-yielding async iterator of
+ * byte chunks.
  *
- * Wraps any `AsyncIterable<Uint8Array>` (typically `uart.read()`,
- * eventually also TCP sockets) and exposes three primitives that
- * share the same underlying byte buffer:
+ * Wraps any `AsyncIterable<Result<Uint8Array, E>>` (typically
+ * `uart.read()`, `fs.readStream`, an HTTP body) and exposes three
+ * primitives that share the same underlying byte buffer:
  *
  *   - `readUntil(delimiter, {timeoutMs})` — pull chunks until the
  *     buffer contains `delimiter`, return everything before it and
@@ -30,12 +37,12 @@
  *     underlying iterator. Useful before sending a new command when
  *     stale bytes from a previous response might be left over.
  *
- * Both `readUntil` and `readBytes` throw `TimeoutError` (an Error
- * with `name === 'TimeoutError'`) if the deadline expires before
- * the request is satisfied, and `StreamClosed` (an Error with
- * `name === 'StreamClosed'`) if the underlying iterator finishes
- * before the request is satisfied. Callers may wrap those in their
- * own Result type if they prefer structured error handling.
+ * Both `readUntil` and `readBytes` return `Result<Uint8Array, E |
+ * ReaderError>`: `err({name: 'Timeout', ms})` if the deadline expires
+ * before the request is satisfied, `err({name: 'StreamClosed'})` if
+ * the underlying iterator finishes early, or whatever error variant
+ * the source yields. `RangeError` is still thrown for invalid
+ * arguments (programmer mistakes, not stream errors).
  *
  * Timeout semantics: when a pull races against a `setTimeout` and
  * the timer wins, the pending `iter.next()` promise is kept so the
@@ -48,18 +55,21 @@
  * not protected against — the caller is responsible for
  * sequential ordering.
  */
-export class BufferedReader {
-  readonly #source: AsyncIterator<Uint8Array>
+export class BufferedReader<E = never> {
+  readonly #source: AsyncIterator<Result<Uint8Array, E>>
   #buffer: Uint8Array
-  #pending: Promise<IteratorResult<Uint8Array>> | null
+  #pending: Promise<IteratorResult<Result<Uint8Array, E>>> | null
 
-  constructor(source: AsyncIterable<Uint8Array>) {
-    this.#source = source[Symbol.asyncIterator]() as AsyncIterator<Uint8Array>
+  constructor(source: AsyncIterable<Result<Uint8Array, E>>) {
+    this.#source = source[Symbol.asyncIterator]() as AsyncIterator<Result<Uint8Array, E>>
     this.#buffer = new Uint8Array(0)
     this.#pending = null
   }
 
-  async readUntil(delimiter: Uint8Array, options: {timeoutMs: number}): Promise<Uint8Array> {
+  async readUntil(
+    delimiter: Uint8Array,
+    options: {timeoutMs: number},
+  ): Promise<Result<Uint8Array, E | ReaderError>> {
     if (delimiter.length === 0) {
       throw new RangeError('BufferedReader.readUntil: delimiter must be non-empty')
     }
@@ -69,24 +79,29 @@ export class BufferedReader {
       if (idx !== -1) {
         const out = this.#buffer.slice(0, idx)
         this.#buffer = this.#buffer.slice(idx + delimiter.length)
-        return out
+        return ok(out)
       }
-      await this.#pull(deadline)
+      const pull = await this.#pull(deadline, options.timeoutMs)
+      if (!pull.ok) return pull
     }
   }
 
-  async readBytes(count: number, options: {timeoutMs: number}): Promise<Uint8Array> {
+  async readBytes(
+    count: number,
+    options: {timeoutMs: number},
+  ): Promise<Result<Uint8Array, E | ReaderError>> {
     if (count < 0) {
       throw new RangeError('BufferedReader.readBytes: count must be non-negative')
     }
-    if (count === 0) return new Uint8Array(0)
+    if (count === 0) return ok(new Uint8Array(0))
     const deadline = Date.now() + options.timeoutMs
     while (this.#buffer.length < count) {
-      await this.#pull(deadline)
+      const pull = await this.#pull(deadline, options.timeoutMs)
+      if (!pull.ok) return pull
     }
     const out = this.#buffer.slice(0, count)
     this.#buffer = this.#buffer.slice(count)
-    return out
+    return ok(out)
   }
 
   /**
@@ -100,13 +115,9 @@ export class BufferedReader {
     this.#buffer = new Uint8Array(0)
   }
 
-  async #pull(deadline: number): Promise<void> {
+  async #pull(deadline: number, timeoutMs: number): Promise<Result<void, E | ReaderError>> {
     const remaining = deadline - Date.now()
-    if (remaining <= 0) {
-      const err = new Error(`BufferedReader: timeout waiting for bytes`)
-      err.name = 'TimeoutError'
-      throw err
-    }
+    if (remaining <= 0) return err({name: 'Timeout' as const, ms: timeoutMs})
 
     if (this.#pending === null) {
       this.#pending = this.#source.next()
@@ -116,24 +127,24 @@ export class BufferedReader {
     let timerId: ReturnType<typeof setTimeout> | undefined
     try {
       const result = await Promise.race([
-        pending.then((v): {kind: 'value'; v: IteratorResult<Uint8Array>} => ({kind: 'value', v})),
+        pending.then((v): {kind: 'value'; v: IteratorResult<Result<Uint8Array, E>>} => ({
+          kind: 'value',
+          v,
+        })),
         new Promise<{kind: 'timeout'}>((resolve) => {
           timerId = setTimeout(() => resolve({kind: 'timeout'}), remaining)
         }),
       ])
       if (result.kind === 'timeout') {
         // Leave #pending intact so the next pull resumes on this chunk.
-        const err = new Error(`BufferedReader: timeout after ${remaining}ms waiting for bytes`)
-        err.name = 'TimeoutError'
-        throw err
+        return err({name: 'Timeout' as const, ms: timeoutMs})
       }
       this.#pending = null
-      if (result.v.done) {
-        const err = new Error('BufferedReader: stream closed before read satisfied')
-        err.name = 'StreamClosed'
-        throw err
-      }
-      this.#buffer = concatBytes(this.#buffer, result.v.value)
+      if (result.v.done) return err({name: 'StreamClosed' as const})
+      const item = result.v.value
+      if (!item.ok) return item
+      this.#buffer = concatBytes(this.#buffer, item.value)
+      return ok()
     } finally {
       if (timerId !== undefined) clearTimeout(timerId)
     }

--- a/packages/@mikrojs/native/runtime/reader/types.ts
+++ b/packages/@mikrojs/native/runtime/reader/types.ts
@@ -7,10 +7,14 @@
  * `packages/mikrojs` and by user apps via their tsconfig.
  */
 
+import type {Result} from 'mikrojs/result'
+
+export type ReaderError = {name: 'Timeout'; ms: number} | {name: 'StreamClosed'}
+
 /**
- * A buffered byte reader over an async iterator of `Uint8Array`
- * chunks. Offers three operations that share the same underlying
- * buffer:
+ * A buffered byte reader over a Result-yielding async iterator of
+ * `Uint8Array` chunks. Offers three operations that share the same
+ * underlying buffer:
  *
  *   - `readUntil(delimiter, {timeoutMs})` — return everything before
  *     the first occurrence of `delimiter`, consume the delimiter.
@@ -19,16 +23,23 @@
  *   - `drain()` — discard buffered bytes without affecting the
  *     underlying iterator.
  *
- * Throws an Error with `name === 'TimeoutError'` if the deadline
- * expires before the request is satisfied, or `name === 'StreamClosed'`
- * if the underlying iterator finishes before the request is satisfied.
+ * Returns `err({name: 'Timeout', ms})` if the deadline expires,
+ * `err({name: 'StreamClosed'})` if the underlying iterator finishes
+ * early, or the source's own error variant when it yields one.
+ * `RangeError` is still thrown for invalid arguments.
  *
  * Single-consumer only: concurrent `readUntil` / `readBytes` calls on
  * the same instance are unsupported.
  */
-export declare class BufferedReader {
-  constructor(source: AsyncIterable<Uint8Array>)
-  readUntil(delimiter: Uint8Array, options: {timeoutMs: number}): Promise<Uint8Array>
-  readBytes(count: number, options: {timeoutMs: number}): Promise<Uint8Array>
+export declare class BufferedReader<E = never> {
+  constructor(source: AsyncIterable<Result<Uint8Array, E>>)
+  readUntil(
+    delimiter: Uint8Array,
+    options: {timeoutMs: number},
+  ): Promise<Result<Uint8Array, E | ReaderError>>
+  readBytes(
+    count: number,
+    options: {timeoutMs: number},
+  ): Promise<Result<Uint8Array, E | ReaderError>>
   drain(): void
 }

--- a/packages/@mikrojs/native/runtime/result/result.ts
+++ b/packages/@mikrojs/native/runtime/result/result.ts
@@ -7,20 +7,9 @@ export class PanicError extends Error {
   }
 }
 
-export function defineError<D extends Record<string, (...args: any[]) => Record<string, unknown>>>(
-  _name: string,
-  variants: D,
-): {[K in keyof D & string]: (...args: Parameters<D[K]>) => {name: K} & ReturnType<D[K]>} {
-  const constructors: Record<string, (...args: unknown[]) => Record<string, unknown>> = {}
-  for (const key in variants) {
-    const factory = variants[key]!
-    constructors[key] = (...args: unknown[]) => {
-      const fields = (factory as (...a: unknown[]) => Record<string, unknown>)(...args)
-      fields.name = key
-      return fields
-    }
-  }
-  return constructors as unknown as {
-    [K in keyof D & string]: (...args: Parameters<D[K]>) => {name: K} & ReturnType<D[K]>
-  }
+export function matchError<E extends {name: string}, R>(
+  error: E,
+  handlers: {[K in E['name']]: (error: Extract<E, {name: K}>) => R},
+): R {
+  return (handlers as unknown as Record<string, (e: E) => R>)[error.name]!(error)
 }

--- a/packages/@mikrojs/native/runtime/result/types.ts
+++ b/packages/@mikrojs/native/runtime/result/types.ts
@@ -37,20 +37,10 @@ export declare function ok<T>(value: T): OkResult<T>
 
 export declare function err<E>(error: E): ErrResult<E>
 
-type VariantDef = Record<string, (...args: any[]) => Record<string, unknown>>
-
-type ErrorConstructors<D extends VariantDef> = {
-  [K in keyof D & string]: (...args: Parameters<D[K]>) => {name: K} & ReturnType<D[K]>
-}
-
-export type ErrorOf<T extends Record<string, (...args: any[]) => any>> = {
-  [K in keyof T & string]: ReturnType<T[K]>
-}[keyof T & string]
-
-export declare function defineError<D extends VariantDef>(
-  name: string,
-  variants: D,
-): ErrorConstructors<D>
+export declare function matchError<E extends {name: string}, R>(
+  error: E,
+  handlers: {[K in E['name']]: (error: Extract<E, {name: K}>) => R},
+): R
 
 /** Raw error shape returned by native mik__result_err(). */
 export interface NativeError {

--- a/packages/@mikrojs/native/runtime/schema/schema.ts
+++ b/packages/@mikrojs/native/runtime/schema/schema.ts
@@ -1,10 +1,11 @@
-import {defineError, err, ok} from 'mikrojs/result'
+import {err, ok} from 'mikrojs/result'
 
 import type {Result} from '../result/types.js'
 
-export const SchemaError = defineError('SchemaError', {
-  ValidationFailed: (message: string, path: string) => ({message, path}),
-})
+export const SchemaError = {
+  ValidationFailed: (message: string, path: string) =>
+    ({name: 'ValidationFailed', message, path}) as const,
+}
 export type SchemaError = ReturnType<typeof SchemaError.ValidationFailed>
 
 // ── Schema types ────────────────────────────────────────────────────

--- a/packages/@mikrojs/native/runtime/stream/stream.ts
+++ b/packages/@mikrojs/native/runtime/stream/stream.ts
@@ -1,24 +1,37 @@
 /**
  * Minimal composable stream primitives for mikrojs.
  *
- * Streams are plain `AsyncIterable<T>` — no class hierarchy, no
- * lockable readers, no BYOB, no queueing strategies. Transforms are
- * async generator functions. Composition is function call.
+ * Streams are `AsyncIterable<Result<T, E>>` — Result-yielding rather
+ * than throwing — so error handling composes uniformly with the rest
+ * of the runtime's Result-based APIs. Combinators short-circuit on the
+ * first err item: they yield the err and return.
  *
- * This is deliberately a subset of what Snell's "new-streams" proposal
- * covers, adapted for the realities of QuickJS on a microcontroller:
- * no fast-path promise optimizations, no sendfile-style native
- * shortcuts, tight heap budget.
+ * Combinators that originate their own errors (`withTimeout`,
+ * `collectUntil`) widen the result's error type with a `StreamError`
+ * variant defined in `./types.ts`.
  *
  * V1 scope: enough to rewrite a modem AT channel as a one-file shim.
  * Expand only when a second call site asks for it.
  */
 
+import {err, ok} from 'mikrojs/result'
+
+import type {Result} from '../result/types.js'
+
 /** Decode a stream of UTF-8 byte chunks into a stream of strings. */
-export async function* decodeUtf8(source: AsyncIterable<Uint8Array>): AsyncIterable<string> {
+export async function* decodeUtf8<E>(
+  source: AsyncIterable<Result<Uint8Array, E>>,
+): AsyncIterable<Result<string, E>> {
   const decoder = new TextDecoder()
-  for await (const chunk of source) yield decoder.decode(chunk, {stream: true})
-  yield decoder.decode()
+  for await (const r of source) {
+    if (!r.ok) {
+      yield r
+      return
+    }
+    yield ok(decoder.decode(r.value, {stream: true}))
+  }
+  const final = decoder.decode()
+  if (final.length > 0) yield ok(final)
 }
 
 /**
@@ -36,10 +49,10 @@ export async function* decodeUtf8(source: AsyncIterable<Uint8Array>): AsyncItera
  * for protocols that use a blank line as a separator, e.g. HTTP
  * headers vs. body.
  */
-export async function* splitLines(
-  source: AsyncIterable<string>,
+export async function* splitLines<E>(
+  source: AsyncIterable<Result<string, E>>,
   delimiter: string = '\n',
-): AsyncIterable<string> {
+): AsyncIterable<Result<string, E>> {
   // indexOf('') returns 0 unconditionally, which would make the inner
   // loop spin forever yielding empty strings. Reject at entry instead
   // of hanging the event loop on a user mistake.
@@ -47,16 +60,20 @@ export async function* splitLines(
     throw new RangeError('splitLines: delimiter must be non-empty')
   }
   let buffer = ''
-  for await (const chunk of source) {
-    buffer += chunk
+  for await (const r of source) {
+    if (!r.ok) {
+      yield r
+      return
+    }
+    buffer += r.value
     let idx = buffer.indexOf(delimiter)
     while (idx !== -1) {
-      yield buffer.slice(0, idx)
+      yield ok(buffer.slice(0, idx))
       buffer = buffer.slice(idx + delimiter.length)
       idx = buffer.indexOf(delimiter)
     }
   }
-  if (buffer.length > 0) yield buffer
+  if (buffer.length > 0) yield ok(buffer)
 }
 
 /**
@@ -68,34 +85,30 @@ export async function* splitLines(
  * like modem AT commands where the terminator (`OK`/`ERROR`) is
  * semantically different from the response body lines in between.
  *
- * If the stream closes before any item matches, throws `StreamClosed`
- * (a plain Error with a `.name`). Callers should wrap this in their
- * own Result type if they want structured error handling.
+ * If the stream closes before any item matches, returns
+ * `err({name: 'StreamClosed'})`. Source errors propagate unchanged.
  */
-export async function collectUntil<T>(
-  source: AsyncIterable<T>,
+export async function collectUntil<T, E>(
+  source: AsyncIterable<Result<T, E>>,
   predicate: (item: T) => boolean,
-): Promise<{matched: T; collected: T[]}> {
+): Promise<Result<{matched: T; collected: T[]}, E | {name: 'StreamClosed'}>> {
   const collected: T[] = []
-  for await (const item of source) {
-    if (predicate(item)) {
-      return {matched: item, collected}
-    }
-    collected.push(item)
+  for await (const r of source) {
+    if (!r.ok) return r
+    if (predicate(r.value)) return ok({matched: r.value, collected})
+    collected.push(r.value)
   }
-  const err = new Error('Stream closed before predicate matched')
-  err.name = 'StreamClosed'
-  throw err
+  return err({name: 'StreamClosed' as const})
 }
 
 /**
  * Wrap an async iterable with a total-duration timeout.
  *
  * The deadline starts when this function is called (not per-item).
- * If the next item doesn't arrive before the deadline, the returned
- * iterable throws a `TimeoutError`, and cleans up the upstream source
- * by calling its `return()` method. Callers using `for await` will see
- * the error propagate out of the loop.
+ * If the next item doesn't arrive before the deadline, yields
+ * `err({name: 'Timeout', ms})` and ends, cleaning up the upstream
+ * source by calling its `return()` method. Source errors propagate
+ * unchanged.
  *
  * Implementation notes:
  * - Promise.race with setTimeout would leak orphaned timers on the
@@ -106,28 +119,30 @@ export async function collectUntil<T>(
  *   timeout, or consumer break) so underlying resources (UART claims,
  *   socket handles, ring buffers) get released.
  */
-export async function* withTimeout<T>(source: AsyncIterable<T>, ms: number): AsyncIterable<T> {
+export async function* withTimeout<T, E>(
+  source: AsyncIterable<Result<T, E>>,
+  ms: number,
+): AsyncIterable<Result<T, E | {name: 'Timeout'; ms: number}>> {
   const deadline = Date.now() + ms
   const iter = source[Symbol.asyncIterator]()
   try {
     while (true) {
       const remaining = deadline - Date.now()
       if (remaining <= 0) {
-        const err = new Error(`Stream did not complete within ${ms}ms`)
-        err.name = 'TimeoutError'
-        throw err
+        yield err({name: 'Timeout' as const, ms})
+        return
       }
 
       let timerId: ReturnType<typeof setTimeout> | undefined
-      let result: IteratorResult<T, unknown>
+      let result: IteratorResult<Result<T, E>, unknown>
+      let timedOut = false
       try {
         result = await Promise.race([
           iter.next(),
-          new Promise<IteratorResult<T, unknown>>((_, reject) => {
+          new Promise<IteratorResult<Result<T, E>, unknown>>((resolve) => {
             timerId = setTimeout(() => {
-              const err = new Error(`Stream did not complete within ${ms}ms`)
-              err.name = 'TimeoutError'
-              reject(err)
+              timedOut = true
+              resolve({done: true, value: undefined})
             }, remaining)
           }),
         ])
@@ -135,8 +150,13 @@ export async function* withTimeout<T>(source: AsyncIterable<T>, ms: number): Asy
         if (timerId !== undefined) clearTimeout(timerId)
       }
 
+      if (timedOut) {
+        yield err({name: 'Timeout' as const, ms})
+        return
+      }
       if (result.done) return
-      yield result.value as T
+      yield result.value
+      if (!result.value.ok) return
     }
   } finally {
     if (typeof iter.return === 'function') {

--- a/packages/@mikrojs/native/runtime/stream/types.ts
+++ b/packages/@mikrojs/native/runtime/stream/types.ts
@@ -5,42 +5,56 @@
  * bytecode at firmware build time. This file is the declaration-only
  * surface consumed by the `mikrojs/stream` re-export in
  * `packages/mikrojs` and by user apps via their tsconfig.
+ *
+ * Streaming sources yield `Result<T, E>` rather than throwing — see
+ * the design note in `stream.ts`. Combinators that originate their own
+ * errors widen the error type with a `StreamError` variant.
  */
 
+import type {Result} from 'mikrojs/result'
+
+export type StreamError = {name: 'Timeout'; ms: number} | {name: 'StreamClosed'}
+
 /** Decode a stream of UTF-8 byte chunks into a stream of strings. */
-export declare function decodeUtf8(source: AsyncIterable<Uint8Array>): AsyncIterable<string>
+export declare function decodeUtf8<E>(
+  source: AsyncIterable<Result<Uint8Array, E>>,
+): AsyncIterable<Result<string, E>>
 
 /**
  * Split a stream of text into a stream of lines on the given delimiter
  * (default `\n`). Partial lines spanning chunk boundaries are buffered
  * and reassembled. Empty lines between consecutive delimiters are
- * preserved. Throws `RangeError` if called with an empty delimiter.
+ * preserved. Throws `RangeError` if called with an empty delimiter
+ * (programmer error, not a stream error).
  */
-export declare function splitLines(
-  source: AsyncIterable<string>,
+export declare function splitLines<E>(
+  source: AsyncIterable<Result<string, E>>,
   delimiter?: string,
-): AsyncIterable<string>
+): AsyncIterable<Result<string, E>>
 
 /**
  * Consume a stream until an item matches `predicate`, then stop.
  *
- * Returns `{matched, collected}` where `collected` is every item that
- * came BEFORE the match (not including the matching item). Throws an
- * Error with `name === 'StreamClosed'` if the stream ends before any
- * item matches.
+ * Returns `ok({matched, collected})` where `collected` is every item
+ * that came BEFORE the match (not including the matching item).
+ * Returns `err({name: 'StreamClosed'})` if the stream ends before any
+ * item matches. Propagates the source's error variants unchanged.
  */
-export declare function collectUntil<T>(
-  source: AsyncIterable<T>,
+export declare function collectUntil<T, E>(
+  source: AsyncIterable<Result<T, E>>,
   predicate: (item: T) => boolean,
-): Promise<{matched: T; collected: T[]}>
+): Promise<Result<{matched: T; collected: T[]}, E | Extract<StreamError, {name: 'StreamClosed'}>>>
 
 /**
- * Wrap an async iterable with a total-duration deadline. Throws an
- * Error with `name === 'TimeoutError'` if the next item doesn't
- * arrive in time. Releases the upstream iterator via `return()` on
- * timeout, error, or consumer break.
+ * Wrap an async iterable with a total-duration deadline. Yields
+ * `err({name: 'Timeout', ms})` if the next item doesn't arrive in
+ * time, then ends. Releases the upstream iterator via `return()` on
+ * timeout, source error, or consumer break.
  */
-export declare function withTimeout<T>(source: AsyncIterable<T>, ms: number): AsyncIterable<T>
+export declare function withTimeout<T, E>(
+  source: AsyncIterable<Result<T, E>>,
+  ms: number,
+): AsyncIterable<Result<T, E | Extract<StreamError, {name: 'Timeout'}>>>
 
 /* BufferedReader lives in the sibling `mikrojs/reader` module — see
  * `runtime/reader/` — so apps that only need byte-level framing can

--- a/packages/@mikrojs/native/runtime/uart/types.ts
+++ b/packages/@mikrojs/native/runtime/uart/types.ts
@@ -53,7 +53,13 @@ export interface UartTx {
  * @public
  */
 export interface UartRx {
-  read(): Result<AsyncIterable<Uint8Array>, UartError>
+  /**
+   * Open a Result-yielding async iterable of received chunks. Mid-stream
+   * failures (driver fault, port closed mid-iteration) arrive as a single
+   * terminal `err(UartError)` item rather than throwing — composes with
+   * stream/* combinators and other Result-based APIs.
+   */
+  read(): Result<AsyncIterable<Result<Uint8Array, UartError>>, UartError>
 }
 
 /**

--- a/packages/@mikrojs/native/runtime/uart/uart.ts
+++ b/packages/@mikrojs/native/runtime/uart/uart.ts
@@ -36,14 +36,15 @@ export class Uart implements UartBase {
     return this.#native.write(data)
   }
 
-  read(): Result<AsyncIterable<Uint8Array>, UartError> {
+  read(): Result<AsyncIterable<Result<Uint8Array, UartError>>, UartError> {
     const result = this.#native.read()
     if (!result.ok) return result
     const nativeIter = result.value
-    // Wrap the native iterator object (which has next/return) into a proper AsyncIterable
-    const iterable: AsyncIterable<Uint8Array> = {
+    // Wrap the native iterator object (which has next/return) into a proper AsyncIterable.
+    // Native yields Result items directly via mik__result_ok / mik__result_err_tag.
+    const iterable: AsyncIterable<Result<Uint8Array, UartError>> = {
       [Symbol.asyncIterator]() {
-        return nativeIter as AsyncIterator<Uint8Array>
+        return nativeIter as AsyncIterator<Result<Uint8Array, UartError>>
       },
     }
     return ok(iterable)

--- a/packages/@mikrojs/native/test/reader_test.cpp
+++ b/packages/@mikrojs/native/test/reader_test.cpp
@@ -54,9 +54,10 @@ TEST_CASE("BufferedReader.readUntil returns bytes before delimiter" *
           doctest::test_suite("reader")) {
     const char* code = R"JS(
         import {BufferedReader} from 'mikrojs/reader'
+        import {ok} from 'mikrojs/result'
 
         async function* source() {
-            yield new Uint8Array([104, 105, 13, 10, 98, 121, 101, 13, 10])  // "hi\r\nbye\r\n"
+            yield ok(new Uint8Array([104, 105, 13, 10, 98, 121, 101, 13, 10]))  // "hi\r\nbye\r\n"
         }
 
         const reader = new BufferedReader(source())
@@ -64,8 +65,12 @@ TEST_CASE("BufferedReader.readUntil returns bytes before delimiter" *
         const first = await reader.readUntil(crlf, {timeoutMs: 5000})
         const second = await reader.readUntil(crlf, {timeoutMs: 5000})
 
-        const td = new TextDecoder()
-        globalThis.__result = `${td.decode(first)}|${td.decode(second)}`
+        if (!first.ok || !second.ok) {
+            globalThis.__result = `err=${(first.error || second.error).name}`
+        } else {
+            const td = new TextDecoder()
+            globalThis.__result = `${td.decode(first.value)}|${td.decode(second.value)}`
+        }
     )JS";
     run_reader_test("BufferedReader readUntil basic", code, "hi|bye");
 }
@@ -74,16 +79,17 @@ TEST_CASE("BufferedReader.readUntil spans multiple source chunks" *
           doctest::test_suite("reader")) {
     const char* code = R"JS(
         import {BufferedReader} from 'mikrojs/reader'
+        import {ok} from 'mikrojs/result'
 
         async function* source() {
-            yield new Uint8Array([104, 101])    // "he"
-            yield new Uint8Array([108, 108])    // "ll"
-            yield new Uint8Array([111, 13, 10]) // "o\r\n"
+            yield ok(new Uint8Array([104, 101]))    // "he"
+            yield ok(new Uint8Array([108, 108]))    // "ll"
+            yield ok(new Uint8Array([111, 13, 10])) // "o\r\n"
         }
 
         const reader = new BufferedReader(source())
-        const line = await reader.readUntil(new Uint8Array([13, 10]), {timeoutMs: 5000})
-        globalThis.__result = new TextDecoder().decode(line)
+        const r = await reader.readUntil(new Uint8Array([13, 10]), {timeoutMs: 5000})
+        globalThis.__result = r.ok ? new TextDecoder().decode(r.value) : `err=${r.error.name}`
     )JS";
     run_reader_test("BufferedReader readUntil multichunk", code, "hello");
 }
@@ -92,8 +98,9 @@ TEST_CASE("BufferedReader.readUntil rejects empty delimiter" *
           doctest::test_suite("reader")) {
     const char* code = R"JS(
         import {BufferedReader} from 'mikrojs/reader'
+        import {ok} from 'mikrojs/result'
 
-        async function* source() { yield new Uint8Array([0]) }
+        async function* source() { yield ok(new Uint8Array([0])) }
 
         try {
             await new BufferedReader(source()).readUntil(new Uint8Array(0), {timeoutMs: 100})
@@ -105,39 +112,58 @@ TEST_CASE("BufferedReader.readUntil rejects empty delimiter" *
     run_reader_test("BufferedReader readUntil empty delim", code, "threw=RangeError");
 }
 
-TEST_CASE("BufferedReader.readUntil throws StreamClosed when source ends early" *
+TEST_CASE("BufferedReader.readUntil returns StreamClosed when source ends early" *
           doctest::test_suite("reader")) {
     const char* code = R"JS(
         import {BufferedReader} from 'mikrojs/reader'
+        import {ok} from 'mikrojs/result'
 
         async function* source() {
-            yield new Uint8Array([1, 2, 3])  // no delimiter, then end
+            yield ok(new Uint8Array([1, 2, 3]))  // no delimiter, then end
         }
 
-        try {
-            await new BufferedReader(source()).readUntil(new Uint8Array([0xff]), {timeoutMs: 100})
-            globalThis.__result = 'no throw'
-        } catch (e) {
-            globalThis.__result = `threw=${e.name}`
-        }
+        const r = await new BufferedReader(source()).readUntil(new Uint8Array([0xff]), {timeoutMs: 100})
+        globalThis.__result = r.ok ? 'no err' : `err=${r.error.name}`
     )JS";
-    run_reader_test("BufferedReader readUntil closed", code, "threw=StreamClosed");
+    run_reader_test("BufferedReader readUntil closed", code, "err=StreamClosed");
+}
+
+TEST_CASE("BufferedReader.readUntil propagates source err" *
+          doctest::test_suite("reader")) {
+    const char* code = R"JS(
+        import {BufferedReader} from 'mikrojs/reader'
+        import {ok, err} from 'mikrojs/result'
+
+        async function* source() {
+            yield ok(new Uint8Array([1, 2]))
+            yield err({name: 'Boom'})
+        }
+
+        const r = await new BufferedReader(source()).readUntil(new Uint8Array([0xff]), {timeoutMs: 1000})
+        globalThis.__result = r.ok ? 'no err' : `err=${r.error.name}`
+    )JS";
+    run_reader_test("BufferedReader readUntil src err", code, "err=Boom");
 }
 
 TEST_CASE("BufferedReader.readBytes returns exactly count bytes" *
           doctest::test_suite("reader")) {
     const char* code = R"JS(
         import {BufferedReader} from 'mikrojs/reader'
+        import {ok} from 'mikrojs/result'
 
         async function* source() {
-            yield new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])
+            yield ok(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]))
         }
 
         const reader = new BufferedReader(source())
         const a = await reader.readBytes(3, {timeoutMs: 5000})
         const b = await reader.readBytes(5, {timeoutMs: 5000})
 
-        globalThis.__result = `a=${[...a].join(',')};b=${[...b].join(',')}`
+        if (!a.ok || !b.ok) {
+            globalThis.__result = 'err'
+        } else {
+            globalThis.__result = `a=${[...a.value].join(',')};b=${[...b.value].join(',')}`
+        }
     )JS";
     run_reader_test("BufferedReader readBytes basic", code, "a=1,2,3;b=4,5,6,7,8");
 }
@@ -146,16 +172,17 @@ TEST_CASE("BufferedReader.readBytes spans multiple source chunks" *
           doctest::test_suite("reader")) {
     const char* code = R"JS(
         import {BufferedReader} from 'mikrojs/reader'
+        import {ok} from 'mikrojs/result'
 
         async function* source() {
-            yield new Uint8Array([1, 2])
-            yield new Uint8Array([3, 4])
-            yield new Uint8Array([5, 6])
+            yield ok(new Uint8Array([1, 2]))
+            yield ok(new Uint8Array([3, 4]))
+            yield ok(new Uint8Array([5, 6]))
         }
 
         const reader = new BufferedReader(source())
-        const all = await reader.readBytes(6, {timeoutMs: 5000})
-        globalThis.__result = [...all].join(',')
+        const r = await reader.readBytes(6, {timeoutMs: 5000})
+        globalThis.__result = r.ok ? [...r.value].join(',') : `err=${r.error.name}`
     )JS";
     run_reader_test("BufferedReader readBytes multichunk", code, "1,2,3,4,5,6");
 }
@@ -164,16 +191,17 @@ TEST_CASE("BufferedReader.readBytes of 0 returns empty buffer without pulling" *
           doctest::test_suite("reader")) {
     const char* code = R"JS(
         import {BufferedReader} from 'mikrojs/reader'
+        import {ok} from 'mikrojs/result'
 
         let pulled = false
         async function* source() {
             pulled = true
-            yield new Uint8Array([])
+            yield ok(new Uint8Array([]))
         }
 
         const reader = new BufferedReader(source())
-        const empty = await reader.readBytes(0, {timeoutMs: 5000})
-        globalThis.__result = `len=${empty.length};pulled=${pulled}`
+        const r = await reader.readBytes(0, {timeoutMs: 5000})
+        globalThis.__result = r.ok ? `len=${r.value.length};pulled=${pulled}` : 'err'
     )JS";
     run_reader_test("BufferedReader readBytes zero", code, "len=0;pulled=false");
 }
@@ -181,10 +209,11 @@ TEST_CASE("BufferedReader.readBytes of 0 returns empty buffer without pulling" *
 TEST_CASE("BufferedReader.drain discards buffered bytes" * doctest::test_suite("reader")) {
     const char* code = R"JS(
         import {BufferedReader} from 'mikrojs/reader'
+        import {ok} from 'mikrojs/result'
 
         async function* source() {
-            yield new Uint8Array([1, 2, 3, 4, 5])
-            yield new Uint8Array([9, 9, 9])
+            yield ok(new Uint8Array([1, 2, 3, 4, 5]))
+            yield ok(new Uint8Array([9, 9, 9]))
         }
 
         const reader = new BufferedReader(source())
@@ -192,7 +221,11 @@ TEST_CASE("BufferedReader.drain discards buffered bytes" * doctest::test_suite("
         reader.drain()
         const second = await reader.readBytes(3, {timeoutMs: 5000})
 
-        globalThis.__result = `first=${[...first].join(',')};second=${[...second].join(',')}`
+        if (!first.ok || !second.ok) {
+            globalThis.__result = 'err'
+        } else {
+            globalThis.__result = `first=${[...first.value].join(',')};second=${[...second.value].join(',')}`
+        }
     )JS";
     run_reader_test("BufferedReader drain", code, "first=1,2;second=9,9,9");
 }
@@ -201,21 +234,26 @@ TEST_CASE("BufferedReader readUntil and readBytes interleave on same buffer" *
           doctest::test_suite("reader")) {
     const char* code = R"JS(
         import {BufferedReader} from 'mikrojs/reader'
+        import {ok} from 'mikrojs/result'
 
         // Simulates a modem-style protocol: header line, then length-prefixed
         // binary payload. The header is CRLF-terminated; the payload is raw.
         async function* source() {
-            yield new Uint8Array([
+            yield ok(new Uint8Array([
                 0x4f, 0x4b, 0x0d, 0x0a,  // "OK\r\n"
                 0xde, 0xad, 0xbe, 0xef,  // 4-byte payload
-            ])
+            ]))
         }
 
         const reader = new BufferedReader(source())
         const line = await reader.readUntil(new Uint8Array([13, 10]), {timeoutMs: 5000})
         const body = await reader.readBytes(4, {timeoutMs: 5000})
 
-        globalThis.__result = `line=${new TextDecoder().decode(line)};body=${[...body].map(b => b.toString(16)).join(',')}`
+        if (!line.ok || !body.ok) {
+            globalThis.__result = 'err'
+        } else {
+            globalThis.__result = `line=${new TextDecoder().decode(line.value)};body=${[...body.value].map(b => b.toString(16)).join(',')}`
+        }
     )JS";
     run_reader_test("BufferedReader mixed mode", code, "line=OK;body=de,ad,be,ef");
 }

--- a/packages/@mikrojs/native/test/stream_test.cpp
+++ b/packages/@mikrojs/native/test/stream_test.cpp
@@ -59,15 +59,17 @@ static void run_stream_test(const char* test_name, const char* js_code,
 TEST_CASE("decodeUtf8 converts byte chunks to strings" * doctest::test_suite("stream")) {
     const char* code = R"JS(
         import {decodeUtf8} from 'mikrojs/stream'
+        import {ok} from 'mikrojs/result'
 
         async function* source() {
-            yield new Uint8Array([104, 101, 108, 108, 111])  // "hello"
-            yield new Uint8Array([32, 119, 111, 114, 108, 100])  // " world"
+            yield ok(new Uint8Array([104, 101, 108, 108, 111]))  // "hello"
+            yield ok(new Uint8Array([32, 119, 111, 114, 108, 100]))  // " world"
         }
 
         const out = []
-        for await (const s of decodeUtf8(source())) {
-            out.push(s)
+        for await (const r of decodeUtf8(source())) {
+            if (!r.ok) { globalThis.__result = `err=${r.error.name}`; throw 'stop' }
+            out.push(r.value)
         }
         globalThis.__result = out.join('|')
     )JS";
@@ -78,35 +80,60 @@ TEST_CASE("decodeUtf8 handles whole multi-byte sequences in a single chunk" *
           doctest::test_suite("stream")) {
     const char* code = R"JS(
         import {decodeUtf8} from 'mikrojs/stream'
+        import {ok} from 'mikrojs/result'
 
         // "café" = 63 61 66 c3 a9 — whole sequence in one chunk is fine.
         // Cross-chunk split is documented as NOT supported in V1.
         async function* source() {
-            yield new Uint8Array([0x63, 0x61, 0x66, 0xc3, 0xa9])
+            yield ok(new Uint8Array([0x63, 0x61, 0x66, 0xc3, 0xa9]))
         }
 
         let out = ''
-        for await (const s of decodeUtf8(source())) {
-            out += s
+        for await (const r of decodeUtf8(source())) {
+            if (!r.ok) { globalThis.__result = `err=${r.error.name}`; throw 'stop' }
+            out += r.value
         }
         globalThis.__result = out
     )JS";
     run_stream_test("decodeUtf8 whole utf8", code, "café");
 }
 
-TEST_CASE("splitLines splits text on newline" * doctest::test_suite("stream")) {
+TEST_CASE("decodeUtf8 short-circuits on source err" * doctest::test_suite("stream")) {
     const char* code = R"JS(
-        import {splitLines} from 'mikrojs/stream'
+        import {decodeUtf8} from 'mikrojs/stream'
+        import {ok, err} from 'mikrojs/result'
 
         async function* source() {
-            yield 'first\n'
-            yield 'second\nthird\n'
-            yield 'fourth'  // no trailing newline
+            yield ok(new Uint8Array([0x61]))
+            yield err({name: 'Boom'})
+            yield ok(new Uint8Array([0x62]))  // should not be reached
         }
 
         const out = []
-        for await (const line of splitLines(source())) {
-            out.push(line)
+        for await (const r of decodeUtf8(source())) {
+            if (!r.ok) { out.push(`err=${r.error.name}`); break }
+            out.push(r.value)
+        }
+        globalThis.__result = out.join('|')
+    )JS";
+    run_stream_test("decodeUtf8 err propagates", code, "a|err=Boom");
+}
+
+TEST_CASE("splitLines splits text on newline" * doctest::test_suite("stream")) {
+    const char* code = R"JS(
+        import {splitLines} from 'mikrojs/stream'
+        import {ok} from 'mikrojs/result'
+
+        async function* source() {
+            yield ok('first\n')
+            yield ok('second\nthird\n')
+            yield ok('fourth')  // no trailing newline
+        }
+
+        const out = []
+        for await (const r of splitLines(source())) {
+            if (!r.ok) { globalThis.__result = `err=${r.error.name}`; throw 'stop' }
+            out.push(r.value)
         }
         globalThis.__result = out.join('|')
     )JS";
@@ -116,16 +143,18 @@ TEST_CASE("splitLines splits text on newline" * doctest::test_suite("stream")) {
 TEST_CASE("splitLines handles lines spanning chunks" * doctest::test_suite("stream")) {
     const char* code = R"JS(
         import {splitLines} from 'mikrojs/stream'
+        import {ok} from 'mikrojs/result'
 
         async function* source() {
-            yield 'hel'
-            yield 'lo\nwo'
-            yield 'rld\n'
+            yield ok('hel')
+            yield ok('lo\nwo')
+            yield ok('rld\n')
         }
 
         const out = []
-        for await (const line of splitLines(source())) {
-            out.push(line)
+        for await (const r of splitLines(source())) {
+            if (!r.ok) { globalThis.__result = `err=${r.error.name}`; throw 'stop' }
+            out.push(r.value)
         }
         globalThis.__result = out.join('|')
     )JS";
@@ -135,15 +164,17 @@ TEST_CASE("splitLines handles lines spanning chunks" * doctest::test_suite("stre
 TEST_CASE("splitLines supports custom delimiter" * doctest::test_suite("stream")) {
     const char* code = R"JS(
         import {splitLines} from 'mikrojs/stream'
+        import {ok} from 'mikrojs/result'
 
         async function* source() {
-            yield 'a\r\nb\r\n'
-            yield 'c\r\n'
+            yield ok('a\r\nb\r\n')
+            yield ok('c\r\n')
         }
 
         const out = []
-        for await (const line of splitLines(source(), '\r\n')) {
-            out.push(line)
+        for await (const r of splitLines(source(), '\r\n')) {
+            if (!r.ok) { globalThis.__result = `err=${r.error.name}`; throw 'stop' }
+            out.push(r.value)
         }
         globalThis.__result = out.join('|')
     )JS";
@@ -153,9 +184,10 @@ TEST_CASE("splitLines supports custom delimiter" * doctest::test_suite("stream")
 TEST_CASE("splitLines rejects empty delimiter" * doctest::test_suite("stream")) {
     const char* code = R"JS(
         import {splitLines} from 'mikrojs/stream'
+        import {ok} from 'mikrojs/result'
 
         async function* source() {
-            yield 'anything'
+            yield ok('anything')
         }
 
         try {
@@ -171,14 +203,16 @@ TEST_CASE("splitLines rejects empty delimiter" * doctest::test_suite("stream")) 
 TEST_CASE("splitLines preserves empty lines" * doctest::test_suite("stream")) {
     const char* code = R"JS(
         import {splitLines} from 'mikrojs/stream'
+        import {ok} from 'mikrojs/result'
 
         async function* source() {
-            yield 'a\n\nb\n'
+            yield ok('a\n\nb\n')
         }
 
         const out = []
-        for await (const line of splitLines(source())) {
-            out.push(line)
+        for await (const r of splitLines(source())) {
+            if (!r.ok) { globalThis.__result = `err=${r.error.name}`; throw 'stop' }
+            out.push(r.value)
         }
         globalThis.__result = out.join('|') + ':' + out.length
     )JS";
@@ -189,42 +223,70 @@ TEST_CASE("collectUntil collects until predicate matches" *
           doctest::test_suite("stream")) {
     const char* code = R"JS(
         import {collectUntil} from 'mikrojs/stream'
+        import {ok} from 'mikrojs/result'
 
         async function* source() {
-            yield '+CSQ: 15,99'
-            yield '+CREG: 0,1'
-            yield 'OK'
-            yield 'should not be reached'
+            yield ok('+CSQ: 15,99')
+            yield ok('+CREG: 0,1')
+            yield ok('OK')
+            yield ok('should not be reached')
         }
 
-        const {matched, collected} = await collectUntil(
+        const r = await collectUntil(
             source(),
             line => line === 'OK' || line.startsWith('ERROR'),
         )
-        globalThis.__result = `matched=${matched};collected=${collected.join('|')}`
+        if (!r.ok) {
+            globalThis.__result = `err=${r.error.name}`
+        } else {
+            const {matched, collected} = r.value
+            globalThis.__result = `matched=${matched};collected=${collected.join('|')}`
+        }
     )JS";
     run_stream_test("collectUntil basic", code,
                     "matched=OK;collected=+CSQ: 15,99|+CREG: 0,1");
 }
 
-TEST_CASE("collectUntil throws StreamClosed if no match" *
+TEST_CASE("collectUntil returns StreamClosed if no match" *
           doctest::test_suite("stream")) {
     const char* code = R"JS(
         import {collectUntil} from 'mikrojs/stream'
+        import {ok} from 'mikrojs/result'
 
         async function* source() {
-            yield 'a'
-            yield 'b'
+            yield ok('a')
+            yield ok('b')
         }
 
-        try {
-            await collectUntil(source(), s => s === 'OK')
-            globalThis.__result = 'no throw'
-        } catch (e) {
-            globalThis.__result = `threw=${e.name}`
+        const r = await collectUntil(source(), s => s === 'OK')
+        if (r.ok) {
+            globalThis.__result = 'no err'
+        } else {
+            globalThis.__result = `err=${r.error.name}`
         }
     )JS";
-    run_stream_test("collectUntil no match", code, "threw=StreamClosed");
+    run_stream_test("collectUntil no match", code, "err=StreamClosed");
+}
+
+TEST_CASE("collectUntil propagates source err" * doctest::test_suite("stream")) {
+    const char* code = R"JS(
+        import {collectUntil} from 'mikrojs/stream'
+        import {ok, err} from 'mikrojs/result'
+
+        async function* source() {
+            yield ok('a')
+            yield err({name: 'Boom'})
+            yield ok('OK')
+        }
+
+        const r = await collectUntil(source(), s => s === 'OK')
+        if (r.ok) {
+            globalThis.__result = 'no err'
+        } else {
+            globalThis.__result = `err=${r.error.name}`
+        }
+    )JS";
+    run_stream_test("collectUntil source err", code, "err=Boom");
 }
 
 /* NOTE: the "slow source" timeout test is intentionally omitted from
@@ -244,16 +306,18 @@ TEST_CASE("collectUntil throws StreamClosed if no match" *
 TEST_CASE("withTimeout passes through fast items" * doctest::test_suite("stream")) {
     const char* code = R"JS(
         import {withTimeout} from 'mikrojs/stream'
+        import {ok} from 'mikrojs/result'
 
         async function* source() {
-            yield 1
-            yield 2
-            yield 3
+            yield ok(1)
+            yield ok(2)
+            yield ok(3)
         }
 
         const out = []
-        for await (const n of withTimeout(source(), 5000)) {
-            out.push(n)
+        for await (const r of withTimeout(source(), 5000)) {
+            if (!r.ok) { globalThis.__result = `err=${r.error.name}`; throw 'stop' }
+            out.push(r.value)
         }
         globalThis.__result = out.join('|')
     )JS";


### PR DESCRIPTION
Async-iterator APIs (http body, fs.readStream, uart.read, stream/*, BufferedReader) used to throw mid-stream errors as either tagged objects or Error subclasses, leaving consumers with no way to handle failures without try/catch. Drains over those iterators (Response.text/bytes/json) returned raw Promise<T> and propagated the same errors as rejections.

This unifies streaming APIs on the Result-yielding shape that already governs the rest of the runtime: each iterator yields Result<T, E>, each drain returns Promise<Result<T, E>>. Combinators short-circuit on the first err. Programmer-error throws (RangeError, TypeError, BodyConsumed) stay as throws — only stream/transport failures move to Result.

Also drops the JS-level defineError helper; the wrapper-closure overhead wasn't worth the small ergonomic win. Modules use plain const factory objects now. matchError stays as a small exhaustive dispatch helper.

Also includes:

- pendingCount harness fixes (drain queue, exclude cancelled entries) that eliminate intermittent "in-flight HTTP at teardown" false positives.
- KVError gains Unknown variant so unrecognised native codes return cleanly instead of throwing.
- Docs and examples updated to the new shapes.

BREAKING CHANGE: Response.body, .text(), .bytes(), .json(); fs.readStream's inner iterator; Uart.read's inner iterator; stream combinators (decodeUtf8, splitLines, withTimeout, collectUntil); BufferedReader's constructor + readUntil/readBytes — all now require/return Result. defineError and ErrorOf are removed from mikrojs/result.