### PR TITLE
feat(analyze-imports): bump ecmaVersion from 2025 to 2026 in parser config

### DIFF
--- a/packages/@mikrojs/analyze-imports/src/analyze.ts
+++ b/packages/@mikrojs/analyze-imports/src/analyze.ts
@@ -35,7 +35,7 @@ export default async function analyze(
 
   try {
     ast = Parser.parse(code, {
-      ecmaVersion: 2025,
+      ecmaVersion: 2026,
       sourceType: 'module',
       allowAwaitOutsideFunction: true,
     }) as unknown as Node


### PR DESCRIPTION
enables support for e.g. `using`