### PR TITLE
feat(cli)!: rename env flags to --env-file/--no-auto-env

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,17 +15,17 @@ Start development mode with live reload. Builds your TypeScript, deploys it to t
 mikro dev [ENTRY]
 ```
 
-| Option             | Description                                                           |
-| ------------------ | --------------------------------------------------------------------- |
-| `ENTRY`            | Entry file (default: `main` field in package.json)                    |
-| `-p, --port PORT`  | Serial port (auto-detected if omitted)                                |
-| `--env FILE`       | Extra `.env` file, layered on top of auto-discovery                   |
-| `--no-env-file`    | Skip auto-loading of `.env` and `.env.development`                    |
-| `--force-deploy`   | Force full deploy, ignoring cached checksums                          |
-| `--no-minify`      | Skip minification                                                     |
-| `--no-bytecode`    | Skip bytecode compilation                                             |
-| `--loglevel LEVEL` | Log level: `none`, `error`, `warn`, `info`, `debug`. Default: `debug` |
-| `--json`           | Output as JSON                                                        |
+| Option             | Description                                                                                             |
+| ------------------ | ------------------------------------------------------------------------------------------------------- |
+| `ENTRY`            | Entry file (default: `main` field in package.json)                                                      |
+| `-p, --port PORT`  | Serial port (auto-detected if omitted)                                                                  |
+| `--env-file FILE`  | Extra `.env` file, applied last (highest priority); see [precedence](/environment-variables#precedence) |
+| `--no-auto-env`    | Skip auto-loading of `.env` and `.env.development`                                                      |
+| `--force-deploy`   | Force full deploy, ignoring cached checksums                                                            |
+| `--no-minify`      | Skip minification                                                                                       |
+| `--no-bytecode`    | Skip bytecode compilation                                                                               |
+| `--loglevel LEVEL` | Log level: `none`, `error`, `warn`, `info`, `debug`. Default: `debug`                                   |
+| `--json`           | Output as JSON                                                                                          |
 
 See [Build options](#build-options) for details on `--no-minify`, `--loglevel`, and other build flags.
 
@@ -43,8 +43,8 @@ mikro deploy [ENTRY]
 | ------------------ | ---------------------------------------------------------------------------------------------------------------- |
 | `ENTRY`            | Entry file (default: `main` field in package.json)                                                               |
 | `-p, --port PORT`  | Serial port (auto-detected if omitted)                                                                           |
-| `--env FILE`       | Extra `.env` file, layered on top of auto-discovery                                                              |
-| `--no-env-file`    | Skip auto-loading of `.env` and `.env.production`                                                                |
+| `--env-file FILE`  | Extra `.env` file, applied last (highest priority); see [precedence](/environment-variables#precedence)          |
+| `--no-auto-env`    | Skip auto-loading of `.env` and `.env.production`                                                                |
 | `--console`        | Attach console after deploy and restart device                                                                   |
 | `-e, --erase`      | Erase current app before uploading                                                                               |
 | `--recover`        | Reset into safe mode before deploying. See [Troubleshooting](/troubleshooting#recovering-a-crash-looping-device) |
@@ -175,19 +175,19 @@ Run on-device tests. Discovers `*.test.ts` files, deploys them, and reports stru
 mikro test [PATTERN]
 ```
 
