### PR TITLE
feat(native)!: support deep-sleep on panic

### DIFF
--- a/dev/crashloop/README.md
+++ b/dev/crashloop/README.md
@@ -4,7 +4,7 @@ Dev fixture that deploys an app which crash-loops on boot. Used to exercise the 
 
 ## What it does
 
-`app/main.ts` throws an uncaught exception as soon as it runs. The runtime always restarts on uncaught exceptions; `mikro.config.ts` shortens the `panicRestartDelay` grace window so the runtime calls `esp_restart()` quickly after the throw. The next boot autoruns the same broken app, throws again, restarts, forever.
+`app/main.ts` throws an uncaught exception as soon as it runs. The runtime always restarts on uncaught exceptions; `mikro.config.ts` shortens the `onPanic` `delay` grace window so the runtime calls `esp_restart()` quickly after the throw. The next boot autoruns the same broken app, throws again, restarts, forever.
 
 Net effect: the device does enter `MIK_StartReplProtocol` briefly between crashes, but it's gone again before a normal `mikro dev` / `mikro deploy` / `mikro clean` can complete its handshake. The crash cycle is short enough that host-side retries alone aren't enough to catch it.
 

--- a/dev/crashloop/app/main.ts
+++ b/dev/crashloop/app/main.ts
@@ -7,7 +7,7 @@ import {version} from 'mikrojs/sys'
 console.log(`crashloop fixture booting v${version} — this app is designed to crash`)
 
 // Uncaught synchronous throw. The runtime catches this and calls
-// esp_restart() after the panicRestartDelay grace window from
+// esp_restart() after the onPanic delay grace window from
 // mikro.config.ts, so the device enters a tight reboot cycle.
 //
 // Alternative forcible variant (uncomment to bypass the runtime entirely):

--- a/dev/crashloop/mikro.config.ts
+++ b/dev/crashloop/mikro.config.ts
@@ -5,6 +5,6 @@ import {defineConfig} from 'mikrojs'
 // `mikro dev` or `mikro clean` can't land a command between reboots. Only
 // `mikro ... --recover` can break out.
 export default defineConfig({
-  panicRestartDelay: 2000,
+  onPanic: {mode: 'restart', delay: 2000},
   logFile: {maxSize: 1024},
 })

