### PR TITLE
feat(eslint-plugin): add no-bigint rule for the runtime's missing intrinsic

### DIFF
--- a/packages/@mikrojs/eslint-plugin/src/index.ts
+++ b/packages/@mikrojs/eslint-plugin/src/index.ts
@@ -1,3 +1,4 @@
+import {noBigInt} from './rules/no-bigint.js'
 import {noDeviceImportsInConfig} from './rules/no-device-imports-in-config.js'
 import {noDotCatch} from './rules/no-dot-catch.js'
 import {noEval} from './rules/no-eval.js'
@@ -22,6 +23,7 @@ const plugin = {
     'no-dot-catch': noDotCatch,
     'no-eval': noEval,
     'no-intl': noIntl,
+    'no-bigint': noBigInt,
     'no-temporal': noTemporal,
     'no-sparse-arrays': noSparseArrays,
     'no-device-imports-in-config': noDeviceImportsInConfig,
@@ -47,6 +49,7 @@ Object.assign(plugin.configs, {
         '@mikrojs/no-dot-catch': 'error',
         '@mikrojs/no-eval': 'error',
         '@mikrojs/no-intl': 'error',
+        '@mikrojs/no-bigint': 'error',
         '@mikrojs/no-temporal': 'error',
         '@mikrojs/no-sparse-arrays': 'warn',
         '@mikrojs/no-device-imports-in-config': 'error',

--- a/packages/@mikrojs/eslint-plugin/src/rules/no-bigint.test.ts
+++ b/packages/@mikrojs/eslint-plugin/src/rules/no-bigint.test.ts
@@ -1,0 +1,46 @@
+import {RuleTester} from '@typescript-eslint/rule-tester'
+import {afterAll, describe, it} from 'vitest'
+
+import {noBigInt} from './no-bigint.js'
+
+RuleTester.afterAll = afterAll
+RuleTester.describe = describe
+RuleTester.it = it
+
+const ruleTester = new RuleTester()
+
+ruleTester.run('no-bigint', noBigInt, {
+  valid: [
+    'const n = 42',
+    'Number.MAX_SAFE_INTEGER',
+    'new Int32Array(1)',
+    'const obj = {BigInt: 1}',
+    'foo.BigInt',
+  ],
+  invalid: [
+    {
+      code: 'const n = 123n',
+      errors: [{messageId: 'noBigInt'}],
+    },
+    {
+      code: 'const n = BigInt(5)',
+      errors: [{messageId: 'noBigInt'}],
+    },
+    {
+      code: 'BigInt.asIntN(64, 1n)',
+      errors: [{messageId: 'noBigInt'}, {messageId: 'noBigInt'}],
+    },
+    {
+      code: 'new BigInt64Array(1)',
+      errors: [{messageId: 'noBigInt'}],
+    },
+    {
+      code: 'new BigUint64Array(1)',
+      errors: [{messageId: 'noBigInt'}],
+    },
+    {
+      code: 'BigInt64Array.from([])',
+      errors: [{messageId: 'noBigInt'}],
+    },
+  ],
+})

--- a/packages/@mikrojs/eslint-plugin/src/rules/no-bigint.ts
+++ b/packages/@mikrojs/eslint-plugin/src/rules/no-bigint.ts
@@ -1,0 +1,32 @@
+import {ESLintUtils, type TSESTree} from '@typescript-eslint/utils'
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/mikrojs/mikrojs/blob/main/docs/rules/${name}.md`,
+)
+
+export const noBigInt = createRule({
+  name: 'no-bigint',
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow use of BigInt. The mikrojs runtime omits the BigInt intrinsic to save memory, so it is not available at runtime.',
+    },
+    messages: {
+      noBigInt:
+        'BigInt is not available in the mikrojs runtime. Use Number, typed arrays, or string-based math instead.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const report = (node: TSESTree.Node) => context.report({node, messageId: 'noBigInt'})
+    return {
+      'Literal[bigint]': report,
+      'CallExpression[callee.name="BigInt"]': report,
+      'MemberExpression[object.name="BigInt"]': report,
+      'NewExpression[callee.name=/^Big(Int|Uint)64Array$/]': report,
+      'MemberExpression[object.name=/^Big(Int|Uint)64Array$/]': report,
+    }
+  },
+})


### PR DESCRIPTION
The mikrojs runtime omits the BigInt intrinsic to save memory, so any BigInt usage throws at runtime. tsconfig can't catch this: BigInt globals ride into the es2024 lib transitively (via sharedmemory) and 123n literals are target-gated, not lib-gated. A lint rule is the only thing that flags it at author time, mirroring the existing no-intl/no-temporal guardrails.

Covers literals (123n), BigInt() calls, BigInt static methods, and BigInt64Array/BigUint64Array. Enabled as error in configs.recommended.