### PR TITLE
fix(runtime): unhang uart.read() when end() races a pending next()

### DIFF
--- a/packages/@mikrojs/firmware/components/mikrojs/mik_http.cpp
+++ b/packages/@mikrojs/firmware/components/mikrojs/mik_http.cpp
@@ -672,9 +672,18 @@ static JSValue mik__http_next_message(JSContext* ctx, JSValue this_val, int argc
  * result_queue before reading the counter. */
 void mik__http_consume(JSContext* ctx);
 
-/* pendingCount() — number of in-flight requests whose terminal message has
- * not yet been consumed. Useful for tests that want to verify cancel+drain
- * freed a slot without relying on heap-headroom for a follow-up request.
+/* pendingCount() — number of in-flight requests with work still visible to
+ * JS (headers/body not yet delivered, not cancelled). Useful for tests that
+ * want to verify cancel+drain freed a slot without relying on heap-headroom
+ * for a follow-up request.
+ *
+ * Semantic shift vs. a "raw slot count": this returns the JS-visible pending
+ * count, not the native slot count. Cancelled-but-not-yet-drained entries
+ * still occupy a native slot (until the BG task wakes from a blocking call
+ * and posts its terminal message) but are excluded from this count. If you
+ * need to know whether a follow-up `request()` will hit TooManyPending, this
+ * is not the right number — the slot may still be held. See
+ * MIK_HTTP_MAX_PENDING and the js_cancelled exclusion below.
  *
  * Drains result_queue first via the consume loop. Without this, a request
  * whose native task has already posted its terminal message but whose

--- a/packages/@mikrojs/firmware/components/mikrojs/mik_uart.cpp
+++ b/packages/@mikrojs/firmware/components/mikrojs/mik_uart.cpp
@@ -12,6 +12,11 @@
 static JSClassID mik_uart_class_id;
 static int mik__uart_slot = -1;
 
+/* Forward decl: defined alongside the iterator class further down. The Uart
+ * state holds a non-owning backpointer so end() can mark the active iterator
+ * as exhausted without having to reach through JS. */
+struct MIKUartIterState;
+
 /* ── State ────────────────────────────────────────────────────────── */
 
 struct MIKUartState {
@@ -22,6 +27,11 @@ struct MIKUartState {
     bool begun;
     bool reading;     // active read() iterator exists
     MIKPromise read_promise;  // pending next() promise (when waiting for data)
+    /* Non-owning ref to the active iterator (when reading == true). The iter
+     * holds a strong ref to this Uart via uart_jsval, so this back-edge is
+     * always cleared (iter_return / finalizer) before the Uart can outlive
+     * the iterator. */
+    MIKUartIterState* iter;
 };
 
 /* Per-runtime tracking of all Uart instances for the loop consumer */
@@ -98,6 +108,7 @@ static JSValue js_uart_constructor(JSContext* ctx, JSValue new_target, int argc,
     s->baud_rate = 115200;
     s->begun = false;
     s->reading = false;
+    s->iter = nullptr;
     s->read_promise.p = JS_UNDEFINED;
     s->read_promise.rfuncs[0] = JS_UNDEFINED;
     s->read_promise.rfuncs[1] = JS_UNDEFINED;
@@ -193,19 +204,29 @@ static JSValue js_uart_begin(JSContext* ctx, JSValue this_val, int argc, JSValue
     return mik__result_ok_void(ctx);
 }
 
+/* Forward decls — bodies live with the iterator class. */
+static JSValue mik__uart_iter_yield(JSContext* ctx, JSValue inner_result);
+static void mik__uart_iter_mark_ended(MIKUartIterState* it);
+
 static JSValue js_uart_end(JSContext* ctx, JSValue this_val, int argc, JSValue* argv) {
     auto* s = mik__uart_get(ctx, this_val);
     if (!s) return JS_EXCEPTION;
     if (!s->begun) return mik__result_ok_void(ctx);  // idempotent
 
-    /* Cancel any pending read. MIK_FreePromise frees the JSValues but
-     * doesn't reset the slot, so MIK_ClearPromise is required to keep
-     * MIK_IsPromisePending honest if the Uart is begun + read again. */
+    /* If a read() iterator is active, deliver a terminal err item so any
+     * awaiting next() unblocks with err(NotStarted) rather than hanging.
+     * Also flip the iterator's `ended` flag so its next call resolves with
+     * {done:true} — without this, the awaiter consumes the err yield, then
+     * the next call hits the `!s->begun` branch in iter_next and emits a
+     * second err yield. The active iterator backpointer makes that flip
+     * possible without reaching through JS. */
     if (s->reading) {
         if (MIK_IsPromisePending(ctx, &s->read_promise)) {
-            MIK_FreePromise(ctx, &s->read_promise);
+            JSValue err_yield = mik__uart_iter_yield(ctx, mik__result_err_tag(ctx, "NotStarted"));
+            MIK_ResolvePromise(ctx, &s->read_promise, 1, &err_yield);
             MIK_ClearPromise(ctx, &s->read_promise);
         }
+        if (s->iter) mik__uart_iter_mark_ended(s->iter);
         s->reading = false;
     }
 
@@ -270,9 +291,14 @@ static void mik__uart_iter_finalizer(JSRuntime* rt, JSValue val) {
      * safe here — except after iterator.return() nulled it out. */
     if (it->uart) {
         it->uart->reading = false;
+        if (it->uart->iter == it) it->uart->iter = nullptr;
     }
     JS_FreeValueRT(rt, it->uart_jsval);
     free(it);
+}
+
+static void mik__uart_iter_mark_ended(MIKUartIterState* it) {
+    if (it) it->ended = true;
 }
 
 static void mik__uart_iter_gc_mark(JSRuntime* rt, JSValue val, JS_MarkFunc* mark_func) {
@@ -370,6 +396,7 @@ static JSValue js_uart_iter_return(JSContext* ctx, JSValue this_val, int argc, J
     }
 
     it->uart->reading = false;
+    if (it->uart->iter == it) it->uart->iter = nullptr;
     it->uart = nullptr;
 
 done:
@@ -411,6 +438,7 @@ static JSValue js_uart_read(JSContext* ctx, JSValue this_val, int argc, JSValue*
         return JS_EXCEPTION;
     }
     JS_SetOpaque(iter_obj, it);
+    s->iter = it;
 
     return mik__result_ok(ctx, iter_obj);
 }

--- a/packages/@mikrojs/native/runtime/kv/__test__/shared.test.ts
+++ b/packages/@mikrojs/native/runtime/kv/__test__/shared.test.ts
@@ -1,0 +1,44 @@
+import {describe, expect, it} from 'vitest'
+
+import {makeCreateValue, type NativeKvFns} from '../shared.js'
+
+function fakeNative(setResult: ReturnType<NativeKvFns['set']>): NativeKvFns {
+  return {
+    get: () => undefined,
+    set: () => setResult,
+    remove: () => true,
+    clear: () => {},
+    info: () => ({entries: 0, used: 0, total: 0, free: 0}),
+  }
+}
+
+describe('mapKvError', () => {
+  // mapKvError is internal; exercise it via the set() path on a createValue.
+  it('maps unknown native error codes to KVError.Unknown', () => {
+    const native = fakeNative({
+      ok: false,
+      error: {code: 0x80ff, message: 'something weird'},
+    })
+    const createValue = makeCreateValue(native)
+    const v = createValue('k') as {set: (x: unknown) => {ok: false; error: unknown}}
+    const result = v.set(42)
+    expect(result.ok).toBe(false)
+    expect(result.error).toEqual({
+      name: 'Unknown',
+      code: 0x80ff,
+      message: 'something weird',
+    })
+  })
+
+  it('maps known native error codes to their named variants', () => {
+    const native = fakeNative({
+      ok: false,
+      error: {code: 0x80d3, message: 'full'},
+    })
+    const createValue = makeCreateValue(native)
+    const v = createValue('k') as {set: (x: unknown) => {ok: false; error: {name: string}}}
+    const result = v.set(42)
+    expect(result.ok).toBe(false)
+    expect(result.error.name).toBe('StorageFull')
+  })
+})

--- a/packages/@mikrojs/native/runtime/result/result.ts
+++ b/packages/@mikrojs/native/runtime/result/result.ts
@@ -11,5 +11,15 @@ export function matchError<E extends {name: string}, R>(
   error: E,
   handlers: {[K in E['name']]: (error: Extract<E, {name: K}>) => R},
 ): R {
-  return (handlers as unknown as Record<string, (e: E) => R>)[error.name]!(error)
+  // hasOwn guard: bare `handlers[error.name]` would resolve to Object.prototype
+  // methods (toString, hasOwnProperty, …) for any error.name string that
+  // happens to match a prototype member — silently returning a wrong value
+  // instead of failing loudly. The type system enforces `name` is one of the
+  // union's tags, but interop with native or hand-built error objects can
+  // bypass that.
+  const h = handlers as unknown as Record<string, (e: E) => R>
+  if (!Object.hasOwn(h, error.name)) {
+    throw new TypeError(`matchError: no handler for ${error.name}`)
+  }
+  return h[error.name]!(error)
 }

--- a/packages/@mikrojs/native/runtime/stream/stream.ts
+++ b/packages/@mikrojs/native/runtime/stream/stream.ts
@@ -118,6 +118,14 @@ export async function collectUntil<T, E>(
  * - The upstream iterator is explicitly .return()'d on exit (normal,
  *   timeout, or consumer break) so underlying resources (UART claims,
  *   socket handles, ring buffers) get released.
+ *
+ * Source contract: the source iterator must surface failures via
+ * `yield err(...)` items, not by rejecting `next()`. On a timer win,
+ * the in-flight `next()` promise is discarded; if that promise
+ * rejects, the rejection is unhandled. Every Result-yielding source
+ * in this codebase (`uart.read()`, `fs.readStream`, `Response.body`)
+ * satisfies that contract — only relevant if you compose
+ * `withTimeout` over a hand-rolled iterator.
  */
 export async function* withTimeout<T, E>(
   source: AsyncIterable<Result<T, E>>,

--- a/packages/@mikrojs/native/runtime/stream/types.ts
+++ b/packages/@mikrojs/native/runtime/stream/types.ts
@@ -50,6 +50,12 @@ export declare function collectUntil<T, E>(
  * `err({name: 'Timeout', ms})` if the next item doesn't arrive in
  * time, then ends. Releases the upstream iterator via `return()` on
  * timeout, source error, or consumer break.
+ *
+ * Source contract: the source must surface failures via `yield err(...)`,
+ * not by rejecting `next()`. On a timer win the in-flight `next()`
+ * promise is discarded — if it later rejects, the rejection is
+ * unhandled. All Result-yielding sources in this runtime
+ * (`uart.read()`, `fs.readStream`, `Response.body`) satisfy that.
  */
 export declare function withTimeout<T, E>(
   source: AsyncIterable<Result<T, E>>,

--- a/packages/@mikrojs/native/test/stream_test.cpp
+++ b/packages/@mikrojs/native/test/stream_test.cpp
@@ -323,3 +323,24 @@ TEST_CASE("withTimeout passes through fast items" * doctest::test_suite("stream"
     )JS";
     run_stream_test("withTimeout fast", code, "1|2|3");
 }
+
+TEST_CASE("withTimeout propagates source err" * doctest::test_suite("stream")) {
+    const char* code = R"JS(
+        import {withTimeout} from 'mikrojs/stream'
+        import {ok, err} from 'mikrojs/result'
+
+        async function* source() {
+            yield ok(1)
+            yield err({name: 'Boom'})
+            yield ok(2)  // should not be reached
+        }
+
+        const out = []
+        for await (const r of withTimeout(source(), 5000)) {
+            if (!r.ok) { out.push(`err=${r.error.name}`); break }
+            out.push(r.value)
+        }
+        globalThis.__result = out.join('|')
+    )JS";
+    run_stream_test("withTimeout source err", code, "1|err=Boom");
+}


### PR DESCRIPTION
js_uart_end was freeing the in-flight read promise without resolving it, hanging any consumer in `await iter.next()`. Resolve the promise with err(NotStarted) and flip the iterator's `ended` flag via a new state backpointer so the next call returns done, matching the doc claim that mid-iteration port closure surfaces as a single terminal err item.

- matchError now hasOwn-guards the handler lookup so prototype methods (toString, hasOwnProperty, ...) can't masquerade as handlers.
- withTimeout docs the "source must yield err, not reject from next()" contract; on a timer win the in-flight next() is dropped.
- pendingCount comment names the JS-visible vs native-slot distinction so callers don't read it as TooManyPending headroom.
- Add doctest for withTimeout source-err propagation and vitest for KVError.Unknown mapping.