### PR TITLE
feat(sleep)!: split wakeup sources by sleep mode and auto-conf RTC pulls

### DIFF
--- a/dev/e2e/test/modules.test.ts
+++ b/dev/e2e/test/modules.test.ts
@@ -53,13 +53,14 @@ describe('module: sleep', () => {
   test('exports exist', async () => {
     const mod = await import('mikrojs/sleep')
     assert.type(mod.sleep, 'function')
-    assert.type(mod.getWakeupCause, 'function')
     assert.type(mod.deepSleep, 'function')
     assert.type(mod.lightSleep, 'function')
+    assert.type(mod.canWakeFromExt0, 'function')
+    assert.type(mod.canWakeFromExt1, 'function')
   })
 
   test('getWakeupCause returns a string', async () => {
-    const {getWakeupCause} = await import('mikrojs/sleep')
+    const {getWakeupCause} = await import('mikrojs/sys')
     const cause = getWakeupCause()
     assert.type(cause, 'string')
   })

--- a/docs/api/sleep.md
+++ b/docs/api/sleep.md
@@ -27,99 +27,116 @@ import {sleep} from 'mikrojs/sleep'
 await sleep(1000) // wait 1 second
 ```
 
-### deepSleep(time)
+### deepSleep(sources)
 
 ```ts
-function deepSleep(time: number): never
+function deepSleep(sources: DeepWakeupSources | number): never
 ```
 
-Enter deep sleep for `time` microseconds. The device resets on wake, so your program restarts from the beginning. Use [`rtcStorage`](/api/kv) to persist state across deep sleep cycles.
+Enter deep sleep until one of the configured `sources` wakes the device. The chip resets on wake, so your program restarts from the beginning. Use [`rtcStorage`](/api/kv) to persist state across deep sleep cycles.
+
+Pass a number as shorthand for a timer-only wakeup in milliseconds:
 
 ```ts twoslash
 import {deepSleep} from 'mikrojs/sleep'
 // ---cut---
-deepSleep(60_000_000) // sleep for 60 seconds
+deepSleep(60_000) // wake in 60 seconds
 ```
 
-### lightSleep(time)
+You can combine sources. The chip wakes when any of them fires:
+
+```ts twoslash
+import {deepSleep} from 'mikrojs/sleep'
+// ---cut---
+deepSleep({
+  timer: 60 * 60 * 1000, // 1 hour
+  ext0: {pin: 4, level: 'low'}, // ...or a button press
+})
+```
+
+### lightSleep(sources)
 
 ```ts
-function lightSleep(time: number): Result<void, SleepError>
+function lightSleep(sources: LightWakeupSources | number): void
 ```
 
-Enter light sleep for `time` microseconds. Execution resumes from the same point after waking. RAM is preserved.
+Enter light sleep until one of the configured `sources` wakes the device. Execution resumes from the same point after waking; RAM is preserved.
+
+Pass a number as shorthand for a timer-only wakeup in milliseconds:
 
 ```ts twoslash
 import {lightSleep} from 'mikrojs/sleep'
 // ---cut---
-lightSleep(5_000_000).orPanic('light sleep failed') // sleep 5 seconds
+lightSleep(5000) // wake in 5 seconds
 ```
 
-### getWakeupCause()
+Throws if the chip refuses to sleep. This is unrecoverable in practice and indicates a programming error: no wakeup source configured, a GPIO wakeup already in its trigger state, or a peripheral that's busy (mid-handshake WiFi, active SPI DMA, etc.). Fix the caller rather than catching the throw.
 
-```ts
-function getWakeupCause(): string
-```
+::: info Light sleep drops the USB console
+On chips with built-in USB Serial/JTAG (C3, C6, S3, and others), light sleep powers down the USB peripheral. The host sees the device disconnect, and `mikro dev` (or `idf.py monitor`) is left holding a port that no longer exists. Any `console.log` after the sleep won't make it through.
 
-Returns the reason the device woke up (e.g., after deep sleep). Useful for branching logic on boot.
-
-```ts twoslash
-import {getWakeupCause} from 'mikrojs/sleep'
-// ---cut---
-const cause = getWakeupCause()
-console.log('Woke up because: %s', cause)
-```
+The device keeps running normally; only the log stream is affected. Restart the monitor to see output again after wake.
+:::
 
 ## Wakeup sources
 
-Configure what can wake the device from sleep. Multiple sources can be active at once.
-
-### enableTimerWakeup(us)
+Each function takes its own source type. Combine sources by passing multiple fields in one call — the chip wakes when any of them fires. Calling `deepSleep` or `lightSleep` replaces any previously-configured sources with exactly what's passed in.
 
 ```ts
-function enableTimerWakeup(us: number): Result<void, SleepError>
+type LightWakeupSources = {
+  timer?: number
+  gpio?: {pin: number; level: 'high' | 'low'}
+}
+
+type DeepWakeupSources = {
+  timer?: number
+  ext0?: {pin: RtcGpio; level: 'high' | 'low'}
+  ext1?: {pins: RtcGpio[]; mode: 'any-low' | 'any-high'}
+}
+
+type RtcGpio = number
 ```
 
-Wake up after `us` microseconds.
+The two sleep modes have different wake-source paths in ESP-IDF — `gpio` only fires during light sleep, and `ext0`/`ext1` only fire during deep sleep — so the API surfaces them separately.
 
-### enableGpioWakeup(pin, level)
+### `timer`
+
+Milliseconds until wake. Fractional values are allowed, so `0.01` is 10 µs. Works in both deep and light sleep.
+
+### `gpio` (light sleep)
+
+Wake when `pin` reaches `level`. Any GPIO works.
+
+### `ext0` (deep sleep)
+
+Wake when an RTC-capable pin reaches `level`. **ESP32, ESP32-S2, ESP32-S3 only** — throws on C3, C6, H2 (use `ext1` instead).
+
+### `ext1` (deep sleep)
+
+Wake as soon as any of the RTC-capable `pins` matches `mode`: `'any-low'` fires when one goes low; `'any-high'` fires when one goes high.
+
+### `RtcGpio`
+
+Type alias for `number` documenting that the pin must be RTC-capable. Set varies per chip: C6/H2 = 0–7, C3 = 0–5, S2/S3 = 0–21, ESP32 = subset of 0–39. Not statically validated; non-RTC pins throw at runtime.
+
+Invalid inputs (bad `level` string, pins that don't support wakeup, capability missing on the current chip) throw. These are programmer errors; fix the call rather than catching.
+
+## Chip capability helpers
+
+For code that needs to target multiple ESP32 variants, gate `ext0` / `ext1` calls with these:
+
+### canWakeFromExt0()
 
 ```ts
-function enableGpioWakeup(pin: number, level: number): Result<void, SleepError>
+function canWakeFromExt0(): boolean
 ```
 
-Wake on GPIO pin state change. For light sleep only. `level`: 4 = low, 5 = high.
+Returns `true` on chips that support EXT0 wakeup (ESP32, ESP32-S2, ESP32-S3). `false` on C3, C6, H2, and other newer variants — use `ext1` there.
 
-### enableExt0Wakeup(pin, level)
+### canWakeFromExt1()
 
 ```ts
-function enableExt0Wakeup(pin: number, level: number): Result<void, SleepError>
+function canWakeFromExt1(): boolean
 ```
 
-Wake on a single RTC GPIO pin. For deep sleep. `level`: 0 = low, 1 = high. ESP32, ESP32-S2, ESP32-S3 only.
-
-### enableExt1Wakeup(pinMask, mode)
-
-```ts
-function enableExt1Wakeup(pinMask: number, mode: number): Result<void, SleepError>
-```
-
-Wake on multiple RTC GPIO pins. For deep sleep. `pinMask` is a bitmask of pin numbers. `mode`: 0 = all low, 1 = any high.
-
-### disableWakeupSource(source?)
-
-```ts
-function disableWakeupSource(source?: string): Result<void, SleepError>
-```
-
-Disable a specific wakeup source (`"timer"`, `"ext0"`, `"ext1"`, `"gpio"`, `"touchpad"`, `"ulp"`), or all sources if no argument is given.
-
-## Errors
-
-### SleepError
-
-| Variant               | Fields    | Description                         |
-| --------------------- | --------- | ----------------------------------- |
-| `WakeupConfigFailed`  | `message` | Failed to configure a wakeup source |
-| `LightSleepFailed`    | `message` | Light sleep failed to enter         |
-| `DisableWakeupFailed` | `message` | Failed to disable a wakeup source   |
+Returns `true` on every chip mikrojs targets except ESP32-C3. C3 has neither EXT0 nor EXT1; deep-sleep wake on C3 is timer-only.

--- a/docs/api/sys.md
+++ b/docs/api/sys.md
@@ -77,6 +77,23 @@ function restart(): never
 
 Restarts the device immediately.
 
+### getWakeupCause()
+
+```ts
+function getWakeupCause(): string
+```
+
+Returns why the device booted. Useful for branching logic right after a deep sleep cycle.
+
+```ts twoslash
+import {getWakeupCause} from 'mikrojs/sys'
+// ---cut---
+const cause = getWakeupCause()
+console.log('Woke up because: %s', cause)
+```
+
+Possible values: `'timer'`, `'ext0'`, `'ext1'`, `'gpio'`, or `'undefined'` (cold boot or unknown).
+
 ### exit(exitCode?)
 
 ```ts

--- a/docs/developing-for-microcontrollers.md
+++ b/docs/developing-for-microcontrollers.md
@@ -128,7 +128,7 @@ Once you've found the hot spot, the fix is usually one of:
 Deep sleep drops power draw from ~80-160mA to ~10-20µA. The tradeoff: the CPU resets on wake, so your program starts from scratch.
 
 ```ts twoslash
-import {deepSleep, enableTimerWakeup} from 'mikrojs/sleep'
+import {deepSleep} from 'mikrojs/sleep'
 import {rtcStorage} from 'mikrojs/kv/rtc'
 import * as s from 'mikrojs/schema'
 
@@ -140,7 +140,7 @@ readings.update((n) => (n ?? 0) + 1)
 // Do your work (read sensor, send data, etc.)
 
 // Sleep for 5 minutes
-deepSleep(5 * 60 * 1_000_000)
+deepSleep({timer: 5 * 60 * 1000})
 ```
 
 Use [`rtcStorage`](/api/kv) to persist state across sleep cycles. It survives deep sleep but not power loss.

--- a/docs/examples/rtc-counter.md
+++ b/docs/examples/rtc-counter.md
@@ -34,7 +34,7 @@ await sleep(5000)
 
 // Sleep for 15 seconds, then wake up again
 console.log('Going to deep sleep for 15s...')
-deepSleep(15000)
+deepSleep({timer: 15_000})
 ```
 
 ## Walkthrough
@@ -45,7 +45,7 @@ deepSleep(15000)
 
 3. **Update.** `count.update(fn)` reads, transforms, and writes atomically. Returns a [`Result`](/api/result), so `.orPanic()` halts with a clear message if the write fails.
 
-4. **Deep sleep.** `deepSleep(15000)` powers down the CPU for 15 seconds. RTC memory is preserved; everything else is lost. On wake, the script runs from the top.
+4. **Deep sleep.** `deepSleep({timer: 15_000})` powers down the CPU for 15 seconds (the value is in milliseconds). RTC memory is preserved; everything else is lost. On wake, the script runs from the top.
 
 ## Create project
 

--- a/examples/rtc-counter/app/main.ts
+++ b/examples/rtc-counter/app/main.ts
@@ -17,4 +17,4 @@ await sleep(5000)
 
 // Sleep for 15 seconds, then wake up again
 console.log('Going to deep sleep for 15s...')
-deepSleep(15000)
+deepSleep({timer: 15_000})

--- a/examples/sleep/.gitignore
+++ b/examples/sleep/.gitignore
@@ -1,0 +1,6 @@
+.env
+.env.*
+.DS_Store
+node_modules
+build
+.mikro

--- a/examples/sleep/README.md
+++ b/examples/sleep/README.md
@@ -1,0 +1,36 @@
+# Sleep
+
+One entry per `<sleep-type>` × `<wake-source>` combination. Designed to work out of the box on any **Seeed XIAO ESP32** board (C6, S3, and friends) — `app/led.ts` picks the right built-in LED pin by `board.chip`, and the wake pins are chosen to be valid across XIAO chips.
+
+## Entries
+
+| File                 | Sleep | Wake source(s)                       | Notes                     |
+| -------------------- | ----- | ------------------------------------ | ------------------------- |
+| `app/light-timer.ts` | light | timer                                | Default entry.            |
+| `app/light-gpio.ts`  | light | timer + GPIO 17 pulled LOW           | Any GPIO works.           |
+| `app/deep-timer.ts`  | deep  | timer                                | Chip resets on wake.      |
+| `app/deep-ext0.ts`   | deep  | timer + single RTC GPIO 0 pulled LOW | **ESP32 / S2 / S3 only.** |
+| `app/deep-ext1.ts`   | deep  | timer + multi RTC GPIO 0 pulled LOW  | Skipped on C3 (no EXT1).  |
+
+The `ext0` and `ext1` examples gate on `canWakeFromExt0()` / `canWakeFromExt1()` from `mikrojs/sleep`, so they print a "try the other entry" hint instead of crashing on chips that don't support that wake path.
+
+## Run
+
+```sh
+pnpm mikro dev                       # default: light-timer.ts
+pnpm mikro dev app/light-timer.ts
+pnpm mikro dev app/light-gpio.ts
+pnpm mikro dev app/deep-timer.ts
+pnpm mikro dev app/deep-ext0.ts      # ESP32 / S2 / S3 only
+pnpm mikro dev app/deep-ext1.ts
+```
+
+## Wiring
+
+- `light-gpio.ts`: button or jumper between **GPIO 17** and **GND**. Labelled **D7** on the XIAO ESP32-C6 header, **D6** on the XIAO ESP32-S3. The internal pull-up keeps the pin HIGH when idle; grounding it triggers wake. Light-sleep wake works on any GPIO.
+- `deep-ext0.ts`: button or jumper between **GPIO 0** and **GND**. **ESP32 / S2 / S3 only** — throws "EXT0 wakeup is not supported on this chip" on C6/C3/H2. mikrojs configures the internal RTC pull-up automatically.
+- `deep-ext1.ts`: button or jumper between **GPIO 0** and **GND**. Labelled **D0** on the XIAO ESP32-C6, **D1** on the XIAO ESP32-S3. mikrojs configures the chip's internal RTC pull (up for `any-low`, down for `any-high`) automatically.
+
+## Porting to a non-XIAO board
+
+`app/led.ts` knows the built-in LED pin for the chips listed in `LED_PIN_BY_CHIP`. On any other chip it falls back to GPIO 15 with a runtime warning. If your board's LED is on a different pin, add an entry to that map (or just edit the fallback).

--- a/examples/sleep/app/deep-ext0.ts
+++ b/examples/sleep/app/deep-ext0.ts
@@ -1,0 +1,43 @@
+// Deep sleep with EXT0 (single RTC-GPIO) wakeup.
+//
+// EXT0 is the single-pin counterpart to EXT1. On chips that support
+// it (ESP32, ESP32-S2, ESP32-S3) it's the simplest way to wake from
+// deep sleep with a button press. **EXT0 is NOT supported on
+// ESP32-C3, C6, or H2** — those chips only have EXT1. On unsupported
+// chips this script prints a note and exits without sleeping; use
+// `deep-ext1.ts` instead.
+//
+// Boot blinks the LED 3× so each wake-and-reboot cycle is visible.
+//
+// To wake: pull GPIO 0 LOW — touch it to GND with a jumper wire, or
+// wire a button between GPIO 0 and GND. mikrojs enables the chip's
+// internal RTC pull-up for you, so no external resistor is needed.
+// (Adjust the pin to a free RTC-capable pin on your board if 0 is
+// already used by a strapping function on that chip.)
+//
+// Deep sleep resets the chip on wake, so this whole script runs
+// from the top after each wake. `getWakeupCause()` reports 'ext0'
+// or 'timer'.
+//
+// Run with: pnpm mikro dev app/deep-ext0.ts
+import {canWakeFromExt0, deepSleep, sleep} from 'mikrojs/sleep'
+import {board, getWakeupCause} from 'mikrojs/sys'
+
+import {blinkLed} from './led.js'
+
+const BUTTON = 0 // RTC-capable on ESP32 / S2 / S3
+
+await blinkLed()
+
+console.log('Boot — wakeup cause: %s', getWakeupCause())
+
+if (!canWakeFromExt0()) {
+  console.log(`EXT0 wakeup is not supported on ${board.chip}. Try app/deep-ext1.ts instead.`)
+} else {
+  await sleep(500)
+  console.log(`Deep sleeping. Pull GPIO ${BUTTON} LOW to wake (or wait 10 s)…`)
+  deepSleep({
+    ext0: {pin: BUTTON, level: 'low'},
+    timer: 10_000,
+  })
+}

--- a/examples/sleep/app/deep-ext1.ts
+++ b/examples/sleep/app/deep-ext1.ts
@@ -1,0 +1,41 @@
+// Deep sleep with EXT1 (RTC-GPIO) wakeup.
+//
+// Boot blinks the LED 3× so each wake-and-reboot cycle is visible.
+// Deep sleep cuts the digital domain — LED stays off.
+//
+// To wake: pull GPIO 0 LOW — touch it to GND with a jumper wire, or
+// wire a button between the pin and GND. mikrojs enables the chip's
+// internal RTC pull-up for you (opposite to the wake direction), so
+// no external resistor is needed.
+//
+// GPIO 0 is RTC-capable on every XIAO ESP32 board that supports
+// EXT1. On the XIAO header it's labelled D0 on the C6 and D1 on the
+// S3 — same chip pin, different silkscreen.
+//
+// Deep sleep resets the chip on wake, so this whole script runs
+// from the top after each wake. `getWakeupCause()` tells you which
+// source fired ('ext1' or 'timer').
+//
+// Run with: pnpm mikro dev app/deep-ext1.ts
+import {canWakeFromExt1, deepSleep, sleep} from 'mikrojs/sleep'
+import {board, getWakeupCause} from 'mikrojs/sys'
+
+import {blinkLed} from './led.js'
+
+const BUTTON = 0 // RTC-capable on every XIAO chip with EXT1
+
+await blinkLed()
+
+console.log('Boot — wakeup cause: %s', getWakeupCause())
+
+if (!canWakeFromExt1()) {
+  // ESP32-C3 has neither EXT0 nor EXT1 — only timer/gpio sources.
+  console.log(`EXT1 wakeup is not supported on ${board.chip}. Try app/deep-timer.ts instead.`)
+} else {
+  await sleep(500)
+  console.log(`Deep sleeping. Pull GPIO ${BUTTON} LOW to wake (or wait 10 s)…`)
+  deepSleep({
+    ext1: {pins: [BUTTON], mode: 'any-low'},
+    timer: 10_000,
+  })
+}

--- a/examples/sleep/app/deep-timer.ts
+++ b/examples/sleep/app/deep-timer.ts
@@ -1,0 +1,20 @@
+// Deep sleep with timer wakeup.
+//
+// Deep sleep cuts power to almost everything, so on wake the chip
+// resets and this script runs from the top again. Boot blinks the
+// LED 3× so each cycle is visible.
+//
+// Run with: pnpm mikro dev app/deep-timer.ts
+import {deepSleep, sleep} from 'mikrojs/sleep'
+import {getWakeupCause} from 'mikrojs/sys'
+
+import {blinkLed} from './led.js'
+
+await blinkLed()
+
+console.log('Boot — wakeup cause: %s', getWakeupCause())
+
+await sleep(1000)
+
+console.log('Deep sleeping for 5 s (chip will reset on wake)…')
+deepSleep(5_000)

--- a/examples/sleep/app/led.ts
+++ b/examples/sleep/app/led.ts
@@ -1,0 +1,24 @@
+// Tiny LED helper shared by the sleep examples. Drives the built-in
+// user LED via the chip-aware `pins` map. All known XIAO LEDs are
+// active-low (write 0 = on, 1 = off), so `setLed(true)` lights it up.
+
+import {digitalWrite, pinMode} from 'mikrojs/pin'
+import {sleep} from 'mikrojs/sleep'
+
+import {pins} from './pins.js'
+
+pinMode(pins.led, 'OUTPUT').orPanic('Failed to configure LED')
+
+export function setLed(on: boolean): void {
+  digitalWrite(pins.led, on ? 0 : 1).orPanic('LED write failed')
+}
+
+/** Blink the LED `count` times with `durationMs` on each phase. */
+export async function blinkLed(count = 3, durationMs = 100): Promise<void> {
+  for (let i = 0; i < count; i++) {
+    setLed(true)
+    await sleep(durationMs)
+    setLed(false)
+    await sleep(durationMs)
+  }
+}

--- a/examples/sleep/app/light-gpio.ts
+++ b/examples/sleep/app/light-gpio.ts
@@ -1,0 +1,41 @@
+// Light sleep with GPIO wakeup.
+//
+// Boot blinks the LED 3× so you can confirm the firmware is running.
+//
+// To wake: pull the **D7** header pad LOW — touch it to GND with a
+// jumper wire, or wire a button between D7 and GND. The internal
+// pull-up holds the pin HIGH when idle, so no external resistor is
+// needed. The chip also wakes on the 10-second timer as a fallback.
+//
+// D7 maps to a different chip pin on each XIAO board (see app/pins.ts).
+// Light-sleep GPIO wake works on any GPIO, so swap in whichever
+// header pin is convenient on your breadboard.
+//
+// Run with: pnpm mikro dev app/light-gpio.ts
+import {pinMode} from 'mikrojs/pin'
+import {lightSleep, sleep} from 'mikrojs/sleep'
+import {getWakeupCause} from 'mikrojs/sys'
+
+import {blinkLed} from './led.js'
+import {pins} from './pins.js'
+
+pinMode(pins.buttonPin, 'INPUT_PULLUP').orPanic('Failed to configure button pin')
+await blinkLed()
+
+console.log('Boot — wakeup cause: %s', getWakeupCause())
+
+for (let i = 1; i <= 5; i++) {
+  console.log(`[${i}/5] Sleeping. Pull D7 (GPIO ${pins.buttonPin}) LOW to wake (or wait 10 s)…`)
+  lightSleep({
+    gpio: {pin: pins.buttonPin, level: 'low'},
+    timer: 10_000,
+  })
+  // note: need a little delay so dev console can reconnect
+  await sleep(500)
+
+  console.log('Woke — cause: %s', getWakeupCause())
+  // Debounce so a held button doesn't immediately re-wake.
+  await sleep(300)
+}
+
+console.log('Done.')

--- a/examples/sleep/app/light-timer.ts
+++ b/examples/sleep/app/light-timer.ts
@@ -1,0 +1,33 @@
+// Light sleep with timer wakeup.
+//
+// Execution resumes from the same line after waking — no chip reset.
+// Boot blinks the LED 3× so you can confirm the firmware is running.
+//
+// Why the `await sleep(5_000)` between iterations:
+// On USJ-console chips (C3/C5/C6/S3/…) `lightSleep` detaches USB so
+// `mikro dev` sees a clean disconnect and re-enumerates on wake. Host
+// re-enumeration takes ~3–5 s on macOS. Without an awake window, the
+// loop calls `lightSleep` again before the host has reopened the port,
+// and every `console.log` between iterations is dropped. The 5 s pause
+// holds the USB connection up long enough for the host to catch up.
+// On battery/standalone this whole concern goes away — drop the pause.
+//
+// Run with: pnpm mikro dev app/light-timer.ts
+import {lightSleep, sleep} from 'mikrojs/sleep'
+import {getWakeupCause} from 'mikrojs/sys'
+
+import {blinkLed} from './led.js'
+
+await blinkLed()
+
+console.log('Boot — wakeup cause: %s', getWakeupCause())
+
+for (let i = 1; i <= 3; i++) {
+  console.log(`[${i}/3] Light sleeping for 2 s…`)
+  lightSleep(2_000)
+  // note: need a little delay so dev console can reconnect
+  await sleep(500)
+  console.log('Woke — cause: %s', getWakeupCause())
+}
+
+console.log('Done.')

--- a/examples/sleep/app/pins.ts
+++ b/examples/sleep/app/pins.ts
@@ -1,0 +1,33 @@
+// Per-board pin map for Seeed XIAO ESP32 boards. Picks the right
+// chip pin for each "role" the examples need (built-in LED, a free
+// GPIO behind the D7 header pad for the light-sleep button example,
+// etc.) based on `board.chip`.
+
+import {board} from 'mikrojs/sys'
+
+export interface XiaoPinMap {
+  /** Built-in user LED (active-low on every XIAO ESP32 board). */
+  led: number
+  /** Chip pin behind the **D7** header pad. Used by the light-sleep
+   *  GPIO-wake example as a known-free, breadboard-accessible pin
+   *  that supports INPUT_PULLUP. */
+  buttonPin: number
+}
+
+/** Add an entry here for any XIAO board not already listed. */
+const PINS_BY_CHIP: Record<string, XiaoPinMap> = {
+  esp32c5: {led: 27, buttonPin: 12},
+  esp32c6: {led: 15, buttonPin: 17},
+  esp32s3: {led: 21, buttonPin: 8},
+}
+
+const FALLBACK_CHIP = 'esp32c6'
+
+export const pins: XiaoPinMap = PINS_BY_CHIP[board.chip] ?? PINS_BY_CHIP[FALLBACK_CHIP]!
+
+if (!(board.chip in PINS_BY_CHIP)) {
+  console.warn(
+    `No XIAO pin map known for ${board.chip}; falling back to ${FALLBACK_CHIP} defaults. ` +
+      `Edit app/pins.ts to add a mapping for your board.`,
+  )
+}

--- a/examples/sleep/mikro.config.ts
+++ b/examples/sleep/mikro.config.ts
@@ -1,0 +1,5 @@
+import {defineConfig} from 'mikrojs'
+
+export default defineConfig({
+  logFile: true,
+})

--- a/examples/sleep/package.json
+++ b/examples/sleep/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "mikrojs-sleep-example",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Mikro.js sleep example: timer, GPIO, and EXT1 wakeups",
+  "license": "MIT",
+  "author": "Bjørge Næss <bjoerge@gmail.com>",
+  "files": [
+    "dist",
+    "app"
+  ],
+  "type": "module",
+  "main": "./app/light-timer.ts",
+  "scripts": {
+    "dev": "mikro dev"
+  },
+  "dependencies": {
+    "mikrojs": "workspace:*"
+  },
+  "mikrojs": {
+    "predeploy": [
+      "tsc --noEmit --pretty"
+    ]
+  }
+}

--- a/examples/sleep/tsconfig.json
+++ b/examples/sleep/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "module": "nodenext",
+    "target": "es2024",
+    "lib": ["ES2024"],
+    "noEmit": true,
+    "types": ["mikrojs/runtime"],
+    "sourceMap": true,
+    "noUncheckedIndexedAccess": true,
+    "erasableSyntaxOnly": true,
+    "strict": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noUncheckedSideEffectImports": true,
+    "moduleDetection": "force",
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "allowUnreachableCode": false
+  }
+}

--- a/knip.ts
+++ b/knip.ts
@@ -17,6 +17,13 @@ const config = {
       ignoreDependencies: ['@mikrojs/native', '@mikrojs/quickjs', 'esbuild'],
       ignore: ['resolve.js'],
     },
+    'examples/sleep': {
+      // Each app/*.ts file is a stand-alone entry — users pick one with
+      // `mikro dev app/<name>.ts`. Without this, only `main` from
+      // package.json counts as an entry and the rest get flagged as
+      // "unused".
+      entry: ['app/*.ts'],
+    },
     'packages/mikrojs': {
       entry: ['src/cli/cliWrapper.ts', 'src/cli/cli.ts', 'src/_exports/*.ts'],
       project: ['src/**/*.{ts,tsx}'],

--- a/packages/@mikrojs/firmware/components/mikrojs/include/mikrojs_esp32.h
+++ b/packages/@mikrojs/firmware/components/mikrojs/include/mikrojs_esp32.h
@@ -64,6 +64,16 @@ void mik_logfile_resume(void);
 /* Serial binary I/O (mik_serial_io.cpp) */
 void mik__serial_binary_begin_no_echo(void);
 
+/* Detach the USB Serial/JTAG peripheral from the host (uninstalls the
+ * driver and disables the PHY pad) so the CLI sees a clean disconnect
+ * before light sleep. No-op when the active console isn't USJ. */
+void mik__serial_io_detach_usb(void);
+
+/* Re-attach the USB Serial/JTAG peripheral after a prior detach. The
+ * host re-enumerates the device. No-op when the active console isn't
+ * USJ. */
+void mik__serial_io_attach_usb(void);
+
 /* Shared NVS helpers (mik_serial_io.cpp) */
 extern const char* MIK__NVS_NS_ENV;  /* env var values */
 extern const char* MIK__NVS_NS_SEC;  /* secret-flag markers (u8) */

--- a/packages/@mikrojs/firmware/components/mikrojs/mik_serial_io.cpp
+++ b/packages/@mikrojs/firmware/components/mikrojs/mik_serial_io.cpp
@@ -17,6 +17,8 @@
 
 #if SOC_USB_SERIAL_JTAG_SUPPORTED
 #include "driver/usb_serial_jtag.h"
+#include "esp_rom_sys.h"
+#include "hal/usb_serial_jtag_ll.h"
 /* mikrojs owns the USB-Serial/JTAG peripheral directly. Leaving
  * CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y would have ESP-IDF register a
  * VFS and write to the TX FIFO from stdio, racing our driver ISR. */
@@ -74,35 +76,41 @@ static enum { CONSOLE_UART, CONSOLE_USB_SERIAL_JTAG } s_console =
 static bool s_usj_installed = false;
 #endif
 
-void mik__console_init(void) {
 #if SOC_USB_SERIAL_JTAG_SUPPORTED
-    /* Install USB-Serial/JTAG via the public driver API only. No VFS
-     * registration, no `fileno(stdin)`, no newlib integration — that's
-     * the whole point of this path.
-     *
-     * Both rings are sized to fit the largest single TLV frame plus a
-     * little headroom for the next frame's header to land alongside it.
-     *
-     * RX (host → device): the largest single command frame is a
-     * CMD_DEPLOY_PUT_CHUNK (≤ 2 KB body + 5 B header). Deploy PUTs no
-     * longer carry the file body in one frame — they're streamed as
-     * begin + N chunks with per-chunk MSG_OK pacing — so this size is
-     * a function of the chunk size, not of the largest deployable file.
-     * 4 KB gives ~2× headroom over a single chunk so the next command
-     * can be queued behind it.
-     *
-     * TX (device → host): bumped from the IDF default (256 B) to 2 KB
-     * so MSG_READY resends during the boot-handshake window don't fill
-     * the ring before the CLI's TTY starts draining. At 256 B the ring
-     * fills after ~3 MSG_READY sends, then subsequent writes (including
-     * the MSG_OK response to the first CMD_RUNTIME_PAUSE) stall long
-     * enough to blow past the CLI's 10 s pause timeout and force a
-     * restart-and-retry on every `mikro dev`. 2 KB is still small
-     * enough not to meaningfully dent RAM for display-heavy apps. */
+/* Install USB-Serial/JTAG via the public driver API only. No VFS
+ * registration, no `fileno(stdin)`, no newlib integration — that's
+ * the whole point of this path.
+ *
+ * Both rings are sized to fit the largest single TLV frame plus a
+ * little headroom for the next frame's header to land alongside it.
+ *
+ * RX (host → device): the largest single command frame is a
+ * CMD_DEPLOY_PUT_CHUNK (≤ 2 KB body + 5 B header). Deploy PUTs no
+ * longer carry the file body in one frame — they're streamed as
+ * begin + N chunks with per-chunk MSG_OK pacing — so this size is
+ * a function of the chunk size, not of the largest deployable file.
+ * 4 KB gives ~2× headroom over a single chunk so the next command
+ * can be queued behind it.
+ *
+ * TX (device → host): bumped from the IDF default (256 B) to 2 KB
+ * so MSG_READY resends during the boot-handshake window don't fill
+ * the ring before the CLI's TTY starts draining. At 256 B the ring
+ * fills after ~3 MSG_READY sends, then subsequent writes (including
+ * the MSG_OK response to the first CMD_RUNTIME_PAUSE) stall long
+ * enough to blow past the CLI's 10 s pause timeout and force a
+ * restart-and-retry on every `mikro dev`. 2 KB is still small
+ * enough not to meaningfully dent RAM for display-heavy apps. */
+static bool mik__usj_install_with_default_config(void) {
     usb_serial_jtag_driver_config_t usj_cfg = USB_SERIAL_JTAG_DRIVER_CONFIG_DEFAULT();
     usj_cfg.rx_buffer_size = 4096;
     usj_cfg.tx_buffer_size = 2048;
-    s_usj_installed = (usb_serial_jtag_driver_install(&usj_cfg) == ESP_OK);
+    return usb_serial_jtag_driver_install(&usj_cfg) == ESP_OK;
+}
+#endif
+
+void mik__console_init(void) {
+#if SOC_USB_SERIAL_JTAG_SUPPORTED
+    s_usj_installed = mik__usj_install_with_default_config();
 #endif
 
 #if MIK_CONSOLE_HAS_UART
@@ -226,6 +234,84 @@ void mik__serial_binary_begin_no_echo(void) {
     esp_log_level_set("*", ESP_LOG_NONE);
     /* No line-ending translation to disable: we bypass VFS entirely,
      * so `\n` passes through unchanged on both USJ and UART paths. */
+}
+
+/* ── USB detach/attach for light sleep ─────────────────────────────
+ *
+ * Light sleep on USJ-console chips (C3, C6, S3, …) powers down the
+ * digital peripheral domain but leaves the USB device enumerated on
+ * the host. node-serialport doesn't see a close, so the CLI can't
+ * tell the difference between "device is busy" and "device is asleep".
+ *
+ * To make the disconnect visible we uninstall the driver and pull
+ * down the D+ pad before sleeping. On wake we restore the pad and
+ * re-install the driver. The host re-enumerates, the CLI's existing
+ * disconnect → reconnect path handles the rest. */
+
+void mik__serial_io_detach_usb(void) {
+#if SOC_USB_SERIAL_JTAG_SUPPORTED
+    if (s_console != CONSOLE_USB_SERIAL_JTAG) return;
+    if (!s_usj_installed) return;
+
+    /* USJ has no public flush API. A short delay covers TX-ring drain
+     * for the typical log-line-sized writes we send before sleeping. */
+    vTaskDelay(pdMS_TO_TICKS(20));
+
+    usb_serial_jtag_driver_uninstall();
+    s_usj_installed = false;
+
+    /* Force a host-visible disconnect by overriding D+/D- pulls to
+     * present SE0 on the bus. `usb_serial_jtag_ll_phy_enable_pad(false)`
+     * (which ESP-IDF's own sleep prep uses) only gates the internal pad
+     * routing for leakage — it does NOT release the host-visible 1.5 k
+     * D+ pullup, so the host still sees the device enumerated. The
+     * pull-override is the only mechanism in ESP-IDF v6.0.1 that
+     * actually triggers a re-enumerate. C6 has no `_SUPPORT_LIGHT_SLEEP`
+     * cap for USJ (IDF-6395 in soc_caps.h), so this is the supported
+     * path.
+     * Refs:
+     *   components/hal/include/hal/usb_serial_jtag_ll.h
+     *   docs.espressif.com/projects/esp-iot-solution/.../usb_serial_jtag.html
+     */
+    usb_serial_jtag_pull_override_vals_t off = {
+        .dp_pu = 0,
+        .dm_pu = 0,
+        .dp_pd = 1,
+        .dm_pd = 1,
+    };
+    usb_serial_jtag_ll_phy_enable_pull_override(&off);
+    /* >2.5 ms of SE0 so the host registers a disconnect rather than a
+     * USB suspend. 5 ms gives plenty of margin without meaningfully
+     * delaying sleep entry. */
+    esp_rom_delay_us(5000);
+#endif
+}
+
+void mik__serial_io_attach_usb(void) {
+#if SOC_USB_SERIAL_JTAG_SUPPORTED
+    if (s_console != CONSOLE_USB_SERIAL_JTAG) return;
+    if (s_usj_installed) return;
+
+    /* `disable_pull_override` only flips `pad_pull_override` back to 0;
+     * the `dp_pullup`/`dp_pulldown` register fields still hold the
+     * disconnect values from detach (D+ pullup off, D+ pulldown on),
+     * so the host sees no connect signal until the peripheral autopilots
+     * — which only happens reliably once the driver is active. Drive
+     * the override to an explicit "connect" state (D+ pullup on,
+     * everything else off) first so the host sees J-state immediately,
+     * install the driver while the override holds it, then release. */
+    usb_serial_jtag_pull_override_vals_t connect = {
+        .dp_pu = 1,
+        .dm_pu = 0,
+        .dp_pd = 0,
+        .dm_pd = 0,
+    };
+    usb_serial_jtag_ll_phy_enable_pull_override(&connect);
+
+    s_usj_installed = mik__usj_install_with_default_config();
+
+    usb_serial_jtag_ll_phy_disable_pull_override();
+#endif
 }
 
 /* ── NVS helpers ─────────────────────────────────────────────────── */

--- a/packages/@mikrojs/firmware/components/mikrojs/mik_sleep.cpp
+++ b/packages/@mikrojs/firmware/components/mikrojs/mik_sleep.cpp
@@ -1,9 +1,33 @@
 #include "driver/gpio.h"
+#include "driver/rtc_io.h"
 #include "esp_sleep.h"
 #include "soc/soc_caps.h"
 
 #include "mikrojs/private.h"
 #include "mikrojs/utils.h"
+#include "mikrojs_esp32.h"
+
+/* For deep-sleep wakeup, the chip's digital pad config (set by `pinMode`)
+ * doesn't persist — only the RTC-IO pad does. Without an explicit RTC
+ * pull, EXT0/EXT1 pins float and trigger spurious wakes. Configure the
+ * RTC pull to the opposite of the wake direction so the pin idles in
+ * the non-trigger state and a button press flips it. */
+static void mik__rtc_pull_for_wake(int pin, bool wake_on_high) {
+#if SOC_RTCIO_INPUT_OUTPUT_SUPPORTED
+    if (!rtc_gpio_is_valid_gpio(static_cast<gpio_num_t>(pin))) return;
+    gpio_num_t g = static_cast<gpio_num_t>(pin);
+    rtc_gpio_pullup_dis(g);
+    rtc_gpio_pulldown_dis(g);
+    if (wake_on_high) {
+        rtc_gpio_pulldown_en(g);
+    } else {
+        rtc_gpio_pullup_en(g);
+    }
+#else
+    (void)pin;
+    (void)wake_on_high;
+#endif
+}
 
 static const char* mik__wakeup_cause_str(uint32_t causes) {
     if (causes & BIT(ESP_SLEEP_WAKEUP_TIMER)) return "timer";
@@ -15,17 +39,197 @@ static const char* mik__wakeup_cause_str(uint32_t causes) {
     return "undefined";
 }
 
+/* ── Wakeup source configuration ───────────────────────────────────── */
+
+static bool mik__configure_timer(JSContext* ctx, JSValue sources) {
+    JSValue v = JS_GetPropertyStr(ctx, sources, "timer");
+    bool ok = true;
+    if (!JS_IsUndefined(v)) {
+        double ms;
+        if (JS_ToFloat64(ctx, &ms, v)) {
+            ok = false;
+        } else if (ms < 0) {
+            JS_ThrowRangeError(ctx, "timer must be >= 0");
+            ok = false;
+        } else {
+            uint64_t us = static_cast<uint64_t>(ms * 1000.0);
+            esp_err_t err = esp_sleep_enable_timer_wakeup(us);
+            if (err != ESP_OK) {
+                JS_ThrowInternalError(ctx, "timer wakeup failed: %s", esp_err_to_name(err));
+                ok = false;
+            }
+        }
+    }
+    JS_FreeValue(ctx, v);
+    return ok;
+}
+
+static bool mik__read_level(JSContext* ctx, JSValue obj, const char* key, int* out_level) {
+    JSValue v = JS_GetPropertyStr(ctx, obj, key);
+    const char* s = JS_ToCString(ctx, v);
+    JS_FreeValue(ctx, v);
+    if (!s) return false;
+    bool ok = true;
+    if (strcmp(s, "high") == 0)
+        *out_level = 1;
+    else if (strcmp(s, "low") == 0)
+        *out_level = 0;
+    else {
+        JS_ThrowRangeError(ctx, "%s must be 'high' or 'low'", key);
+        ok = false;
+    }
+    JS_FreeCString(ctx, s);
+    return ok;
+}
+
+static bool mik__configure_gpio(JSContext* ctx, JSValue sources) {
+    JSValue gpio = JS_GetPropertyStr(ctx, sources, "gpio");
+    if (JS_IsUndefined(gpio)) {
+        JS_FreeValue(ctx, gpio);
+        return true;
+    }
+
+    JSValue pin_val = JS_GetPropertyStr(ctx, gpio, "pin");
+    int32_t pin;
+    bool ok = !JS_ToInt32(ctx, &pin, pin_val);
+    JS_FreeValue(ctx, pin_val);
+
+    int level = 0;
+    if (ok) ok = mik__read_level(ctx, gpio, "level", &level);
+    JS_FreeValue(ctx, gpio);
+    if (!ok) return false;
+
+    gpio_int_type_t intr = (level == 1) ? GPIO_INTR_HIGH_LEVEL : GPIO_INTR_LOW_LEVEL;
+    esp_err_t err = gpio_wakeup_enable(static_cast<gpio_num_t>(pin), intr);
+    if (err != ESP_OK) {
+        JS_ThrowInternalError(ctx, "GPIO wakeup on pin %d failed: %s", pin, esp_err_to_name(err));
+        return false;
+    }
+    err = esp_sleep_enable_gpio_wakeup();
+    if (err != ESP_OK) {
+        JS_ThrowInternalError(ctx, "GPIO wakeup source failed: %s", esp_err_to_name(err));
+        return false;
+    }
+    return true;
+}
+
+static bool mik__configure_ext0(JSContext* ctx, JSValue sources) {
+    JSValue ext0 = JS_GetPropertyStr(ctx, sources, "ext0");
+    if (JS_IsUndefined(ext0)) {
+        JS_FreeValue(ctx, ext0);
+        return true;
+    }
+#if SOC_PM_SUPPORT_EXT0_WAKEUP
+    JSValue pin_val = JS_GetPropertyStr(ctx, ext0, "pin");
+    int32_t pin;
+    bool ok = !JS_ToInt32(ctx, &pin, pin_val);
+    JS_FreeValue(ctx, pin_val);
+
+    int level = 0;
+    if (ok) ok = mik__read_level(ctx, ext0, "level", &level);
+    JS_FreeValue(ctx, ext0);
+    if (!ok) return false;
+
+    mik__rtc_pull_for_wake(pin, level == 1);
+    esp_err_t err = esp_sleep_enable_ext0_wakeup(static_cast<gpio_num_t>(pin), level);
+    if (err != ESP_OK) {
+        JS_ThrowInternalError(ctx, "EXT0 wakeup on pin %d failed: %s", pin, esp_err_to_name(err));
+        return false;
+    }
+    return true;
+#else
+    JS_FreeValue(ctx, ext0);
+    JS_ThrowInternalError(ctx, "EXT0 wakeup is not supported on this chip");
+    return false;
+#endif
+}
+
+static bool mik__configure_ext1(JSContext* ctx, JSValue sources) {
+    JSValue ext1 = JS_GetPropertyStr(ctx, sources, "ext1");
+    if (JS_IsUndefined(ext1)) {
+        JS_FreeValue(ctx, ext1);
+        return true;
+    }
+#if SOC_PM_SUPPORT_EXT1_WAKEUP
+    JSValue pins_val = JS_GetPropertyStr(ctx, ext1, "pins");
+    JSValue len_val = JS_GetPropertyStr(ctx, pins_val, "length");
+    uint32_t pin_count;
+    bool ok = !JS_ToUint32(ctx, &pin_count, len_val);
+    JS_FreeValue(ctx, len_val);
+
+    uint64_t pin_mask = 0;
+    for (uint32_t i = 0; ok && i < pin_count; i++) {
+        JSValue pin_val = JS_GetPropertyUint32(ctx, pins_val, i);
+        int32_t pin;
+        if (JS_ToInt32(ctx, &pin, pin_val))
+            ok = false;
+        else
+            pin_mask |= (1ULL << pin);
+        JS_FreeValue(ctx, pin_val);
+    }
+    JS_FreeValue(ctx, pins_val);
+
+    int mode_value = 0;
+    if (ok) {
+        JSValue mode_val = JS_GetPropertyStr(ctx, ext1, "mode");
+        const char* mode_str = JS_ToCString(ctx, mode_val);
+        JS_FreeValue(ctx, mode_val);
+        if (!mode_str) {
+            ok = false;
+        } else {
+            if (strcmp(mode_str, "any-low") == 0)
+                mode_value = ESP_EXT1_WAKEUP_ANY_LOW;
+            else if (strcmp(mode_str, "any-high") == 0)
+                mode_value = ESP_EXT1_WAKEUP_ANY_HIGH;
+            else {
+                JS_ThrowRangeError(ctx, "ext1.mode must be 'any-low' or 'any-high'");
+                ok = false;
+            }
+            JS_FreeCString(ctx, mode_str);
+        }
+    }
+    JS_FreeValue(ctx, ext1);
+    if (!ok) return false;
+
+    const bool wake_on_high = mode_value == ESP_EXT1_WAKEUP_ANY_HIGH;
+    for (int pin = 0; pin < 64; pin++) {
+        if (pin_mask & (1ULL << pin)) {
+            mik__rtc_pull_for_wake(pin, wake_on_high);
+        }
+    }
+    esp_err_t err = esp_sleep_enable_ext1_wakeup(
+        pin_mask, static_cast<esp_sleep_ext1_wakeup_mode_t>(mode_value));
+    if (err != ESP_OK) {
+        JS_ThrowInternalError(ctx, "EXT1 wakeup failed: %s", esp_err_to_name(err));
+        return false;
+    }
+    return true;
+#else
+    JS_FreeValue(ctx, ext1);
+    JS_ThrowInternalError(ctx, "EXT1 wakeup is not supported on this chip");
+    return false;
+#endif
+}
+
+/* Clears any previously-configured sources, then applies the ones in
+ * `sources`. Throws and returns false on any error. */
+static bool mik__configure_wakeup_sources(JSContext* ctx, JSValue sources) {
+    if (!JS_IsObject(sources)) {
+        JS_ThrowTypeError(ctx, "wakeup sources must be an object");
+        return false;
+    }
+    esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_ALL);
+    if (!mik__configure_timer(ctx, sources)) return false;
+    if (!mik__configure_gpio(ctx, sources)) return false;
+    if (!mik__configure_ext0(ctx, sources)) return false;
+    if (!mik__configure_ext1(ctx, sources)) return false;
+    return true;
+}
+
 /* ── native:sleep JS module ─────────────────────────────────────────── */
 
 static JSValue mik__sleep_deep(JSContext* ctx, JSValue this_val, int argc, JSValue* argv) {
-    int64_t ms;
-    if (JS_ToInt64(ctx, &ms, argv[0])) return JS_EXCEPTION;
-
-    if (ms > 0) {
-        esp_err_t err = esp_sleep_enable_timer_wakeup(static_cast<uint64_t>(ms) * 1000);
-        if (err != ESP_OK)
-            return JS_ThrowInternalError(ctx, "timer wakeup failed: %s", esp_err_to_name(err));
-    }
+    if (!mik__configure_wakeup_sources(ctx, argv[0])) return JS_EXCEPTION;
 
     /* Note: we intentionally do NOT call MIK_FreeRuntime() here.  We are inside
      * a JS function call, so the runtime still has live GC objects on the call
@@ -37,23 +241,19 @@ static JSValue mik__sleep_deep(JSContext* ctx, JSValue this_val, int argc, JSVal
 }
 
 static JSValue mik__sleep_light(JSContext* ctx, JSValue this_val, int argc, JSValue* argv) {
-    int64_t ms;
-    if (JS_ToInt64(ctx, &ms, argv[0])) return JS_EXCEPTION;
+    if (!mik__configure_wakeup_sources(ctx, argv[0])) return JS_EXCEPTION;
 
-    if (ms > 0) {
-        esp_err_t err = esp_sleep_enable_timer_wakeup(static_cast<uint64_t>(ms) * 1000);
-        if (err != ESP_OK)
-            return mik__result_err_named(ctx, "WakeupConfigFailed",
-                                         "failed to enable timer wakeup: %s",
-                                         esp_err_to_name(err));
-    }
-
+    /* Tear down USB before sleeping so the host sees a clean unplug,
+     * not a silent enumerated-but-asleep device. This lets `mikro dev`
+     * trigger its existing reconnect path. Restored after wake. */
+    mik__serial_io_detach_usb();
     esp_err_t err = esp_light_sleep_start();
-    if (err != ESP_OK)
-        return mik__result_err_named(ctx, "LightSleepFailed",
-                                     "light sleep failed: %s", esp_err_to_name(err));
+    mik__serial_io_attach_usb();
 
-    return mik__result_ok_void(ctx);
+    if (err != ESP_OK)
+        return JS_ThrowInternalError(ctx, "light sleep failed: %s", esp_err_to_name(err));
+
+    return JS_UNDEFINED;
 }
 
 static JSValue mik__sleep_get_wakeup_cause(JSContext* ctx, JSValue this_val, int argc,
@@ -62,124 +262,22 @@ static JSValue mik__sleep_get_wakeup_cause(JSContext* ctx, JSValue this_val, int
     return JS_NewString(ctx, mik__wakeup_cause_str(causes));
 }
 
-static JSValue mik__sleep_enable_timer_wakeup(JSContext* ctx, JSValue this_val, int argc,
-                                               JSValue* argv) {
-    int64_t us;
-    if (JS_ToInt64(ctx, &us, argv[0])) return JS_EXCEPTION;
-
-    esp_err_t err = esp_sleep_enable_timer_wakeup(static_cast<uint64_t>(us));
-    if (err != ESP_OK)
-        return mik__result_err_named(ctx, "WakeupConfigFailed",
-                                     "failed to enable timer wakeup: %s", esp_err_to_name(err));
-
-    return mik__result_ok_void(ctx);
-}
-
-static JSValue mik__sleep_enable_gpio_wakeup(JSContext* ctx, JSValue this_val, int argc,
+static JSValue mik__sleep_can_wake_from_ext0(JSContext* ctx, JSValue this_val, int argc,
                                               JSValue* argv) {
-    int32_t pin, level;
-    if (JS_ToInt32(ctx, &pin, argv[0])) return JS_EXCEPTION;
-    if (JS_ToInt32(ctx, &level, argv[1])) return JS_EXCEPTION;
-
-    esp_err_t err =
-        gpio_wakeup_enable(static_cast<gpio_num_t>(pin), static_cast<gpio_int_type_t>(level));
-    if (err != ESP_OK)
-        return mik__result_err_named(ctx, "WakeupConfigFailed",
-                                     "failed to enable GPIO wakeup on pin %d: %s", pin,
-                                     esp_err_to_name(err));
-
-    err = esp_sleep_enable_gpio_wakeup();
-    if (err != ESP_OK)
-        return mik__result_err_named(ctx, "WakeupConfigFailed",
-                                     "failed to enable GPIO wakeup source: %s",
-                                     esp_err_to_name(err));
-
-    return mik__result_ok_void(ctx);
-}
-
-/* EXT0 / EXT1 wakeup is chip-specific (not on ESP32-C3, C6, H2). We still
- * register the JS exports unconditionally so `mikrojs/sleep`'s static
- * re-exports resolve on every target; the function bodies return a
- * `WakeupConfigFailed` error on chips where the capability is missing. */
-static JSValue mik__sleep_enable_ext0_wakeup(JSContext* ctx, JSValue this_val, int argc,
-                                             JSValue* argv) {
 #if SOC_PM_SUPPORT_EXT0_WAKEUP
-    int32_t pin, level;
-    if (JS_ToInt32(ctx, &pin, argv[0])) return JS_EXCEPTION;
-    if (JS_ToInt32(ctx, &level, argv[1])) return JS_EXCEPTION;
-
-    esp_err_t err = esp_sleep_enable_ext0_wakeup(static_cast<gpio_num_t>(pin), level);
-    if (err != ESP_OK)
-        return mik__result_err_named(ctx, "WakeupConfigFailed",
-                                     "failed to enable EXT0 wakeup on pin %d: %s", pin,
-                                     esp_err_to_name(err));
-
-    return mik__result_ok_void(ctx);
+    return JS_TRUE;
 #else
-    return mik__result_err_named(ctx, "WakeupConfigFailed",
-                                 "EXT0 wakeup is not supported on this chip");
+    return JS_FALSE;
 #endif
 }
 
-static JSValue mik__sleep_enable_ext1_wakeup(JSContext* ctx, JSValue this_val, int argc,
-                                             JSValue* argv) {
+static JSValue mik__sleep_can_wake_from_ext1(JSContext* ctx, JSValue this_val, int argc,
+                                              JSValue* argv) {
 #if SOC_PM_SUPPORT_EXT1_WAKEUP
-    int64_t pin_mask;
-    int32_t mode;
-    if (JS_ToInt64(ctx, &pin_mask, argv[0])) return JS_EXCEPTION;
-    if (JS_ToInt32(ctx, &mode, argv[1])) return JS_EXCEPTION;
-
-    esp_err_t err = esp_sleep_enable_ext1_wakeup(static_cast<uint64_t>(pin_mask),
-                                                  static_cast<esp_sleep_ext1_wakeup_mode_t>(mode));
-    if (err != ESP_OK)
-        return mik__result_err_named(ctx, "WakeupConfigFailed",
-                                     "failed to enable EXT1 wakeup: %s", esp_err_to_name(err));
-
-    return mik__result_ok_void(ctx);
+    return JS_TRUE;
 #else
-    return mik__result_err_named(ctx, "WakeupConfigFailed",
-                                 "EXT1 wakeup is not supported on this chip");
+    return JS_FALSE;
 #endif
-}
-
-static JSValue mik__sleep_disable_wakeup_source(JSContext* ctx, JSValue this_val, int argc,
-                                                 JSValue* argv) {
-    esp_sleep_source_t source = ESP_SLEEP_WAKEUP_ALL;
-
-    if (argc > 0 && !JS_IsUndefined(argv[0])) {
-        const char* str = JS_ToCString(ctx, argv[0]);
-        if (!str) return JS_EXCEPTION;
-
-        bool valid = true;
-        if (strcmp(str, "timer") == 0)
-            source = ESP_SLEEP_WAKEUP_TIMER;
-        else if (strcmp(str, "ext0") == 0)
-            source = ESP_SLEEP_WAKEUP_EXT0;
-        else if (strcmp(str, "ext1") == 0)
-            source = ESP_SLEEP_WAKEUP_EXT1;
-        else if (strcmp(str, "gpio") == 0)
-            source = ESP_SLEEP_WAKEUP_GPIO;
-        else if (strcmp(str, "touchpad") == 0)
-            source = ESP_SLEEP_WAKEUP_TOUCHPAD;
-        else if (strcmp(str, "ulp") == 0)
-            source = ESP_SLEEP_WAKEUP_ULP;
-        else
-            valid = false;
-
-        if (!valid) {
-            JSValue err = JS_ThrowRangeError(ctx, "unknown wakeup source: %s", str);
-            JS_FreeCString(ctx, str);
-            return err;
-        }
-        JS_FreeCString(ctx, str);
-    }
-
-    esp_err_t err = esp_sleep_disable_wakeup_source(source);
-    if (err != ESP_OK)
-        return mik__result_err_named(ctx, "DisableWakeupFailed",
-                                     "failed to disable wakeup source: %s", esp_err_to_name(err));
-
-    return mik__result_ok_void(ctx);
 }
 
 /* ── Module init ─────────────────────────────────────────────────── */
@@ -192,20 +290,11 @@ static int mik__sleep_module_init(JSContext* ctx, JSModuleDef* m) {
     JS_SetModuleExport(ctx, m, "getWakeupCause",
                        JS_NewCFunction(ctx, mik__sleep_get_wakeup_cause, "getWakeupCause", 0));
     JS_SetModuleExport(
-        ctx, m, "enableTimerWakeup",
-        JS_NewCFunction(ctx, mik__sleep_enable_timer_wakeup, "enableTimerWakeup", 1));
+        ctx, m, "canWakeFromExt0",
+        JS_NewCFunction(ctx, mik__sleep_can_wake_from_ext0, "canWakeFromExt0", 0));
     JS_SetModuleExport(
-        ctx, m, "enableGpioWakeup",
-        JS_NewCFunction(ctx, mik__sleep_enable_gpio_wakeup, "enableGpioWakeup", 2));
-    JS_SetModuleExport(
-        ctx, m, "enableExt0Wakeup",
-        JS_NewCFunction(ctx, mik__sleep_enable_ext0_wakeup, "enableExt0Wakeup", 2));
-    JS_SetModuleExport(
-        ctx, m, "enableExt1Wakeup",
-        JS_NewCFunction(ctx, mik__sleep_enable_ext1_wakeup, "enableExt1Wakeup", 2));
-    JS_SetModuleExport(
-        ctx, m, "disableWakeupSource",
-        JS_NewCFunction(ctx, mik__sleep_disable_wakeup_source, "disableWakeupSource", 1));
+        ctx, m, "canWakeFromExt1",
+        JS_NewCFunction(ctx, mik__sleep_can_wake_from_ext1, "canWakeFromExt1", 0));
     return 0;
 }
 
@@ -215,11 +304,8 @@ static JSModuleDef* mik__sleep_init(JSContext* ctx) {
     JS_AddModuleExport(ctx, m, "deepSleep");
     JS_AddModuleExport(ctx, m, "lightSleep");
     JS_AddModuleExport(ctx, m, "getWakeupCause");
-    JS_AddModuleExport(ctx, m, "enableTimerWakeup");
-    JS_AddModuleExport(ctx, m, "enableGpioWakeup");
-    JS_AddModuleExport(ctx, m, "enableExt0Wakeup");
-    JS_AddModuleExport(ctx, m, "enableExt1Wakeup");
-    JS_AddModuleExport(ctx, m, "disableWakeupSource");
+    JS_AddModuleExport(ctx, m, "canWakeFromExt0");
+    JS_AddModuleExport(ctx, m, "canWakeFromExt1");
     return m;
 }
 

--- a/packages/@mikrojs/firmware/components/mikrojs/test/sleep_test.cpp
+++ b/packages/@mikrojs/firmware/components/mikrojs/test/sleep_test.cpp
@@ -31,26 +31,17 @@ TEST_CASE("native:sleep exports expected functions", "[modules]") {
     setup();
 
     JSValue ret = eval_module(R"(
-        import {
-            deepSleep, lightSleep, getWakeupCause,
-            enableTimerWakeup, enableGpioWakeup,
-            disableWakeupSource
-        } from "native:sleep";
+        import { deepSleep, lightSleep, getWakeupCause } from "native:sleep";
         globalThis.__deepSleep = typeof deepSleep === "function";
         globalThis.__lightSleep = typeof lightSleep === "function";
         globalThis.__getWakeupCause = typeof getWakeupCause === "function";
-        globalThis.__enableTimerWakeup = typeof enableTimerWakeup === "function";
-        globalThis.__enableGpioWakeup = typeof enableGpioWakeup === "function";
-        globalThis.__disableWakeupSource = typeof disableWakeupSource === "function";
     )");
     TEST_ASSERT_FALSE_MESSAGE(JS_IsException(ret), "Module eval should not throw");
 
     JSValue global = JS_GetGlobalObject(ctx);
 
-    const char* names[] = {"__deepSleep",          "__lightSleep",    "__getWakeupCause",
-                           "__enableTimerWakeup",   "__enableGpioWakeup",
-                           "__disableWakeupSource"};
-    for (int i = 0; i < 6; i++) {
+    const char* names[] = {"__deepSleep", "__lightSleep", "__getWakeupCause"};
+    for (int i = 0; i < 3; i++) {
         JSValue v = JS_GetPropertyStr(ctx, global, names[i]);
         TEST_ASSERT_TRUE_MESSAGE(JS_ToBool(ctx, v), names[i]);
         JS_FreeValue(ctx, v);
@@ -92,77 +83,15 @@ TEST_CASE("native:sleep getWakeupCause returns a string", "[modules]") {
     teardown();
 }
 
-/* ── enableTimerWakeup accepts microseconds ──────────────────────── */
+/* ── invalid gpio.level throws RangeError ────────────────────────── */
 
-TEST_CASE("native:sleep enableTimerWakeup does not throw", "[modules]") {
+TEST_CASE("native:sleep lightSleep throws RangeError on invalid level", "[modules]") {
     setup();
 
     JSValue ret = eval_module(R"(
-        import { enableTimerWakeup } from "native:sleep";
-        enableTimerWakeup(5000000);
-        globalThis.__ok = true;
-    )");
-    TEST_ASSERT_FALSE_MESSAGE(JS_IsException(ret), "Module eval should not throw");
-
-    JSValue global = JS_GetGlobalObject(ctx);
-    JSValue ok = JS_GetPropertyStr(ctx, global, "__ok");
-    TEST_ASSERT_TRUE_MESSAGE(JS_ToBool(ctx, ok), "enableTimerWakeup should succeed");
-    JS_FreeValue(ctx, ok);
-    JS_FreeValue(ctx, global);
-    teardown();
-}
-
-/* ── disableWakeupSource works ───────────────────────────────────── */
-
-TEST_CASE("native:sleep disableWakeupSource clears all sources", "[modules]") {
-    setup();
-
-    JSValue ret = eval_module(R"(
-        import { enableTimerWakeup, disableWakeupSource } from "native:sleep";
-        enableTimerWakeup(1000000);
-        disableWakeupSource();
-        globalThis.__ok = true;
-    )");
-    TEST_ASSERT_FALSE_MESSAGE(JS_IsException(ret), "Module eval should not throw");
-
-    JSValue global = JS_GetGlobalObject(ctx);
-    JSValue ok = JS_GetPropertyStr(ctx, global, "__ok");
-    TEST_ASSERT_TRUE_MESSAGE(JS_ToBool(ctx, ok), "disableWakeupSource should succeed");
-    JS_FreeValue(ctx, ok);
-    JS_FreeValue(ctx, global);
-    teardown();
-}
-
-/* ── disableWakeupSource with specific source ────────────────────── */
-
-TEST_CASE("native:sleep disableWakeupSource with 'timer'", "[modules]") {
-    setup();
-
-    JSValue ret = eval_module(R"(
-        import { enableTimerWakeup, disableWakeupSource } from "native:sleep";
-        enableTimerWakeup(1000000);
-        disableWakeupSource("timer");
-        globalThis.__ok = true;
-    )");
-    TEST_ASSERT_FALSE_MESSAGE(JS_IsException(ret), "Module eval should not throw");
-
-    JSValue global = JS_GetGlobalObject(ctx);
-    JSValue ok = JS_GetPropertyStr(ctx, global, "__ok");
-    TEST_ASSERT_TRUE_MESSAGE(JS_ToBool(ctx, ok), "disableWakeupSource('timer') should succeed");
-    JS_FreeValue(ctx, ok);
-    JS_FreeValue(ctx, global);
-    teardown();
-}
-
-/* ── disableWakeupSource throws on invalid source ────────────────── */
-
-TEST_CASE("native:sleep disableWakeupSource throws on invalid source", "[modules]") {
-    setup();
-
-    JSValue ret = eval_module(R"(
-        import { disableWakeupSource } from "native:sleep";
+        import { lightSleep } from "native:sleep";
         try {
-            disableWakeupSource("invalid");
+            lightSleep({gpio: {pin: 0, level: "bogus"}});
             globalThis.__threw = false;
         } catch (e) {
             globalThis.__threw = true;
@@ -174,8 +103,7 @@ TEST_CASE("native:sleep disableWakeupSource throws on invalid source", "[modules
     JSValue global = JS_GetGlobalObject(ctx);
 
     JSValue threw = JS_GetPropertyStr(ctx, global, "__threw");
-    TEST_ASSERT_TRUE_MESSAGE(JS_ToBool(ctx, threw),
-                             "disableWakeupSource should throw on invalid source");
+    TEST_ASSERT_TRUE_MESSAGE(JS_ToBool(ctx, threw), "lightSleep should throw on invalid level");
     JS_FreeValue(ctx, threw);
 
     JSValue isRange = JS_GetPropertyStr(ctx, global, "__isRangeError");
@@ -190,19 +118,19 @@ TEST_CASE("native:sleep disableWakeupSource throws on invalid source", "[modules
 /* Light sleep disconnects UART console on targets without USB Serial/JTAG,
    causing the test monitor to stall. Only run on chips that have USB
    Serial/JTAG which keeps the connection alive through light sleep. */
-TEST_CASE("native:sleep lightSleep with 1ms returns or rejects gracefully", "[modules]") {
+TEST_CASE("native:sleep lightSleep with 1us timer returns or rejects gracefully", "[modules]") {
 #if !SOC_USB_SERIAL_JTAG_SUPPORTED
-    TEST_IGNORE_MESSAGE("light sleep disconnects UART console — skipped on non-USB targets");
+    TEST_IGNORE_MESSAGE("light sleep disconnects UART console, skipped on non-USB targets");
 #endif
     setup();
 
     JSValue ret = eval_module(R"(
         import { lightSleep } from "native:sleep";
         try {
-            lightSleep(1);
+            lightSleep({timer: 1});
             globalThis.__result = "ok";
         } catch (e) {
-            // Light sleep may fail on boards with USB JTAG or other constraints
+            /* Light sleep may throw on boards with USB JTAG or other constraints */
             globalThis.__result = "caught:" + e.message;
         }
     )");
@@ -212,7 +140,7 @@ TEST_CASE("native:sleep lightSleep with 1ms returns or rejects gracefully", "[mo
     JSValue result = JS_GetPropertyStr(ctx, global, "__result");
     const char* str = JS_ToCString(ctx, result);
     TEST_ASSERT_NOT_NULL_MESSAGE(str, "result should be set");
-    /* Either "ok" (sleep succeeded) or "caught:..." (threw a catchable error) — both are fine */
+    /* Either "ok" (sleep succeeded) or "caught:..." (threw a catchable error) */
     TEST_ASSERT_TRUE_MESSAGE(strncmp(str, "ok", 2) == 0 || strncmp(str, "caught:", 7) == 0,
                              "lightSleep should either succeed or throw a catchable error");
     JS_FreeCString(ctx, str);

--- a/packages/@mikrojs/native/runtime/internal.d.ts
+++ b/packages/@mikrojs/native/runtime/internal.d.ts
@@ -128,17 +128,13 @@ declare module 'native:pin' {
 }
 
 declare module 'native:sleep' {
-  import type {SleepError} from '@mikrojs/native/runtime/sleep/types'
-  import type {Result} from 'mikrojs/result'
+  import type {DeepWakeupSources, LightWakeupSources} from '@mikrojs/native/runtime/sleep/types'
 
-  export function deepSleep(ms: number): never
-  export function lightSleep(ms: number): Result<void, SleepError>
+  export function deepSleep(sources: DeepWakeupSources): never
+  export function lightSleep(sources: LightWakeupSources): void
   export function getWakeupCause(): string
-  export function enableTimerWakeup(us: number): Result<void, SleepError>
-  export function enableGpioWakeup(pin: number, level: number): Result<void, SleepError>
-  export function enableExt0Wakeup(pin: number, level: number): Result<void, SleepError>
-  export function enableExt1Wakeup(pinMask: number, mode: number): Result<void, SleepError>
-  export function disableWakeupSource(source?: string): Result<void, SleepError>
+  export function canWakeFromExt0(): boolean
+  export function canWakeFromExt1(): boolean
 }
 
 declare module 'native:http' {

--- a/packages/@mikrojs/native/runtime/sleep/sleep.ts
+++ b/packages/@mikrojs/native/runtime/sleep/sleep.ts
@@ -1,13 +1,17 @@
-export {
-  deepSleep,
-  disableWakeupSource,
-  enableExt0Wakeup,
-  enableExt1Wakeup,
-  enableGpioWakeup,
-  enableTimerWakeup,
-  getWakeupCause,
-  lightSleep,
-} from 'native:sleep'
+import {deepSleep as nativeDeepSleep, lightSleep as nativeLightSleep} from 'native:sleep'
+
+import type {DeepWakeupSources, LightWakeupSources} from './types.js'
+
+export type {DeepWakeupSources, LightWakeupSources, RtcGpio, WakeupLevel} from './types.js'
+export {canWakeFromExt0, canWakeFromExt1} from 'native:sleep'
+
+export function deepSleep(sources: DeepWakeupSources | number): never {
+  return nativeDeepSleep(typeof sources === 'number' ? {timer: sources} : sources)
+}
+
+export function lightSleep(sources: LightWakeupSources | number): void {
+  nativeLightSleep(typeof sources === 'number' ? {timer: sources} : sources)
+}
 
 export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))

--- a/packages/@mikrojs/native/runtime/sleep/types.ts
+++ b/packages/@mikrojs/native/runtime/sleep/types.ts
@@ -1,44 +1,60 @@
-import type {Result} from '../result/types.js'
+export type WakeupLevel = 'high' | 'low'
 
-export type SleepError =
-  | {name: 'WakeupConfigFailed'; message: string}
-  | {name: 'LightSleepFailed'; message: string}
-  | {name: 'DisableWakeupFailed'; message: string}
+/** A GPIO pin number that must be RTC-capable for deep-sleep wake.
+ *  Set varies per chip:
+ *  - ESP32-C6 / H2: 0–7 (LP_GPIO0–LP_GPIO7)
+ *  - ESP32-C3: 0–5
+ *  - ESP32-S2 / S3: 0–21 (LP_IO0–LP_IO21)
+ *  - ESP32: subset of 0–39 (see datasheet for RTC_GPIO mapping)
+ *
+ *  Not statically validated — passing a non-RTC pin throws at runtime.
+ */
+export type RtcGpio = number
 
-export declare function deepSleep(time: number): never
+/** Sources that can wake the chip from light sleep. */
+export type LightWakeupSources = {
+  /** Wake after this many milliseconds. Fractional values are allowed
+   *  (e.g. `0.01` = 10 µs). */
+  timer?: number
+  /** Wake when `pin` reaches `level`. Any GPIO works — no RTC-capable
+   *  constraint. */
+  gpio?: {pin: number; level: WakeupLevel}
+}
 
-export declare function lightSleep(time: number): Result<void, SleepError>
-
-export declare function getWakeupCause(): string
-
-/** Configure timer wakeup source (microseconds). */
-export declare function enableTimerWakeup(us: number): Result<void, SleepError>
+/** Sources that can wake the chip from deep sleep. */
+export type DeepWakeupSources = {
+  /** Wake after this many milliseconds. Fractional values are allowed. */
+  timer?: number
+  /** Wake on a single RTC GPIO. ESP32 / S2 / S3 only — throws on
+   *  C3 / C6 / H2 (use `ext1` instead). */
+  ext0?: {pin: RtcGpio; level: WakeupLevel}
+  /** Wake when any of `pins` matches `mode`. Pins must be RTC-capable. */
+  ext1?: {pins: RtcGpio[]; mode: 'any-low' | 'any-high'}
+}
 
 /**
- * Configure GPIO wakeup for light sleep.
- * @param pin GPIO pin number
- * @param level GPIO interrupt type (e.g. 4 = low, 5 = high)
+ * Enter deep sleep. Pass a `DeepWakeupSources` object, or a number as
+ * shorthand for `{timer: ms}`. The chip resets on wake.
  */
-export declare function enableGpioWakeup(pin: number, level: number): Result<void, SleepError>
+export declare function deepSleep(ms: number): never
+export declare function deepSleep(sources: DeepWakeupSources): never
 
 /**
- * Configure ext0 wakeup for deep sleep (ESP32, ESP32-S2, ESP32-S3 only).
- * @param pin RTC GPIO pin number
- * @param level 0 = low, 1 = high
+ * Enter light sleep. Pass a `LightWakeupSources` object, or a number as
+ * shorthand for `{timer: ms}`. Execution resumes from the call site
+ * after waking.
  */
-export declare function enableExt0Wakeup(pin: number, level: number): Result<void, SleepError>
+export declare function lightSleep(ms: number): void
+export declare function lightSleep(sources: LightWakeupSources): void
 
-/**
- * Configure ext1 wakeup for deep sleep.
- * @param pinMask Bitmask of RTC GPIO pins
- * @param mode 0 = ESP_EXT1_WAKEUP_ALL_LOW, 1 = ESP_EXT1_WAKEUP_ANY_HIGH
- */
-export declare function enableExt1Wakeup(pinMask: number, mode: number): Result<void, SleepError>
+/** Returns `true` if the current chip supports EXT0 wakeup
+ *  (ESP32, ESP32-S2, ESP32-S3). Use to gate `deepSleep({ext0: …})`
+ *  calls when targeting boards across the ESP32 family. */
+export declare function canWakeFromExt0(): boolean
 
-/**
- * Disable a wakeup source. If no source is specified, all sources are disabled.
- * @param source Optional: "timer", "ext0", "ext1", "gpio", "touchpad", "ulp"
- */
-export declare function disableWakeupSource(source?: string): Result<void, SleepError>
+/** Returns `true` if the current chip supports EXT1 wakeup. Every
+ *  chip mikrojs targets except ESP32-C3. Use to gate
+ *  `deepSleep({ext1: …})` calls. */
+export declare function canWakeFromExt1(): boolean
 
 export declare function sleep(ms: number): Promise<void>

--- a/packages/@mikrojs/native/runtime/sys/sys.ts
+++ b/packages/@mikrojs/native/runtime/sys/sys.ts
@@ -1,4 +1,5 @@
 import {err, ok, PanicError, type Result} from 'mikrojs/result'
+import {getWakeupCause as nativeGetWakeupCause} from 'native:sleep'
 import * as native from 'native:sys'
 
 export function uptime(): {boot: number; rtc: number} {
@@ -38,6 +39,10 @@ export const deviceId: string = native.deviceId
 
 export function restart(): never {
   return native.restart() as never
+}
+
+export function getWakeupCause(): string {
+  return nativeGetWakeupCause()
 }
 
 export function exit(_exitCode?: number): never {

--- a/packages/@mikrojs/native/runtime/sys/types.ts
+++ b/packages/@mikrojs/native/runtime/sys/types.ts
@@ -124,6 +124,11 @@ export declare const firmware: {
 
 export declare function restart(): never
 
+/** Reason the device woke up this boot. Set after deep sleep (or first
+ *  boot). One of: `'timer'`, `'ext0'`, `'ext1'`, `'gpio'`, or `'undefined'`
+ *  (cold boot or unknown). */
+export declare function getWakeupCause(): string
+
 export declare function exit(exitCode?: number): never
 
 /** Immediately crash with an error message. Use for unrecoverable situations. */

--- a/packages/@mikrojs/native/test/native_stubs.cpp
+++ b/packages/@mikrojs/native/test/native_stubs.cpp
@@ -64,8 +64,8 @@ JSValue stub_ctor(JSContext* ctx, JSValueConst, int, JSValueConst*) {
 STUB_FUNCS(pin, "native:pin", "pinMode", "digitalWrite", "digitalRead", "analogRead",
            "analogReadMillivolts")
 STUB_FUNCS(sntp, "native:sntp", "sync", "stop", "setTimezone")
-STUB_FUNCS(sleep, "native:sleep", "deepSleep", "lightSleep", "getWakeupCause", "enableTimerWakeup",
-           "enableGpioWakeup", "enableExt0Wakeup", "enableExt1Wakeup", "disableWakeupSource")
+STUB_FUNCS(sleep, "native:sleep", "deepSleep", "lightSleep", "getWakeupCause",
+           "canWakeFromExt0", "canWakeFromExt1")
 STUB_FUNCS(http, "native:http", "request", "nextMessage", "cancel", "pendingCount")
 STUB_FUNCS(nvs_kv, "native:nvs_kv", "set", "get", "remove", "clear", "info")
 STUB_FUNCS(rtc, "native:rtc", "set", "get", "remove", "clear", "info")

--- a/packages/create-mikrojs/src/templates/rtc-counter/app/main.ts
+++ b/packages/create-mikrojs/src/templates/rtc-counter/app/main.ts
@@ -19,4 +19,4 @@ await sleep(5000);
 
 // Sleep for 15 seconds, then wake up again
 console.log("Going to deep sleep for 15s...");
-deepSleep(15000);
+deepSleep({ timer: 15_000 });

--- a/packages/mikrojs/src/_exports/sim.ts
+++ b/packages/mikrojs/src/_exports/sim.ts
@@ -5,6 +5,8 @@
  * which erases at compile time, preventing accidental runtime import in app code.
  */
 
+import type {DeepWakeupSources, LightWakeupSources} from '@mikrojs/native/runtime/sleep/types'
+
 type NR<T> = {ok: true; value: T} | {ok: false; error: {name: string; message: string}}
 type NRV = {ok: true} | {ok: false; error: {name: string; message: string}}
 
@@ -97,14 +99,11 @@ export interface SimStubMethods {
     write(data: Uint8Array): NRV
   }
   sleep: {
-    deepSleep(ms: number): void
-    lightSleep(ms: number): NRV
+    deepSleep(sources: DeepWakeupSources): void
+    lightSleep(sources: LightWakeupSources): void
     getWakeupCause(): string
-    enableTimerWakeup(us: number): NRV
-    enableGpioWakeup(pin: number, level: number): NRV
-    enableExt0Wakeup(pin: number, level: number): NRV
-    enableExt1Wakeup(pinMask: number, mode: number): NRV
-    disableWakeupSource(source?: string): NRV
+    canWakeFromExt0(): boolean
+    canWakeFromExt1(): boolean
   }
   kv: {
     set(key: string, value: unknown): void

--- a/packages/mikrojs/src/cli/lib/__test__/replStateMachine.test.ts
+++ b/packages/mikrojs/src/cli/lib/__test__/replStateMachine.test.ts
@@ -923,11 +923,12 @@ describe('replStateMachine', () => {
       })
     })
 
-    test('disconnect with error sets error state', () => {
+    test('disconnect with error sets error state without duplicating in events', () => {
       const state = createInitialState()
       const [next] = reduce(state, deviceEvent({type: 'disconnect', error: 'device lost'}))
       expect(next.connection).toEqual({type: 'error', message: 'device lost'})
-      expect(next.events.at(-1)).toEqual({type: 'disconnect', error: 'device lost'})
+      // Footer renders the error; appending to events would duplicate it.
+      expect(next.events).toEqual(state.events)
     })
 
     test('disconnect without error emits end', () => {

--- a/packages/mikrojs/src/cli/lib/serial/InkReplMode.tsx
+++ b/packages/mikrojs/src/cli/lib/serial/InkReplMode.tsx
@@ -6,12 +6,13 @@ import {catchError, from, map, type Observable, of, shareReplay, switchMap} from
 import type {LogLevel} from '../../../_exports/index.js'
 import {BAUD_RATE} from '../deploy.js'
 import {triggerSafeMode} from '../recover.js'
-import {connectRepl, type ReplSession} from '../session.js'
+import type {ReplSession} from '../session.js'
 import {Spinner} from '../Spinner.js'
-import {createSerialTransport, openSerial} from '../transport.js'
+import {openSerial} from '../transport.js'
 import {useObservable} from '../useObservable.js'
 import {InkReplConsole} from './InkReplConsole.js'
 import {createRepl, type ReplHandle} from './replStateMachine.js'
+import {createSupervisedSession} from './supervisedSession.js'
 
 export interface InkReplDriverContext {
   session: ReplSession
@@ -65,7 +66,7 @@ export function InkReplMode(props: InkReplModeProps) {
         // subscription inside connectRepl is listening when the
         // post-reset MSG_READY arrives.
         switchMap((serial) => {
-          const session = connectRepl(createSerialTransport(serial))
+          const session = createSupervisedSession(serial, {devicePath, baudRate: BAUD_RATE})
           return recover ? from(triggerSafeMode(serial)).pipe(map(() => session)) : of(session)
         }),
         map((session) => {

--- a/packages/mikrojs/src/cli/lib/serial/ReplConsole.tsx
+++ b/packages/mikrojs/src/cli/lib/serial/ReplConsole.tsx
@@ -249,6 +249,7 @@ export function ReplConsole({repl, config, logLevel = 'debug', watch}: ReplConso
   }
 
   const isConnecting = conn.type === 'connecting' || conn.type === 'negotiating'
+  const isReconnecting = conn.type === 'reconnecting'
   const isError = conn.type === 'error'
 
   // One footer line drives both progress and watch-mode messaging so the
@@ -261,26 +262,33 @@ export function ReplConsole({repl, config, logLevel = 'debug', watch}: ReplConso
           message: conn.message ?? (state.port ? `Connecting to ${state.port}…` : 'Connecting…'),
           tone: 'busy',
         }
-      : isError
+      : isReconnecting
         ? {
-            // Multi-line error messages (e.g. resolvePort listing several
-            // matches) get clipped to the first line so the footer stays a
-            // single row; the full text is in the scrollback. Single-line
-            // failures (DeviceTimeoutError) pass through unchanged.
-            // Watch-mode messaging is suppressed so we don't claim to be
-            // "watching" when we can't actually reach the device.
-            message: conn.message.split('\n')[0] || 'Disconnected from device',
-            tone: 'error',
+            // Subtle dim line — the disconnect was transient (light sleep,
+            // brief replug); we're already polling for the port to come back.
+            message: conn.message ?? 'Reconnecting…',
+            tone: 'idle',
           }
-        : state.disabled
-          ? {message: state.deployStatus ?? 'Deploying…', tone: 'busy'}
-          : state.footerError
-            ? {message: state.footerError, tone: 'error'}
-            : watch === true
-              ? {message: 'Watching for file changes…', tone: 'watching'}
-              : watch === false
-                ? {message: 'File watching off. Press Ctrl+S to redeploy', tone: 'idle'}
-                : null
+        : isError
+          ? {
+              // Multi-line error messages (e.g. resolvePort listing several
+              // matches) get clipped to the first line so the footer stays a
+              // single row; the full text is in the scrollback. Single-line
+              // failures (DeviceTimeoutError) pass through unchanged.
+              // Watch-mode messaging is suppressed so we don't claim to be
+              // "watching" when we can't actually reach the device.
+              message: conn.message.split('\n')[0] || 'Disconnected from device',
+              tone: 'error',
+            }
+          : state.disabled
+            ? {message: state.deployStatus ?? 'Deploying…', tone: 'busy'}
+            : state.footerError
+              ? {message: state.footerError, tone: 'error'}
+              : watch === true
+                ? {message: 'Watching for file changes…', tone: 'watching'}
+                : watch === false
+                  ? {message: 'File watching off. Press Ctrl+S to redeploy', tone: 'idle'}
+                  : null
 
   const renderableEvents = state.events.filter((event) => shouldRender(event, logLevel))
 

--- a/packages/mikrojs/src/cli/lib/serial/replStateMachine.ts
+++ b/packages/mikrojs/src/cli/lib/serial/replStateMachine.ts
@@ -25,6 +25,7 @@ import type {ReplEvent, ReplSession} from '../session.js'
 export type ConnectionState =
   | {type: 'connecting'; message?: string}
   | {type: 'negotiating'; message?: string}
+  | {type: 'reconnecting'; message?: string}
   | {type: 'ready'; chip: string | null; deviceId: string | null; firmwareVersion: string | null}
   | {type: 'error'; message: string}
   | {type: 'fallback'}
@@ -328,10 +329,26 @@ function reduceSessionEvent(
     case 'raw':
     case 'test':
       return [{...state, events: [...state.events, event]}, []]
+    case 'reconnecting': {
+      // Already showing reconnecting state — drop the duplicate without
+      // re-appending. The supervised session can emit this more than once
+      // (each new poll cycle), and we only want one line in the footer.
+      if (state.connection.type === 'reconnecting') return [state, []]
+      const connection: ConnectionState = {
+        type: 'reconnecting',
+        message: state.port ? `Reconnecting to ${state.port}…` : 'Reconnecting…',
+      }
+      return [{...state, connection}, []]
+    }
+    case 'reconnected':
+      // Informational only — the follow-up `ready` event transitions back.
+      return [state, []]
     case 'disconnect': {
       if (event.error) {
+        // The footer already shows the error message; appending to events
+        // would duplicate it as a red scrollback line.
         const connection: ConnectionState = {type: 'error', message: event.error}
-        return [{...state, connection, events: [...state.events, event]}, []]
+        return [{...state, connection}, []]
       }
       return [state, [{type: 'end'}]]
     }

--- a/packages/mikrojs/src/cli/lib/serial/supervisedSession.ts
+++ b/packages/mikrojs/src/cli/lib/serial/supervisedSession.ts
@@ -1,0 +1,266 @@
+/**
+ * SupervisedSession — a `ReplSession` that survives transient serial
+ * disconnects.
+ *
+ * The state machine in `replStateMachine` binds to a single `ReplSession`
+ * for its lifetime: it subscribes once to `messages$` and calls
+ * `awaitReady$` once. To stay alive across USB re-enumerations (e.g. light
+ * sleep on USJ-console chips), this wrapper owns the inner `ReplSession`
+ * lifecycle, swaps the inner instance on disconnect, and re-drives the
+ * handshake on the new instance — all transparent to the state machine.
+ *
+ * Events surfaced to the state machine (in addition to the inner
+ * session's events):
+ *   - `{type: 'reconnecting'}` when the inner disconnects and we're
+ *     starting the reconnect poll. The state machine renders a subtle
+ *     "Reconnecting…" footer line.
+ *   - `{type: 'reconnected'}` after the new transport is open. The new
+ *     inner's MSG_READY (delivered via `messages$` shortly after) drives
+ *     the state machine back to `ready`.
+ *   - `{type: 'disconnect', error: '...'}` if the device doesn't return
+ *     within the timeout — the same shape as a hard transport error, so
+ *     the state machine's existing handler surfaces it as an error.
+ */
+
+import {
+  BehaviorSubject,
+  filter,
+  merge,
+  type Observable,
+  share,
+  Subject,
+  type Subscription,
+  switchMap,
+} from 'rxjs'
+import {SerialPort} from 'serialport'
+
+import {connectRepl, type ReadyEvent, type ReplEvent, type ReplSession} from '../session.js'
+import {createSerialTransport} from '../transport.js'
+
+/** How long to keep trying to reopen the port before giving up. Defaults
+ *  to Infinity: once the initial connect has succeeded, the supervisor
+ *  trusts that the device exists and will wait indefinitely for it to
+ *  come back. This covers arbitrarily long deep sleeps and brief replugs
+ *  without racing the user. Ctrl+C is always available if the device
+ *  really is gone. */
+const RECONNECT_TIMEOUT_MS = Infinity
+/** Interval between `open()` attempts while waiting for the device to
+ *  re-enumerate. We don't pre-check via `SerialPort.list()` — `open()`
+ *  on a missing path returns ENOENT in microseconds, so polling open
+ *  directly catches the new device node the instant macOS publishes it
+ *  (~hundreds of ms faster than list-then-open). */
+const OPEN_RETRY_INTERVAL_MS = 100
+
+export interface SupervisedSessionOptions {
+  devicePath: string
+  baudRate: number
+  /** Total ms to wait for the port path to reappear before giving up.
+   *  Defaults to 30 s, which covers light-sleep re-enumeration plus
+   *  brief replugs without hanging an idle session overnight. */
+  reconnectTimeoutMs?: number
+  /** Called when a reconnect cycle starts, before the `'reconnecting'`
+   *  event reaches the state machine. Useful for aborting in-flight
+   *  deploys. */
+  onReconnectStart?: () => void
+}
+
+interface Inner {
+  serial: SerialPort
+  session: ReplSession
+}
+
+function buildInner(serial: SerialPort): Inner {
+  return {serial, session: connectRepl(createSerialTransport(serial))}
+}
+
+function closeInner(inner: Inner): void {
+  try {
+    inner.session.close()
+  } catch {
+    // already closed
+  }
+  try {
+    if (inner.serial.isOpen) inner.serial.close()
+  } catch {
+    // already closed
+  }
+}
+
+function openSerialOnce(path: string, baudRate: number): Promise<SerialPort> {
+  return new Promise((resolve, reject) => {
+    const sp = new SerialPort({path, baudRate, autoOpen: false})
+    sp.open((err) => (err ? reject(err) : resolve(sp)))
+  })
+}
+
+/**
+ * Hammer `open()` on `path` at `OPEN_RETRY_INTERVAL_MS` until it succeeds
+ * or `timeoutMs` elapses. Faster than list-then-open because the OS
+ * publishes the new device node before `SerialPort.list()` catches up,
+ * and `open()` on a missing path returns ENOENT in microseconds.
+ */
+async function openWithRetry(
+  path: string,
+  baudRate: number,
+  timeoutMs: number,
+  signal: AbortSignal,
+): Promise<SerialPort> {
+  const deadline = Date.now() + timeoutMs
+  let lastErr: unknown = null
+  while (Date.now() < deadline) {
+    if (signal.aborted) throw new Error('reconnect aborted')
+    try {
+      return await openSerialOnce(path, baudRate)
+    } catch (err) {
+      lastErr = err
+      await new Promise((r) => setTimeout(r, OPEN_RETRY_INTERVAL_MS))
+    }
+  }
+  throw lastErr instanceof Error
+    ? lastErr
+    : new Error(`Device did not return within ${Math.round(timeoutMs / 1000)}s`)
+}
+
+/**
+ * Wrap an already-open SerialPort into a self-supervising ReplSession.
+ * The caller hands off ownership of `initialSerial`; closing the returned
+ * session closes the underlying port.
+ */
+export function createSupervisedSession(
+  initialSerial: SerialPort,
+  opts: SupervisedSessionOptions,
+): ReplSession {
+  const reconnectTimeoutMs = opts.reconnectTimeoutMs ?? RECONNECT_TIMEOUT_MS
+
+  let closed = false
+  let reconnectAbort: AbortController | null = null
+  let innerDisconnectSub: Subscription | null = null
+
+  const inner$ = new BehaviorSubject<Inner>(buildInner(initialSerial))
+  // Synthetic supervisor-level events injected into the outer stream
+  // (`reconnecting`, `reconnected`, and the final terminal disconnect on
+  // reconnect timeout).
+  const supervisorEvents$ = new Subject<ReplEvent>()
+
+  // Watch the current inner's stream for its terminal `disconnect`. When
+  // it fires, suppress it from the outer stream (the outer subscriber
+  // sees `'reconnecting'` instead) and start the reconnect loop.
+  function watchInnerForDisconnect(inner: Inner): void {
+    innerDisconnectSub?.unsubscribe()
+    innerDisconnectSub = inner.session.messages$
+      .pipe(filter((e): e is Extract<ReplEvent, {type: 'disconnect'}> => e.type === 'disconnect'))
+      .subscribe((event) => {
+        if (closed) {
+          supervisorEvents$.next(event)
+          supervisorEvents$.complete()
+          return
+        }
+        if (event.error) {
+          // Hard transport error (e.g. write failure). Don't auto-reconnect;
+          // surface the original error so the state machine shows it.
+          supervisorEvents$.next(event)
+          supervisorEvents$.complete()
+          return
+        }
+        opts.onReconnectStart?.()
+        supervisorEvents$.next({type: 'reconnecting'})
+        startReconnect(inner).catch(() => {
+          // startReconnect handles its own errors via supervisorEvents$.
+        })
+      })
+  }
+  watchInnerForDisconnect(inner$.value)
+
+  async function startReconnect(previous: Inner): Promise<void> {
+    reconnectAbort?.abort()
+    const ac = new AbortController()
+    reconnectAbort = ac
+
+    // Release the OS handle on the old port so the re-enumerated device
+    // can grab the same path.
+    closeInner(previous)
+
+    try {
+      const serial = await openWithRetry(
+        opts.devicePath,
+        opts.baudRate,
+        reconnectTimeoutMs,
+        ac.signal,
+      )
+
+      const next = buildInner(serial)
+      watchInnerForDisconnect(next)
+      inner$.next(next)
+      supervisorEvents$.next({type: 'reconnected'})
+      // Drive HELLO on the new inner so MSG_READY flows through and the
+      // state machine transitions back to `ready`. Errors are swallowed:
+      // a firmware-incompat or timeout will surface via `disconnect` on
+      // its own when the inner closes.
+      next.session.awaitReady$().subscribe({error: () => {}})
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      supervisorEvents$.next({type: 'disconnect', error: message})
+      supervisorEvents$.complete()
+    }
+  }
+
+  // Outer messages$: current inner's events (minus its terminal
+  // `disconnect`) + supervisor-injected events.
+  const innerEvents$: Observable<ReplEvent> = inner$.pipe(
+    switchMap((inner) => inner.session.messages$.pipe(filter((e) => e.type !== 'disconnect'))),
+  )
+  const messages$: Observable<ReplEvent> = merge(innerEvents$, supervisorEvents$).pipe(share())
+  // Keep the pipeline warm so inner subscriptions stay live even when
+  // the state machine momentarily has no active subscription.
+  const keepalive = messages$.subscribe()
+
+  function current(): ReplSession {
+    return inner$.value.session
+  }
+
+  return {
+    messages$,
+    ready$: messages$.pipe(filter((e): e is ReadyEvent => e.type === 'ready')),
+    eval(code) {
+      current().eval(code)
+    },
+    directive(name) {
+      current().directive(name)
+    },
+    complete(partial) {
+      current().complete(partial)
+    },
+    exit() {
+      current().exit()
+    },
+    awaitReady$(timeoutMs) {
+      return current().awaitReady$(timeoutMs)
+    },
+    deploy(deployOpts) {
+      return current().deploy(deployOpts)
+    },
+    eraseApp(eraseOpts) {
+      return current().eraseApp(eraseOpts)
+    },
+    fsGet(path) {
+      return current().fsGet(path)
+    },
+    restart() {
+      current().restart()
+    },
+    config: {
+      list: () => current().config.list(),
+      set: (k, v, s) => current().config.set(k, v, s),
+      delete: (k) => current().config.delete(k),
+    },
+    close() {
+      if (closed) return
+      closed = true
+      reconnectAbort?.abort()
+      innerDisconnectSub?.unsubscribe()
+      keepalive.unsubscribe()
+      closeInner(inner$.value)
+      supervisorEvents$.complete()
+    },
+  }
+}

--- a/packages/mikrojs/src/cli/lib/session.ts
+++ b/packages/mikrojs/src/cli/lib/session.ts
@@ -149,6 +149,21 @@ export interface DisconnectEvent {
   error?: string
 }
 
+/** Emitted by `createSupervisedSession` when the underlying serial transport
+ *  drops but a reconnect attempt is in progress. The state machine renders
+ *  a subtle "reconnecting…" line. */
+export interface ReconnectingEvent {
+  type: 'reconnecting'
+}
+
+/** Emitted by `createSupervisedSession` after the reconnect handshake
+ *  succeeds (a fresh MSG_READY arrives via the new transport). The state
+ *  machine's `ready` reducer already handles the transition back to
+ *  `ready`; this event is informational. */
+export interface ReconnectedEvent {
+  type: 'reconnected'
+}
+
 export type ReplEvent =
   | ReadyEvent
   | TextEvent
@@ -163,6 +178,8 @@ export type ReplEvent =
   | TestEvent
   | ManifestDoneEvent
   | DisconnectEvent
+  | ReconnectingEvent
+  | ReconnectedEvent
 
 /** Response events that deploy/config commands wait for */
 type ResponseEvent = OkEvent | ErrEvent | ChecksumResultEvent | ConfigEntriesEvent

--- a/packages/mikrojs/src/simulator/builtins/sleep.ts
+++ b/packages/mikrojs/src/simulator/builtins/sleep.ts
@@ -1,34 +1,27 @@
 import type {BuiltinDefinition} from './types.js'
 
-// sleep uses a raw source module so deepSleep can use setTimeout + restart,
-// and lightSleep can return a delayed Promise.
+// sleep uses a raw source module so deepSleep can use setTimeout + restart.
 export const sleepBuiltin: BuiltinDefinition = {
   source: `
 import {restart} from 'native:sys'
-import {ok} from 'mikrojs/result'
 
 const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms))
 
 let wakeupCause = 'undefined'
 
