### PR TITLE
chore: remove redundant maturity period configuration and sync notes

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,7 +41,6 @@ catalogs:
 
 ignoreWorkspaceRootCheck: true
 
-# Note: keep in sync with maturityPeriod in taze.config.ts
 minimumReleaseAge: 1440 # minutes
 
 trustPolicy: no-downgrade

--- a/taze.config.ts
+++ b/taze.config.ts
@@ -6,9 +6,6 @@ export default defineConfig({
   // ignore package.json that in other workspaces (with their own .git,pnpm-workspace.yaml,etc.)
   ignoreOtherWorkspaces: true,
 
-  // Note: keep in sync with minimumReleaseAge in pnpm-workspace.yaml
-  maturityPeriod: 1, // days
-
   packageMode: {
     node: 'minor',
     '@types/node': 'minor',


### PR DESCRIPTION
Inferred from pnpm workspace config as of https://github.com/antfu-collective/taze/releases/tag/v19.13.0