-| Option                    | Description                                                 |
-| ------------------------- | ----------------------------------------------------------- |
-| `PATTERN`                 | Glob pattern to filter test files (default: `**/*.test.ts`) |
-| `-p, --port PORT`         | Serial port (auto-detected if omitted)                      |
-| `--env FILE`              | Extra `.env` file, layered on top of auto-discovery         |
-| `--no-env-file`           | Skip auto-loading of `.env` and `.env.test`                 |
-| `--no-minify`             | Skip minification                                           |
-| `--no-bytecode`           | Skip bytecode compilation                                   |
-| `-t, --timeout MS`        | Per-file timeout in ms (default: `60000`)                   |
-| `--update-heap-baselines` | Overwrite committed per-file heap-baseline snapshots        |
-| `--diagnostics`           | Show per-test heap progress and supervisor announcements    |
-| `-y, --yes`               | Skip confirmation prompt                                    |
-| `--json`                  | Output as JSON                                              |
+| Option                    | Description                                                                                             |
+| ------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `PATTERN`                 | Glob pattern to filter test files (default: `**/*.test.ts`)                                             |
+| `-p, --port PORT`         | Serial port (auto-detected if omitted)                                                                  |
+| `--env-file FILE`         | Extra `.env` file, applied last (highest priority); see [precedence](/environment-variables#precedence) |
+| `--no-auto-env`           | Skip auto-loading of `.env` and `.env.test`                                                             |
+| `--no-minify`             | Skip minification                                                                                       |
+| `--no-bytecode`           | Skip bytecode compilation                                                                               |
+| `-t, --timeout MS`        | Per-file timeout in ms (default: `60000`)                                                               |
+| `--update-heap-baselines` | Overwrite committed per-file heap-baseline snapshots                                                    |
+| `--diagnostics`           | Show per-test heap progress and supervisor announcements                                                |
+| `-y, --yes`               | Skip confirmation prompt                                                                                |
+| `--json`                  | Output as JSON                                                                                          |
 
 See [Build options](#build-options) for details on `--no-minify` and other build flags.
 
@@ -199,7 +199,7 @@ mikro test
 mikro test 'test/smoke.test.ts'
 
 # Run with env vars
-mikro test --env .env
+mikro test --env-file .env
 ```
 
 Test files import from `mikrojs/test`:
@@ -332,13 +332,13 @@ Watch + build + deploy + REPL against the simulator. The sim equivalent of `mikr
 mikro sim dev [ENTRY]
 ```
 
-| Option          | Description                                         |
-| --------------- | --------------------------------------------------- |
-| `ENTRY`         | Entry file (default: `main` field in package.json)  |
-| `--env FILE`    | Extra `.env` file, layered on top of auto-discovery |
-| `--no-env-file` | Skip auto-loading of `.env` and `.env.simulator`    |
-| `--no-minify`   | Skip minification                                   |
-| `--no-bytecode` | Skip bytecode compilation                           |
+| Option            | Description                                                                                             |
+| ----------------- | ------------------------------------------------------------------------------------------------------- |
+| `ENTRY`           | Entry file (default: `main` field in package.json)                                                      |
+| `--env-file FILE` | Extra `.env` file, applied last (highest priority); see [precedence](/environment-variables#precedence) |
+| `--no-auto-env`   | Skip auto-loading of `.env` and `.env.simulator`                                                        |
+| `--no-minify`     | Skip minification                                                                                       |
+| `--no-bytecode`   | Skip bytecode compilation                                                                               |
 
 ### mikro sim deploy
 
@@ -348,16 +348,16 @@ One-shot build + deploy to the simulator (no watch). The sim equivalent of `mikr
 mikro sim deploy [ENTRY]
 ```
 
-| Option          | Description                                         |
-| --------------- | --------------------------------------------------- |
-| `ENTRY`         | Entry file (default: `main` field in package.json)  |
-| `--env FILE`    | Extra `.env` file, layered on top of auto-discovery |
-| `--no-env-file` | Skip auto-loading of `.env` and `.env.simulator`    |
-| `-e, --erase`   | Erase current app before uploading                  |
-| `--no-restart`  | Do not restart sim after deploy                     |
-| `--no-minify`   | Skip minification                                   |
-| `--no-bytecode` | Skip bytecode compilation                           |
-| `--json`        | Output as JSON                                      |
+| Option            | Description                                                                                             |
+| ----------------- | ------------------------------------------------------------------------------------------------------- |
+| `ENTRY`           | Entry file (default: `main` field in package.json)                                                      |
+| `--env-file FILE` | Extra `.env` file, applied last (highest priority); see [precedence](/environment-variables#precedence) |
+| `--no-auto-env`   | Skip auto-loading of `.env` and `.env.simulator`                                                        |
+| `-e, --erase`     | Erase current app before uploading                                                                      |
+| `--no-restart`    | Do not restart sim after deploy                                                                         |
+| `--no-minify`     | Skip minification                                                                                       |
+| `--no-bytecode`   | Skip bytecode compilation                                                                               |
+| `--json`          | Output as JSON                                                                                          |
 
 ### mikro sim repl
 
@@ -375,17 +375,17 @@ Discover and run `*.test.ts` files in the simulator. The sim equivalent of `mikr
 mikro sim test [PATTERN]
 ```
 
-| Option                    | Description                                                 |
-| ------------------------- | ----------------------------------------------------------- |
-| `PATTERN`                 | Glob pattern to filter test files (default: `**/*.test.ts`) |
-| `--env FILE`              | Extra `.env` file, layered on top of auto-discovery         |
-| `--no-env-file`           | Skip auto-loading of `.env` and `.env.simulator`            |
-| `--no-minify`             | Skip minification                                           |
-| `--no-bytecode`           | Skip bytecode compilation                                   |
-| `-t, --timeout MS`        | Per-file timeout in ms (default: `60000`)                   |
-| `--update-heap-baselines` | Overwrite committed per-file heap-baseline snapshots        |
-| `--diagnostics`           | Show per-test heap progress and supervisor announcements    |
-| `--json`                  | Output as JSON                                              |
+| Option                    | Description                                                                                             |
+| ------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `PATTERN`                 | Glob pattern to filter test files (default: `**/*.test.ts`)                                             |
+| `--env-file FILE`         | Extra `.env` file, applied last (highest priority); see [precedence](/environment-variables#precedence) |
+| `--no-auto-env`           | Skip auto-loading of `.env` and `.env.simulator`                                                        |
+| `--no-minify`             | Skip minification                                                                                       |
+| `--no-bytecode`           | Skip bytecode compilation                                                                               |
+| `-t, --timeout MS`        | Per-file timeout in ms (default: `60000`)                                                               |
+| `--update-heap-baselines` | Overwrite committed per-file heap-baseline snapshots                                                    |
+| `--diagnostics`           | Show per-test heap progress and supervisor announcements                                                |
+| `--json`                  | Output as JSON                                                                                          |
 
 ### mikro sim env
 
@@ -426,22 +426,22 @@ Run your app in the simulator and report per-module QuickJS heap usage, so you c
 mikro sim profile [ENTRY]
 ```
 
-| Option               | Description                                                |
-| -------------------- | ---------------------------------------------------------- |
-| `ENTRY`              | Entry file (default: `main` field in package.json)         |
-| `--mem-limit BYTES`  | QuickJS heap ceiling for the profile run (default: `32M`)  |
-| `--memory-budget KB` | Highlight rows against an explicit budget in KB            |
-| `--chip NAME`        | Preset budget for a chip (e.g. `esp32c6`, `esp32s3`)       |
-| `--top N`            | Show only the N largest modules                            |
-| `--sort KEY`         | Sort by `size` (default) or `order` (load order)           |
-| `--min-bytes N`      | Hide modules smaller than N bytes                          |
-| `--include-native`   | Include `native:*` runtime modules (excluded by default)   |
-| `--include-builtins` | Include `mikrojs/*` built-in modules (excluded by default) |
-| `--only-native`      | Show only `native:*` modules                               |
-| `--only-builtins`    | Show only `mikrojs/*` built-ins                            |
-| `--json`             | Output as JSON                                             |
-| `--env FILE`         | Extra `.env` file, layered on top of auto-discovery        |
-| `--no-env-file`      | Skip auto-loading of `.env` and `.env.development`         |
+| Option               | Description                                                                                             |
+| -------------------- | ------------------------------------------------------------------------------------------------------- |
+| `ENTRY`              | Entry file (default: `main` field in package.json)                                                      |
+| `--mem-limit BYTES`  | QuickJS heap ceiling for the profile run (default: `32M`)                                               |
+| `--memory-budget KB` | Highlight rows against an explicit budget in KB                                                         |
+| `--chip NAME`        | Preset budget for a chip (e.g. `esp32c6`, `esp32s3`)                                                    |
+| `--top N`            | Show only the N largest modules                                                                         |
+| `--sort KEY`         | Sort by `size` (default) or `order` (load order)                                                        |
+| `--min-bytes N`      | Hide modules smaller than N bytes                                                                       |
+| `--include-native`   | Include `native:*` runtime modules (excluded by default)                                                |
+| `--include-builtins` | Include `mikrojs/*` built-in modules (excluded by default)                                              |
+| `--only-native`      | Show only `native:*` modules                                                                            |
+| `--only-builtins`    | Show only `mikrojs/*` built-ins                                                                         |
+| `--json`             | Output as JSON                                                                                          |
+| `--env-file FILE`    | Extra `.env` file, applied last (highest priority); see [precedence](/environment-variables#precedence) |
+| `--no-auto-env`      | Skip auto-loading of `.env` and `.env.development`                                                      |
 
 By default, `native:*` runtime modules and `mikrojs/*` built-ins are hidden so you see only your own code's heap cost. Use `--include-native` / `--include-builtins` to add them back, or `--only-native` / `--only-builtins` for a focused view of just those categories.
 
@@ -495,7 +495,7 @@ Then start a fresh shell session and try:
 
 ```sh
 mikro <TAB>              # → dev, deploy, env, build, flash, ...
-mikro dev --<TAB>        # → --port, --env, --no-minify, ...
+mikro dev --<TAB>        # → --port, --env-file, --no-minify, ...
 mikro dev --port <TAB>   # → live serial devices on your machine
 ```
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -99,13 +99,13 @@ Every entry is treated as a secret by default. Add a `# @no-secret` comment line
 
 #### Precedence
 
-Auto-loaded in this order, with later files overriding earlier ones:
+Files are loaded in the order below and **merged per key**: a variable set in a later source overrides the same variable from an earlier one, while keys a later source doesn't mention are left untouched. The last source therefore has the highest priority.
 
-1. `.env`
+1. `.env` (lowest priority)
 2. `.env.<mode>`: where `<mode>` matches the `MIKRO_ENV` value the command sets (see [Built-in variables](#mikro-env) below). For example: `.env.development` for `mikro dev`, `.env.production` for `mikro deploy`, `.env.test` for `mikro test`, `.env.simulator` for any `mikro sim …` command.
-3. `--env FILE`: extra file passed explicitly (additive)
+3. `--env-file FILE`: an extra file passed explicitly, layered on top (highest priority)
 
-Auto-discovered files are silently skipped if missing. An explicit `--env` path errors if the file doesn't exist.
+Auto-discovered files (1 and 2) are silently skipped if missing. An explicit `--env-file` errors if the file doesn't exist. `--no-auto-env` removes steps 1 and 2, leaving only `--env-file` if given.
 
 ::: warning .env files should never be committed
 The `create-mikrojs` scaffold gitignores `.env*`. Commit `.env.example` instead to share the shape of the variables your project expects.
@@ -117,14 +117,14 @@ Names must be 15 characters or fewer. The CLI errors with the full list of offen
 
 #### Opting out
 
-Pass `--no-env-file` to skip auto-discovery. An explicit `--env` file still loads:
+Pass `--no-auto-env` to skip auto-discovery. A file passed via `--env-file` still loads:
 
 ```sh
-# Use only what's in the shell environment (CI scenarios)
-npx mikro deploy --no-env-file
+# Skip auto-discovery entirely (deploy with no project env vars)
+npx mikro deploy --no-auto-env
 
-# Skip auto-discovery, but still load this one file
-npx mikro deploy --no-env-file --env=ci.env
+# Skip auto-discovery, but still load this one file (e.g. in CI)
+npx mikro deploy --no-auto-env --env-file=ci.env
 ```
 
 ## Built-in variables

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -286,7 +286,7 @@ mikro test 'test/math.test.ts'
 
 ### With environment variables
 
-`mikro test` auto-loads `.env` and `.env.test` from the project root. Pass `--env FILE` to layer an extra file on top, or `--no-env-file` to skip auto-discovery. See [Environment Variables](/environment-variables) for the full precedence rules.
+`mikro test` auto-loads `.env` and `.env.test` from the project root. Pass `--env-file FILE` to layer an extra file on top, or `--no-auto-env` to skip auto-discovery. See [Environment Variables](/environment-variables) for the full precedence rules.
 
 The `MIKRO_ENV` variable is automatically set to `"test"` during test runs. Use it for conditional behavior:
 

--- a/packages/mikrojs/src/cli/commands/deploy.tsx
+++ b/packages/mikrojs/src/cli/commands/deploy.tsx
@@ -51,12 +51,12 @@ export const args = command(
       }),
     ),
     env: optional(
-      option('--env', string({metavar: 'FILE'}), {
+      option('--env-file', path({metavar: 'FILE', type: 'file', mustExist: true}), {
         description: message`Path to .env file with environment variables`,
       }),
     ),
-    noEnvFile: optional(
-      flag('--no-env-file', {
+    noAutoEnv: optional(
+      flag('--no-auto-env', {
         description: message`Skip auto-loading of .env and .env.production from the project root`,
       }),
     ),
@@ -169,7 +169,7 @@ export async function run(
       cwd: resolveProjectRoot(),
       mode: 'production',
       envFile: config.env,
-      noEnvFile: config.noEnvFile === true,
+      noAutoEnv: config.noAutoEnv === true,
     })),
   ]
   validateNvsKeys(envVars)

--- a/packages/mikrojs/src/cli/commands/dev.tsx
+++ b/packages/mikrojs/src/cli/commands/dev.tsx
@@ -55,12 +55,12 @@ export const args = command(
       }),
     ),
     env: optional(
-      option('--env', string({metavar: 'FILE'}), {
+      option('--env-file', path({metavar: 'FILE', type: 'file', mustExist: true}), {
         description: message`Path to .env file with environment variables`,
       }),
     ),
-    noEnvFile: optional(
-      flag('--no-env-file', {
+    noAutoEnv: optional(
+      flag('--no-auto-env', {
         description: message`Skip auto-loading of .env and .env.development from the project root`,
       }),
     ),
@@ -99,7 +99,7 @@ export async function run(config: InferValue<typeof args>) {
           minifyLevel: parseMinifyLevel(config.minifyLevel),
           logLevel: parseLogLevel(config.logLevel),
           envFile: config.env,
-          noEnvFile: config.noEnvFile === true,
+          noAutoEnv: config.noAutoEnv === true,
           externalDeploys$: deploys$.asObservable(),
         })
 
@@ -187,7 +187,7 @@ export default function Dev(props: Props) {
         minifyLevel,
         logLevel,
         envFile: props.args.env,
-        noEnvFile: props.args.noEnvFile === true,
+        noAutoEnv: props.args.noAutoEnv === true,
       })
       return {run$: dev.state$, dispose: () => dev.close()}
     },
@@ -202,7 +202,7 @@ export default function Dev(props: Props) {
       minifyLevel,
       logLevel,
       props.args.env,
-      props.args.noEnvFile,
+      props.args.noAutoEnv,
     ],
   )
 

--- a/packages/mikrojs/src/cli/commands/sim/deploy.ts
+++ b/packages/mikrojs/src/cli/commands/sim/deploy.ts
@@ -24,12 +24,12 @@ export const args = command(
     subcommand: constant('deploy' as const),
     entry: optional(argument(path({metavar: 'ENTRY', mustExist: true, type: 'file'}))),
     env: optional(
-      option('--env', string({metavar: 'FILE'}), {
+      option('--env-file', path({metavar: 'FILE', type: 'file', mustExist: true}), {
         description: message`Path to .env file with environment variables`,
       }),
     ),
-    noEnvFile: optional(
-      flag('--no-env-file', {
+    noAutoEnv: optional(
+      flag('--no-auto-env', {
         description: message`Skip auto-loading of .env and .env.simulator from the project root`,
       }),
     ),
@@ -60,7 +60,7 @@ export const args = command(
 interface RunConfig {
   entry?: string
   env?: string
-  noEnvFile?: boolean
+  noAutoEnv?: boolean
   erase?: boolean
   noRestart?: boolean
   noMinify?: boolean
@@ -99,7 +99,7 @@ export async function run(config: RunConfig): Promise<void> {
         cwd: resolveProjectRoot(),
         mode: 'simulator',
         envFile: config.env,
-        noEnvFile: config.noEnvFile === true,
+        noAutoEnv: config.noAutoEnv === true,
       })),
     ]
 

--- a/packages/mikrojs/src/cli/commands/sim/dev.tsx
+++ b/packages/mikrojs/src/cli/commands/sim/dev.tsx
@@ -59,12 +59,12 @@ export const args = command(
       }),
     ),
     env: optional(
-      option('--env', string({metavar: 'FILE'}), {
+      option('--env-file', path({metavar: 'FILE', type: 'file', mustExist: true}), {
         description: message`Path to .env file with environment variables`,
       }),
     ),
-    noEnvFile: optional(
-      flag('--no-env-file', {
+    noAutoEnv: optional(
+      flag('--no-auto-env', {
         description: message`Skip auto-loading of .env and .env.simulator from the project root`,
       }),
     ),
@@ -88,7 +88,7 @@ interface DevConfig {
   noHooks?: boolean
   logLevel?: string
   env?: string
-  noEnvFile?: boolean
+  noAutoEnv?: boolean
   noWatch?: boolean
   agent?: boolean
 }
@@ -111,7 +111,7 @@ function devSessionOptions(config: DevConfig) {
     minifyLevel: parseMinifyLevel(config.minifyLevel),
     logLevel: parseLogLevel(config.logLevel),
     envFile: config.env,
-    noEnvFile: config.noEnvFile === true,
+    noAutoEnv: config.noAutoEnv === true,
     mode: 'simulator' as const,
   }
 }
@@ -152,7 +152,7 @@ export async function run(config: DevConfig): Promise<void> {
     minifyLevel: opts.minifyLevel,
     logLevel: opts.logLevel,
     envFile: opts.envFile,
-    noEnvFile: opts.noEnvFile,
+    noAutoEnv: opts.noAutoEnv,
     externalDeploys$: deploys$.asObservable(),
     mode: opts.mode,
   })
@@ -377,7 +377,7 @@ function SimDevMode(props: DevModeProps) {
         minifyLevel: opts.minifyLevel,
         logLevel: opts.logLevel,
         envFile: opts.envFile,
-        noEnvFile: opts.noEnvFile,
+        noAutoEnv: opts.noAutoEnv,
         mode: opts.mode,
       })
 
@@ -432,7 +432,7 @@ function SimDevMode(props: DevModeProps) {
     opts.minifyLevel,
     opts.logLevel,
     opts.envFile,
-    opts.noEnvFile,
+    opts.noAutoEnv,
   ])
 
   if (error && !conn) {

--- a/packages/mikrojs/src/cli/commands/sim/profile.ts
+++ b/packages/mikrojs/src/cli/commands/sim/profile.ts
@@ -104,12 +104,12 @@ export const args = command(
     ),
     json: optional(flag('--json', {description: message`Output as JSON`})),
     env: optional(
-      option('--env', string({metavar: 'FILE'}), {
+      option('--env-file', path({metavar: 'FILE', type: 'file', mustExist: true}), {
         description: message`Path to .env file with environment variables`,
       }),
     ),
-    noEnvFile: optional(
-      flag('--no-env-file', {
+    noAutoEnv: optional(
+      flag('--no-auto-env', {
         description: message`Skip auto-loading of .env and .env.development from the project root`,
       }),
     ),
@@ -150,7 +150,7 @@ interface RunConfig {
   minifyLevel?: string
   json?: boolean
   env?: string
-  noEnvFile?: boolean
+  noAutoEnv?: boolean
 }
 
 export async function run(config: RunConfig): Promise<void> {
@@ -194,7 +194,7 @@ async function runImpl(config: RunConfig): Promise<void> {
       cwd: resolveProjectRoot(),
       mode: 'development',
       envFile: config.env,
-      noEnvFile: config.noEnvFile === true,
+      noAutoEnv: config.noAutoEnv === true,
     })),
   ]
 

--- a/packages/mikrojs/src/cli/commands/sim/test.ts
+++ b/packages/mikrojs/src/cli/commands/sim/test.ts
@@ -5,6 +5,7 @@ import {command, constant, message, multiple, optional} from '@optique/core'
 import {object} from '@optique/core/constructs'
 import {argument, flag, option} from '@optique/core/primitives'
 import {string} from '@optique/core/valueparser'
+import {path} from '@optique/run'
 
 import {agentEmit, agentError, agentResult, isAgentMode} from '../../lib/agent.js'
 import {loadEnvFiles} from '../../lib/deploy.js'
@@ -29,9 +30,9 @@ export const args = command(
         description: message`Test file paths and/or glob patterns. Pass one or more. Default: **/*.test.ts`,
       }),
     ),
-    env: optional(option('--env', string({metavar: 'FILE'}))),
-    noEnvFile: optional(
-      flag('--no-env-file', {
+    env: optional(option('--env-file', path({metavar: 'FILE', type: 'file', mustExist: true}))),
+    noAutoEnv: optional(
+      flag('--no-auto-env', {
         description: message`Skip auto-loading of .env and .env.simulator from the project root`,
       }),
     ),
@@ -79,7 +80,7 @@ interface RunConfig {
   filters?: readonly string[]
   env?: string
   secrets?: string
-  noEnvFile?: boolean
+  noAutoEnv?: boolean
   noMinify?: boolean
   minifier?: string
   minifyLevel?: string
@@ -141,7 +142,7 @@ export async function run(config: RunConfig): Promise<void> {
     cwd: resolveProjectRoot(),
     mode: 'simulator',
     envFile: config.env,
-    noEnvFile: config.noEnvFile === true,
+    noAutoEnv: config.noAutoEnv === true,
   })
   if (envVars.length > 0) log(`Loaded ${envVars.length} env var(s) from file`)
   const timeoutMs = config.timeout ? parseInt(config.timeout, 10) : 60_000

--- a/packages/mikrojs/src/cli/commands/test.tsx
+++ b/packages/mikrojs/src/cli/commands/test.tsx
@@ -5,6 +5,7 @@ import {object} from '@optique/core/constructs'
 import type {InferValue} from '@optique/core/parser'
 import {argument, flag, option} from '@optique/core/primitives'
 import {string} from '@optique/core/valueparser'
+import {path} from '@optique/run'
 
 import {agentEmit, agentResult, isAgentMode} from '../lib/agent.js'
 import {loadEnvFiles, validateNvsKeys} from '../lib/deploy.js'
@@ -36,12 +37,12 @@ export const args = command(
       }),
     ),
     env: optional(
-      option('--env', string({metavar: 'FILE'}), {
+      option('--env-file', path({metavar: 'FILE', type: 'file', mustExist: true}), {
         description: message`Path to .env file`,
       }),
     ),
-    noEnvFile: optional(
-      flag('--no-env-file', {
+    noAutoEnv: optional(
+      flag('--no-auto-env', {
         description: message`Skip auto-loading of .env and .env.test from the project root`,
       }),
     ),
@@ -153,7 +154,7 @@ export async function run(config: InferValue<typeof args>): Promise<void> {
     cwd: resolveProjectRoot(),
     mode: 'test',
     envFile: config.env,
-    noEnvFile: config.noEnvFile === true,
+    noAutoEnv: config.noAutoEnv === true,
   })
   validateNvsKeys(envVars)
   if (envVars.length > 0) {

--- a/packages/mikrojs/src/cli/lib/__test__/loadEnvFiles.test.ts
+++ b/packages/mikrojs/src/cli/lib/__test__/loadEnvFiles.test.ts
@@ -52,12 +52,12 @@ describe('loadEnvFiles', () => {
     expect(vars).to.deep.equal([{key: 'FOO', value: 'explicit', secret: true}])
   })
 
-  it('skips auto-discovery when noEnvFile is true', async () => {
+  it('skips auto-discovery when noAutoEnv is true', async () => {
     writeFileSync(pathlib.join(cwd, '.env'), 'FOO=bar\n')
-    expect(await loadEnvFiles({cwd, mode: 'development', noEnvFile: true})).to.deep.equal([])
+    expect(await loadEnvFiles({cwd, mode: 'development', noAutoEnv: true})).to.deep.equal([])
   })
 
-  it('still loads explicit envFile when noEnvFile is true', async () => {
+  it('still loads explicit envFile when noAutoEnv is true', async () => {
     writeFileSync(pathlib.join(cwd, '.env'), 'FOO=auto\n')
     const explicit = pathlib.join(cwd, 'explicit.env')
     writeFileSync(explicit, 'FOO=explicit\n')
@@ -65,7 +65,7 @@ describe('loadEnvFiles', () => {
       cwd,
       mode: 'development',
       envFile: explicit,
-      noEnvFile: true,
+      noAutoEnv: true,
     })
     expect(vars).to.deep.equal([{key: 'FOO', value: 'explicit', secret: true}])
   })

--- a/packages/mikrojs/src/cli/lib/deploy.ts
+++ b/packages/mikrojs/src/cli/lib/deploy.ts
@@ -89,10 +89,10 @@ export interface LoadEnvOptions {
   cwd: string
   /** Mode name used to discover .env.<mode> (e.g. 'development', 'production', 'test'). */
   mode: string
-  /** Explicit --env FILE path (additive, layered after auto-discovery). */
+  /** Explicit --env-file FILE path (additive, layered after auto-discovery). */
   envFile?: string
   /** When true, skips auto-discovery of .env / .env.<mode>. Explicit files still load. */
-  noEnvFile?: boolean
+  noAutoEnv?: boolean
 }
 
 async function readDotenvFile(path: string): Promise<EnvVar[]> {
@@ -106,9 +106,9 @@ async function readDotenvFile(path: string): Promise<EnvVar[]> {
 
 /**
  * Load env vars from .env files with precedence (later overrides earlier):
- *   1. <cwd>/.env                  (auto, skipped when noEnvFile)
- *   2. <cwd>/.env.<mode>           (auto, skipped when noEnvFile)
- *   3. opts.envFile                (explicit --env, error if missing)
+ *   1. <cwd>/.env                  (auto, skipped when noAutoEnv)
+ *   2. <cwd>/.env.<mode>           (auto, skipped when noAutoEnv)
+ *   3. opts.envFile                (explicit --env-file, error if missing)
  *
  * Auto-discovered files are silently skipped if missing.
  * Returned array is deduped by key with last-wins semantics.
@@ -119,7 +119,7 @@ async function readDotenvFile(path: string): Promise<EnvVar[]> {
 export async function loadEnvFiles(opts: LoadEnvOptions): Promise<EnvVar[]> {
   const vars: EnvVar[] = []
 
-  if (!opts.noEnvFile) {
+  if (!opts.noAutoEnv) {
     const base = pathlib.join(opts.cwd, '.env')
     if (await fileExists(base)) {
       vars.push(...(await readDotenvFile(base)))

--- a/packages/mikrojs/src/cli/lib/serial/devSession.ts
+++ b/packages/mikrojs/src/cli/lib/serial/devSession.ts
@@ -77,7 +77,7 @@ export function createDevSession(options: {
   minifyLevel?: MinifyLevel
   logLevel?: LogLevel
   envFile?: string
-  noEnvFile?: boolean
+  noAutoEnv?: boolean
   /** Drives `MIKRO_ENV` and the `.env.<mode>` file picked up by
    *  `loadEnvFiles`. `mikro dev` passes `'development'` (default);
    *  `mikro sim dev` passes `'simulator'`. */
@@ -97,7 +97,7 @@ export function createDevSession(options: {
     minifyLevel,
     logLevel,
     envFile,
-    noEnvFile,
+    noAutoEnv,
     mode = 'development',
   } = options
   const buildDir = pathlib.join(getMikroDir(), 'build')
@@ -190,7 +190,7 @@ export function createDevSession(options: {
             cwd: projectRoot,
             mode,
             envFile,
-            noEnvFile,
+            noAutoEnv,
           })),
         ]
         validateNvsKeys(envVars)


### PR DESCRIPTION
Renames for clarity and convention:
- `--env` -> `--env-file`
- `--no-env-file` -> `--no-auto-env`

Also switches the value parser from string() to path({type:'file', mustExist:true}) so the value autocompletes file paths and a missing file fails at parse time (before hooks/build run) instead of after.

BREAKING CHANGE:
`--env` is now `--env-file` and `--no-env-file` is now `--no-auto-env` across deploy, dev, test, and all sim subcommands.