### PR TITLE
ci(workflows): add zizmor audit and harden workflows

### DIFF
--- a/.github/actions/firmware-build/action.yml
+++ b/.github/actions/firmware-build/action.yml
@@ -59,7 +59,9 @@ runs:
     # compute path entirely.
     - if: inputs.version != ''
       shell: bash
-      run: pnpm --silent releaser bump --mode release --set ${{ inputs.version }}
+      env:
+        VERSION: ${{ inputs.version }}
+      run: pnpm --silent releaser bump --mode release --set "$VERSION"
 
     - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5
       with:
@@ -104,9 +106,11 @@ runs:
     - if: inputs.pack-format == 'tarball'
       shell: bash
       working-directory: esp32/build
+      env:
+        ARTIFACT_NAME: ${{ inputs.artifact-name }}
       run: |
         mkdir -p ../../firmware-out
-        tar czf ../../firmware-out/${{ inputs.artifact-name }}.tar.gz \
+        tar czf "../../firmware-out/${ARTIFACT_NAME}.tar.gz" \
           flasher_args.json \
           bootloader/bootloader.bin \
           partition_table/partition-table.bin \

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -22,8 +22,10 @@ runs:
         registry-url: ${{ inputs.registry-url }}
 
     - shell: bash
+      env:
+        IGNORE_SCRIPTS: ${{ inputs.ignore-scripts }}
       run: |
-        if [ "${{ inputs.ignore-scripts }}" = "true" ]; then
+        if [ "$IGNORE_SCRIPTS" = "true" ]; then
           pnpm install --frozen-lockfile --ignore-scripts
         else
           pnpm install --frozen-lockfile

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -62,6 +62,9 @@ jobs:
         with:
           client-id: ${{ secrets.MIKRODROID_CLIENT_ID }}
           private-key: ${{ secrets.MIKRODROID_APP_PRIVATE_KEY }}
+          permission-contents: write # push the ci/release-main branch
+          permission-pull-requests: write # create/update the rolling PR
+          permission-issues: write # PR conversation comments use the issues API
 
       - name: Configure git
         if: steps.plan.outputs.should_run == 'true'

--- a/.github/workflows/memory-bench-backfill.yml
+++ b/.github/workflows/memory-bench-backfill.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6 # zizmor: ignore[cache-poisoning] workflow_dispatch-only (no PR-writable cache scope), and pnpm --frozen-lockfile verifies tarball integrity. Re-evaluate if push/pull_request/schedule triggers are added.
         with:
           node-version: 24
           cache: pnpm
@@ -91,6 +91,9 @@ jobs:
       - name: Commit and push to bench-data
         if: ${{ !inputs.dry_run }}
         working-directory: bench-data
+        env:
+          RANGE: ${{ inputs.range }}
+          STEP: ${{ inputs.step }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -98,7 +101,7 @@ jobs:
           if git diff --cached --quiet; then
             echo "no changes"
           else
-            git commit -m "bench: backfill ${{ inputs.range }} (step=${{ inputs.step }})"
+            git commit -m "bench: backfill $RANGE (step=$STEP)"
             git push
           fi
 

--- a/.github/workflows/memory-bench.yml
+++ b/.github/workflows/memory-bench.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6 # zizmor: ignore[cache-poisoning] GitHub scopes caches per-ref so PR runs cannot write to main's cache; pnpm --frozen-lockfile additionally verifies tarball integrity. Re-evaluate if schedule/workflow_run triggers are added.
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           client-id: ${{ secrets.MIKRODROID_CLIENT_ID }}
           private-key: ${{ secrets.MIKRODROID_APP_PRIVATE_KEY }}
+          permission-issues: write # label removal goes through the issues API
 
       # Remove the trigger label immediately so a second click during the long
       # publish (10–15 min) doesn't queue another run, and so the PR isn't
@@ -178,6 +179,9 @@ jobs:
         with:
           client-id: ${{ secrets.MIKRODROID_CLIENT_ID }}
           private-key: ${{ secrets.MIKRODROID_APP_PRIVATE_KEY }}
+          permission-contents: write # tag push + GitHub Release
+          permission-pull-requests: write # PR-preview comment edits
+          permission-issues: write # PR-preview comments go through the issues API
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,7 +1,7 @@
 name: Validate PR title
 
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] reads only PR title metadata; no checkout, no PR code execution
     types:
       - opened
       - edited

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        uses: zizmorcore/zizmor-action@b572f7b1a1c2d41efaab43d504f68d215c3cd727 # ratchet:zizmorcore/zizmor-action@v0.5.4
         with:
           advanced-security: false
           min-severity: high

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,30 @@
+name: Zizmor
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Audit workflows
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: false
+          min-severity: high

--- a/knip.ts
+++ b/knip.ts
@@ -70,7 +70,8 @@ const config = {
     '**/*.stub.ts',
   ],
   ignoreDependencies: ['unbarrelify', 'taze'],
-  ignoreBinaries: ['cmake', 'ctest'],
+  // zizmor is installed system-wide (brew/uv/pipx), not via npm
+  ignoreBinaries: ['cmake', 'ctest', 'zizmor'],
   // Knip can't trace `import * as` namespace member access or type-only re-exports
   // through barrel files. All remaining "unused" exports/types have been manually
   // verified as used.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -22,6 +22,11 @@ pre-commit:
       glob: '*.{js,ts,tsx,md,json}'
       exclude: '(^|/)CHANGELOG\.md$'
       run: pnpm fmt:check -- {staged_files}
+    zizmor:
+      skip:
+        - run: node scripts/is-agent.js
+      glob: '.github/{workflows,actions}/**/*.{yml,yaml}'
+      run: pnpm lint:workflows
 
     # Agent: full project checks
     build-cpp:
@@ -48,6 +53,10 @@ pre-commit:
       only:
         - run: node scripts/is-agent.js
       run: pnpm knip
+    zizmor-all:
+      only:
+        - run: node scripts/is-agent.js
+      run: pnpm lint:workflows
     publint:
       only:
         - run: node scripts/is-agent.js

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "fmt:check": "oxfmt --check",
     "knip": "knip",
     "lint": "eslint",
+    "lint:workflows": "if command -v zizmor >/dev/null 2>&1; then zizmor .github --min-severity high; else echo 'zizmor not found. Install it: https://docs.zizmor.sh/installation/'; exit 1; fi",
     "precommit": "run-p lint fmt:check",
     "prepare": "lefthook install",
     "publint": "pnpm -r run publint",


### PR DESCRIPTION
Eliminate template-injection sinks (route inputs through env), scope GitHub App tokens with permission-* inputs, and silence remaining warnings with rationale comments. New Zizmor workflow gates main on high-severity findings; lefthook runs the same audit pre-commit when .github/ files are staged.