--- a/docs/config.md
+++ b/docs/config.md
@@ -21,21 +21,33 @@ export default defineConfig({
 
 These options are bundled into the deployed app and read by the firmware at boot.
 
-| Option              | Type                | Default          | Description                                         |
-| ------------------- | ------------------- | ---------------- | --------------------------------------------------- |
-| `panicRestartDelay` | `number` (ms)       | `1000`           | Grace window between uncaught exception and restart |
-| `stackSize`         | `number` (bytes)    | firmware default | QuickJS C stack size                                |
-| `memReserved`       | `number` (bytes)    | `65536` (64 KB)  | Heap reserved for native subsystems                 |
-| `wifi.country`      | `WifiCountryCode`   | none             | WiFi regulatory country code                        |
-| `wifi.hostname`     | `string`            | `mikrojs-<id>`   | DHCP hostname advertised by the STA interface       |
-| `logFile`           | `true \| object`    | off              | Enable on-device file logging                       |
-| `logFile.dir`       | `string`            | `'/appfs/logs'`  | Directory the log file lives in                     |
-| `logFile.maxSize`   | `number \| string`  | `'64k'`          | Rotate when file exceeds this size                  |
-| `logFile.flush`     | `'line' \| 'error'` | `'error'`        | When to flush buffered writes to flash              |
+| Option            | Type                | Default                          | Description                                      |
+| ----------------- | ------------------- | -------------------------------- | ------------------------------------------------ |
+| `onPanic`         | `object`            | `{mode: 'restart', delay: 1000}` | What the device does after an uncaught exception |
+| `stackSize`       | `number` (bytes)    | firmware default                 | QuickJS C stack size                             |
+| `memReserved`     | `number` (bytes)    | `65536` (64 KB)                  | Heap reserved for native subsystems              |
+| `wifi.country`    | `WifiCountryCode`   | none                             | WiFi regulatory country code                     |
+| `wifi.hostname`   | `string`            | `mikrojs-<id>`                   | DHCP hostname advertised by the STA interface    |
+| `logFile`         | `true \| object`    | off                              | Enable on-device file logging                    |
+| `logFile.dir`     | `string`            | `'/appfs/logs'`                  | Directory the log file lives in                  |
+| `logFile.maxSize` | `number \| string`  | `'64k'`                          | Rotate when file exceeds this size               |
+| `logFile.flush`   | `'line' \| 'error'` | `'error'`                        | When to flush buffered writes to flash           |
 
-### `panicRestartDelay`
+### `onPanic`
 
-The runtime always restarts the device when an uncaught exception reaches the top level so apps in the field can self-heal. `panicRestartDelay` controls the grace window (in milliseconds) between the exception and the actual `esp_restart()`. During this window the protocol REPL stays responsive so the host can land `mikro deploy` / `mikro clean` / `mikro ... --recover` commands and break a tight crash loop. Longer windows are friendlier to dev iteration; shorter windows make a self-healing device converge faster. See [Error Handling](/error-handling) for details.
+When an uncaught exception reaches the top level (a "panic"), the device restarts. `onPanic` configures what happens between the exception and that restart.
+
+`delay` is the time in milliseconds the device waits before acting (default `1000`). While it waits, the protocol REPL stays responsive, so you can run `mikro deploy`, `mikro clean`, or `mikro ... --recover` to break a crash loop. Use a longer delay during development to give yourself time to recover the device; use a shorter delay in production so it restarts sooner.
+
+- **`{mode: 'restart', delay?}`** (default): restart after the delay.
+- **`{mode: 'deepSleep', delay?, duration}`**: enter deep sleep for `duration` ms after the delay, then restart on wake. This draws far less power than restarting straight away, which matters for battery-powered devices. The device is unreachable while asleep, so set a longer `delay` during development to keep a window for recovery.
+
+```ts
+// Battery device: sleep immediately, retry every 10 minutes
+onPanic: {mode: 'deepSleep', delay: 0, duration: 600000}
+```
+
+See [Error Handling](/error-handling) for details.
 
 ### `stackSize`
 
@@ -165,7 +177,7 @@ All size options accept a number of bytes or a string with K/M suffix (e.g. `'30
 import {defineConfig} from 'mikrojs'
 
 export default defineConfig({
-  panicRestartDelay: 500,
+  onPanic: {mode: 'restart', delay: 500},
   memReserved: 32 * 1024,
   wifi: {
     country: 'NO', // Norway

--- a/docs/developing-for-microcontrollers.md
+++ b/docs/developing-for-microcontrollers.md
@@ -177,7 +177,7 @@ if (!result.ok) {
 }
 ```
 
-For truly unrecoverable errors (missing config, hardware failure at boot), use `.orPanic()`. The runtime always restarts the device after an uncaught exception so apps in the field can self-heal; tune the grace window via [`panicRestartDelay`](/config#panicrestartdelay).
+For truly unrecoverable errors (missing config, hardware failure at boot), use `.orPanic()`. The runtime always restarts the device after an uncaught exception so apps in the field can self-heal; tune the grace window and recovery behavior via [`onPanic`](/config#onpanic).
 
 ## Host simulator
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -219,13 +219,13 @@ import {env} from 'mikrojs/env'
 const ssid = env.require('WIFI_SSID')
 ```
 
-The runtime always restarts the device on an uncaught exception so deployed apps can self-heal. Tune [`panicRestartDelay`](/config#panicrestartdelay) (the grace window between the exception and the actual reboot) to match your environment. Longer for friendlier dev iteration, shorter for faster convergence in the field:
+The runtime restarts the device after an uncaught exception, so a deployed app recovers on its own. Use [`onPanic`](/config#onpanic) to control this: `delay` sets how long the device waits before acting (use a longer delay during development to give yourself time to recover the device, a shorter one in production), and `mode` chooses whether it restarts right away or deep-sleeps to save power first:
 
 ```ts twoslash
 import {defineConfig} from 'mikrojs'
 
 export default defineConfig({
-  panicRestartDelay: 500,
+  onPanic: {mode: 'restart', delay: 500},
 })
 ```
 

--- a/docs/internals/runtime-lifecycle.md
+++ b/docs/internals/runtime-lifecycle.md
@@ -81,7 +81,9 @@ Runtime behavior is controlled by `MIKConfig`:
 
 ```c
 typedef struct MIKConfig {
-    int panic_restart_delay_ms;
+    int panic_restart_delay_ms;   // grace window before the panic action
+    MIKPanicMode panic_mode;      // MIK_PANIC_RESTART | MIK_PANIC_DEEP_SLEEP
+    int panic_sleep_duration_ms;  // deep-sleep length (deep-sleep mode only)
     size_t stack_size;
     uint32_t mem_reserved;
     uint32_t fs_read_max;  // 0 = keep runtime default (65536)
@@ -124,7 +126,7 @@ The runtime can be stopped in several ways:
 - **Uncaught exception**: Detected at the top of each loop iteration
 - **Explicit stop**: `MIK_Stop(mik_rt)` sets `stop_requested`
 
-After an uncaught exception, `MIK_Stop()` records a deadline `panic_restart_delay_ms` in the future on `MIKRuntime.restart_at_us`. `MIK_Loop()` keeps the protocol REPL pumping (no more user JS) until the deadline elapses, then calls `platform->restart()` so the host can land deploy / clean / --recover commands during the grace window.
+After an uncaught exception, `MIK_Stop()` records a deadline `panic_restart_delay_ms` in the future on `MIKRuntime.restart_at_us`. `MIK_Loop()` keeps the protocol REPL pumping (no more user JS) until the deadline elapses, then takes the configured panic action: `platform->restart()` (default), or `platform->deep_sleep_us()` for `panic_sleep_duration_ms` when `panic_mode` is `MIK_PANIC_DEEP_SLEEP` (the timer wake reboots the chip). The host can land deploy / clean / --recover commands during the grace window; deep-sleep forfeits that window once asleep.
 
 ## Destruction
 

--- a/packages/@mikrojs/firmware/components/mikrojs/platform_esp32.cpp
+++ b/packages/@mikrojs/firmware/components/mikrojs/platform_esp32.cpp
@@ -5,6 +5,7 @@
 #include <esp_heap_caps.h>
 #include <esp_mac.h>
 #include <esp_random.h>
+#include <esp_sleep.h>
 #include <esp_system.h>
 #include <esp_rtc_time.h>
 #include <esp_timer.h>
@@ -38,6 +39,16 @@ static uint32_t esp32_random(void) {
 
 static void esp32_restart(void) {
     esp_restart();
+}
+
+static void esp32_deep_sleep_us(uint64_t us) {
+    /* Flush + close the file log so buffered lines reach flash; deep sleep
+     * reboots the chip on wake, same as mik__sleep_deep does for the JS API. */
+    mik_logfile_close();
+    esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_ALL);
+    esp_sleep_enable_timer_wakeup(us);
+    esp_deep_sleep_start();
+    /* Never reached */
 }
 
 static void esp32_yield(void) {
@@ -205,6 +216,7 @@ static const MIKPlatform esp32_platform = {
     .get_rtc_us = esp32_get_rtc_us,
     .random = esp32_random,
     .restart = esp32_restart,
+    .deep_sleep_us = esp32_deep_sleep_us,
     .yield = esp32_yield,
     .get_free_system_mem = esp32_get_free_system_mem,
     .get_min_free_system_mem = esp32_get_min_free_system_mem,

--- a/packages/@mikrojs/native/include/mikrojs/mikrojs.h
+++ b/packages/@mikrojs/native/include/mikrojs/mikrojs.h
@@ -29,8 +29,20 @@ typedef enum MIKLogFlush {
     MIK_LOG_FLUSH_LINE = 1,
 } MIKLogFlush;
 
+/* What the device does after an uncaught exception (a "panic"). Mirror of
+ * the `onPanic.mode` field in the host-side TS config. */
+typedef enum MIKPanicMode {
+    MIK_PANIC_RESTART = 0,    /* default: reboot after the grace window */
+    MIK_PANIC_DEEP_SLEEP = 1, /* deep-sleep panic_sleep_duration_ms; wake reboots */
+} MIKPanicMode;
+
 typedef struct MIKConfig {
+    /* Grace window after a panic, awake and reachable, before the action
+     * fires (applies to both modes). */
     int panic_restart_delay_ms;
+    MIKPanicMode panic_mode;
+    /* Deep-sleep length for MIK_PANIC_DEEP_SLEEP; ignored otherwise. */
+    int panic_sleep_duration_ms;
     size_t stack_size;
     uint32_t mem_reserved;
     uint32_t fs_read_max; /* 0 = keep runtime default (65536) */

--- a/packages/@mikrojs/native/include/mikrojs/platform.h
+++ b/packages/@mikrojs/native/include/mikrojs/platform.h
@@ -14,6 +14,10 @@ typedef struct MIKPlatform {
     int64_t (*get_rtc_us)(void);        /* RTC timer, survives deep sleep */
     uint32_t (*random)(void);
     void (*restart)(void);
+    /** Enter deep sleep for `us` microseconds; the timer wake reboots the
+     *  chip, so this never returns on hardware. NULL on platforms without
+     *  deep sleep (hosts), where callers fall back to restart(). */
+    void (*deep_sleep_us)(uint64_t us);
     void (*yield)(void);
     size_t (*get_free_system_mem)(void);
     size_t (*get_min_free_system_mem)(void); /* All-time low watermark */

--- a/packages/@mikrojs/native/src/mik_app_config.cpp
+++ b/packages/@mikrojs/native/src/mik_app_config.cpp
@@ -13,6 +13,8 @@ static const char* TAG = "mik_app_config";
 
 void MIK_DefaultConfig(MIKConfig* config) {
     config->panic_restart_delay_ms = 1000;
+    config->panic_mode = MIK_PANIC_RESTART;
+    config->panic_sleep_duration_ms = 0;
     config->stack_size = 0;
     config->mem_reserved = 64 * 1024;
     config->fs_read_max = 0; /* 0 = runtime default (65536) */
@@ -318,8 +320,18 @@ int MIK_LoadConfig(const char* base_path, MIKConfig* config) {
         if (buf) {
             double num_val;
 
-            if (mik__json_get_number(buf, "panicRestartDelay", &num_val)) {
+            if (mik__json_get_number(buf, "onPanic.delay", &num_val)) {
                 config->panic_restart_delay_ms = (int)num_val;
+            }
+            char panic_mode_str[16];
+            if (mik__json_get_string(buf, "onPanic.mode", panic_mode_str,
+                                     sizeof(panic_mode_str))) {
+                config->panic_mode = strcmp(panic_mode_str, "deepSleep") == 0
+                                         ? MIK_PANIC_DEEP_SLEEP
+                                         : MIK_PANIC_RESTART;
+            }
+            if (mik__json_get_number(buf, "onPanic.duration", &num_val)) {
+                config->panic_sleep_duration_ms = (int)num_val;
             }
             if (mik__json_get_number(buf, "stackSize", &num_val)) {
                 config->stack_size = (size_t)num_val;

--- a/packages/@mikrojs/native/src/mikrojs.cpp
+++ b/packages/@mikrojs/native/src/mikrojs.cpp
@@ -542,6 +542,14 @@ int MIK_Loop(MIKRuntime* mik_rt) {
     if (mik_rt->restart_at_us > 0) {
         const MIKPlatform* platform = MIK_GetPlatform();
         if (platform->get_boot_us() >= mik_rt->restart_at_us) {
+            /* The grace window has elapsed; take the configured panic action.
+             * In deep-sleep mode the timer wake reboots the chip, so the wake
+             * IS the restart — and the live --recover window is forfeit by
+             * design (the CPU is suspended). If the platform has no deep-sleep
+             * hook (hosts), fall through to a plain restart. */
+            if (mik_rt->config.panic_mode == MIK_PANIC_DEEP_SLEEP && platform->deep_sleep_us) {
+                platform->deep_sleep_us((uint64_t)mik_rt->config.panic_sleep_duration_ms * 1000);
+            }
             platform->restart();
         }
         return 0;

--- a/packages/@mikrojs/native/test/app_config_test.cpp
+++ b/packages/@mikrojs/native/test/app_config_test.cpp
@@ -179,14 +179,33 @@ TEST_CASE("MIK_LoadConfig reads mikro.config.json settings" * doctest::test_suit
     auto dir = make_temp_dir();
     write_file(dir + "/package.json", R"({"name": "test", "main": "./main.js"})");
     write_file(dir + "/mikro.config.json",
-               R"({"panicRestartDelay": 5000, "stackSize": 32768, "memReserved": 131072})");
+               R"({"onPanic.delay": 5000, "stackSize": 32768, "memReserved": 131072})");
 
     MIKConfig config;
     MIK_LoadConfig(dir.c_str(), &config);
 
     CHECK_EQ(5000, config.panic_restart_delay_ms);
+    CHECK_EQ(MIK_PANIC_RESTART, config.panic_mode); /* default when mode absent */
     CHECK_EQ(32768, (int)config.stack_size);
     CHECK_EQ((uint32_t)131072, config.mem_reserved);
+
+    remove_file(dir + "/mikro.config.json");
+    remove_file(dir + "/package.json");
+    rmdir(dir.c_str());
+}
+
+TEST_CASE("MIK_LoadConfig reads onPanic deepSleep mode" * doctest::test_suite("config")) {
+    auto dir = make_temp_dir();
+    write_file(dir + "/package.json", R"({"name": "test", "main": "./main.js"})");
+    write_file(dir + "/mikro.config.json",
+               R"({"onPanic.mode": "deepSleep", "onPanic.delay": 0, "onPanic.duration": 600000})");
+
+    MIKConfig config;
+    MIK_LoadConfig(dir.c_str(), &config);
+
+    CHECK_EQ(MIK_PANIC_DEEP_SLEEP, config.panic_mode);
+    CHECK_EQ(0, config.panic_restart_delay_ms);
+    CHECK_EQ(600000, config.panic_sleep_duration_ms);
 
     remove_file(dir + "/mikro.config.json");
     remove_file(dir + "/package.json");

--- a/packages/mikrojs/src/_exports/index.ts
+++ b/packages/mikrojs/src/_exports/index.ts
@@ -118,13 +118,28 @@ export interface MikroJSLogFileOptions {
   flush?: LogFlush
 }
 
+/** What the device does after an uncaught exception (a "panic").
+ *
+ * `delay` is the grace window (ms) the device stays awake and reachable
+ * before acting. The protocol REPL keeps servicing deploy / clean /
+ * --recover commands during it, so a long enough delay lets the host break
+ * a tight crash loop; short enough keeps the device converging when no one
+ * is watching. Default: `1000`.
+ *
+ * - `restart` (default): reboot after the grace window.
+ * - `deepSleep`: deep-sleep for `duration` ms after the grace window; the
+ *   timer wake reboots the chip (the wake IS the restart). Conserves battery
+ *   for field devices, at the cost of being unreachable while asleep. Keep
+ *   `delay` low (or `0`) in the field; raise it on the bench so you can still
+ *   grab the device before it goes dark. */
+export type MikroJSPanicAction =
+  | {mode: 'restart'; delay?: number}
+  | {mode: 'deepSleep'; delay?: number; duration: number}
+
 export interface MikroJSConfig {
-  /** Grace window (in ms) between an uncaught exception and the
-   * subsequent device restart. The protocol REPL stays responsive to
-   * deploy / clean / --recover commands during this window — long enough
-   * lets the host break a tight crash loop, short enough keeps the device
-   * converging when no one is watching. Default: `1000`. */
-  panicRestartDelay?: number
+  /** Behavior after an uncaught exception. Default:
+   * `{mode: 'restart', delay: 1000}`. */
+  onPanic?: MikroJSPanicAction
   stackSize?: number
   memReserved?: number
   /** Maximum size in bytes for a single readFile() call. Files larger than

--- a/packages/mikrojs/src/cli/lib/build.ts
+++ b/packages/mikrojs/src/cli/lib/build.ts
@@ -164,11 +164,16 @@ const DEFAULT_LOG_DIR = '/appfs/logs'
 // form so the device-side JSON parser (mik_app_config.cpp) can read them
 // without a nested-object pass.
 function serializeRuntimeConfig(config: MikroJSConfig): Record<string, unknown> {
-  const {sim: _sim, build: _build, wifi, logFile, fsReadMax, ...rest} = config
+  const {sim: _sim, build: _build, wifi, logFile, fsReadMax, onPanic, ...rest} = config
   const out: Record<string, unknown> = {...rest}
   if (fsReadMax !== undefined) out.fsReadMax = parseSize(fsReadMax)
   if (wifi?.country) out['wifi.country'] = wifi.country
   if (wifi?.hostname) out['wifi.hostname'] = wifi.hostname
+  if (onPanic !== undefined) {
+    out['onPanic.mode'] = onPanic.mode
+    if (onPanic.delay !== undefined) out['onPanic.delay'] = onPanic.delay
+    if (onPanic.mode === 'deepSleep') out['onPanic.duration'] = onPanic.duration
+  }
   if (logFile !== undefined) {
     const opts = logFile === true ? {} : logFile
     out['logFile.dir'] = opts.dir ?? DEFAULT_LOG_DIR


### PR DESCRIPTION
Adds a `deepSleep` panic mode so devices can power down between crash retries instead. The `delay` grace window still keeps the device awake and reachable for `--recover` before the action fires.

BREAKING CHANGE: the flat `panicRestartDelay: N` config is replaced by `onPanic: {mode: 'restart', delay: N}`. Use `{mode: 'deepSleep', delay, duration}` to deep-sleep on panic.