-export function deepSleep(ms) {
+export function deepSleep(sources) {
+  console.warn('[sim] deepSleep ' + JSON.stringify(sources))
   // On device, deepSleep is \`never\` (chip resets after sleep).
-  // In the sim, wait the duration then restart the runtime.
-  console.warn('[sim] deepSleep(' + ms + 'ms)')
-  sleep(ms).then(() => restart())
+  // In the sim, wait the timer duration (if any) then restart the runtime.
+  sleep(sources?.timer ?? 0).then(() => restart())
 }
 
-export function lightSleep(ms) {
-  console.warn('[sim] lightSleep(' + ms + 'ms)')
-  // Block-ish: return a result after the delay
-  return ok()
+export function lightSleep(sources) {
+  console.warn('[sim] lightSleep ' + JSON.stringify(sources))
 }
 
 export function getWakeupCause() { return wakeupCause }
-export function enableTimerWakeup() { return ok() }
-export function enableGpioWakeup() { return ok() }
-export function enableExt0Wakeup() { return ok() }
-export function enableExt1Wakeup() { return ok() }
-export function disableWakeupSource() { return ok() }
+export function canWakeFromExt0() { return false }
+export function canWakeFromExt1() { return true }
 `,
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,6 +294,12 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  examples/sleep:
+    dependencies:
+      mikrojs:
+        specifier: workspace:*
+        version: link:../../packages/mikrojs
+
   examples/sntp:
     dependencies:
       mikrojs:

--- a/skills/mikrojs-dev/SKILL.md
+++ b/skills/mikrojs-dev/SKILL.md
@@ -207,7 +207,8 @@ Variable names are limited to 15 characters (NVS storage constraint on ESP32).
 ## Deep sleep for battery-powered projects
 
 ```typescript
-import {deepSleep, enableTimerWakeup, getWakeupCause} from 'mikrojs/sleep'
+import {deepSleep} from 'mikrojs/sleep'
+import {getWakeupCause} from 'mikrojs/sys'
 import {rtcStorage} from 'mikrojs/kv'
 import * as s from 'mikrojs/schema'
 
@@ -219,9 +220,8 @@ console.log(`Boot #${bootCount.get() ?? 0}, cause: ${getWakeupCause()}`)
 // Do work: read sensor, send data, etc.
 // ...
 
-// Sleep for 5 minutes (microseconds)
-enableTimerWakeup(5 * 60 * 1_000_000).orPanic('timer wakeup')
-deepSleep(5 * 60 * 1_000_000) // never returns, device reboots on wake
+// Sleep for 5 minutes (milliseconds); never returns, device reboots on wake
+deepSleep({timer: 5 * 60 * 1000})
 ```
 
 Deep sleep draws ~10-20 uA vs. ~80-160 mA active. For battery projects, spend as little time awake as possible.


### PR DESCRIPTION
feat(sleep)!: split wakeup sources by sleep mode and auto-configure RTC pulls

Light sleep and deep sleep use different ESP-IDF wake-source paths: `gpio` only fires during light sleep, `ext0`/`ext1` only during deep sleep. Encode that in the type system by splitting WakeupSources into LightWakeupSources (timer + gpio) and DeepWakeupSources (timer + ext0 + ext1), so mismatches like `deepSleep({gpio: …})` are a TS error rather than a runtime no-op.

Also adds an RtcGpio type alias documenting the chip-specific RTC pin range, auto-configures the RTC internal pull-up/down inside ext0/ext1 (matching the wake direction so the pin idles in the non-trigger state), and exposes canWakeFromExt0()/canWakeFromExt1() helpers so code targeting multiple chips can gate calls without crashing on chips where the source isn't supported (per SOC_PM_SUPPORT_EXT[01]_WAKEUP).

BREAKING CHANGE: WakeupSources is replaced by LightWakeupSources + DeepWakeupSources; `deepSleep({gpio: …})` now fails to compile.

The whole pre-config API (enableTimerWakeup / enableGpioWakeup / enableExt0Wakeup / enableExt1Wakeup / disableWakeupSource) is removed — pass sources directly to lightSleep/deepSleep instead.

```ts
// before
enableTimerWakeup(5_000_000)         // µs
deepSleep(5_000_000)
// after
deepSleep({timer: 5_000})            // ms
```

`SleepError` is gone; `lightSleep` returns void and throws on failure. `getWakeupCause` moved to mikrojs/sys.

ext1: mode renamed `'all-low'` → `'any-low'`; pins is now `number[]` not a bitmask. ext0/gpio: level is now `'low' | 'high'`, not a numeric flag. Timer durations are milliseconds everywhere (previously microseconds in enable*Wakeup).
