### PR TITLE
feat(mikrojs): export shared tsconfig base as mikrojs/tsconfig

### DIFF
--- a/dev/crashloop/tsconfig.json
+++ b/dev/crashloop/tsconfig.json
@@ -1,24 +1,4 @@
 {
-  "include": ["./**/*"],
-  "compilerOptions": {
-    "module": "nodenext",
-    "target": "es2024",
-    "lib": ["ES2024"],
-    "noEmit": true,
-    "types": ["mikrojs/runtime"],
-    "sourceMap": true,
-    "noUncheckedIndexedAccess": true,
-    "erasableSyntaxOnly": true,
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowUnreachableCode": false
-  }
+  "extends": "mikrojs/tsconfig",
+  "include": ["./**/*"]
 }

--- a/dev/e2e/tsconfig.json
+++ b/dev/e2e/tsconfig.json
@@ -1,24 +1,4 @@
 {
-  "include": ["./**/*"],
-  "compilerOptions": {
-    "module": "nodenext",
-    "target": "es2024",
-    "lib": ["ES2024"],
-    "noEmit": true,
-    "types": ["mikrojs/runtime"],
-    "sourceMap": true,
-    "noUncheckedIndexedAccess": true,
-    "erasableSyntaxOnly": true,
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowUnreachableCode": false
-  }
+  "extends": "mikrojs/tsconfig",
+  "include": ["./**/*"]
 }

--- a/dev/errors/tsconfig.json
+++ b/dev/errors/tsconfig.json
@@ -1,24 +1,4 @@
 {
-  "include": ["./**/*"],
-  "compilerOptions": {
-    "module": "nodenext",
-    "target": "es2024",
-    "lib": ["ES2024"],
-    "noEmit": true,
-    "types": ["mikrojs/runtime"],
-    "sourceMap": true,
-    "noUncheckedIndexedAccess": true,
-    "erasableSyntaxOnly": true,
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowUnreachableCode": false
-  }
+  "extends": "mikrojs/tsconfig",
+  "include": ["./**/*"]
 }

--- a/dev/kitchen-sink/tsconfig.json
+++ b/dev/kitchen-sink/tsconfig.json
@@ -1,24 +1,4 @@
 {
-  "include": ["./**/*"],
-  "compilerOptions": {
-    "module": "nodenext",
-    "target": "es2024",
-    "lib": ["ES2024"],
-    "noEmit": true,
-    "types": ["mikrojs/runtime"],
-    "sourceMap": true,
-    "noUncheckedIndexedAccess": true,
-    "erasableSyntaxOnly": true,
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowUnreachableCode": false
-  }
+  "extends": "mikrojs/tsconfig",
+  "include": ["./**/*"]
 }

--- a/dev/logging/tsconfig.json
+++ b/dev/logging/tsconfig.json
@@ -1,24 +1,4 @@
 {
-  "include": ["./**/*"],
-  "compilerOptions": {
-    "module": "nodenext",
-    "target": "es2024",
-    "lib": ["ES2024"],
-    "noEmit": true,
-    "types": ["mikrojs/runtime"],
-    "sourceMap": true,
-    "noUncheckedIndexedAccess": true,
-    "erasableSyntaxOnly": true,
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowUnreachableCode": false
-  }
+  "extends": "mikrojs/tsconfig",
+  "include": ["./**/*"]
 }

--- a/dev/oom/tsconfig.json
+++ b/dev/oom/tsconfig.json
@@ -1,24 +1,4 @@
 {
-  "include": ["./**/*"],
-  "compilerOptions": {
-    "module": "nodenext",
-    "target": "es2024",
-    "lib": ["ES2024"],
-    "noEmit": true,
-    "types": ["mikrojs/runtime"],
-    "sourceMap": true,
-    "noUncheckedIndexedAccess": true,
-    "erasableSyntaxOnly": true,
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowUnreachableCode": false
-  }
+  "extends": "mikrojs/tsconfig",
+  "include": ["./**/*"]
 }

--- a/dev/probe/tsconfig.json
+++ b/dev/probe/tsconfig.json
@@ -1,24 +1,4 @@
 {
-  "include": ["./**/*"],
-  "compilerOptions": {
-    "module": "nodenext",
-    "target": "es2024",
-    "lib": ["ES2024"],
-    "noEmit": true,
-    "types": ["mikrojs/runtime"],
-    "sourceMap": true,
-    "noUncheckedIndexedAccess": true,
-    "erasableSyntaxOnly": true,
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowUnreachableCode": false
-  }
+  "extends": "mikrojs/tsconfig",
+  "include": ["./**/*"]
 }

--- a/dev/sram-pressure/tsconfig.json
+++ b/dev/sram-pressure/tsconfig.json
@@ -1,24 +1,4 @@
 {
-  "include": ["./**/*"],
-  "compilerOptions": {
-    "module": "nodenext",
-    "target": "es2024",
-    "lib": ["ES2024"],
-    "noEmit": true,
-    "types": ["mikrojs/runtime"],
-    "sourceMap": true,
-    "noUncheckedIndexedAccess": true,
-    "erasableSyntaxOnly": true,
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowUnreachableCode": false
-  }
+  "extends": "mikrojs/tsconfig",
+  "include": ["./**/*"]
 }

--- a/dev/stackoverflow/tsconfig.json
+++ b/dev/stackoverflow/tsconfig.json
@@ -1,24 +1,4 @@
 {
-  "include": ["./**/*"],
-  "compilerOptions": {
-    "module": "nodenext",
-    "target": "es2024",
-    "lib": ["ES2024"],
-    "noEmit": true,
-    "types": ["mikrojs/runtime"],
-    "sourceMap": true,
-    "noUncheckedIndexedAccess": true,
-    "erasableSyntaxOnly": true,
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowUnreachableCode": false
-  }
+  "extends": "mikrojs/tsconfig",
+  "include": ["./**/*"]
 }

--- a/examples/blank/tsconfig.json
+++ b/examples/blank/tsconfig.json
@@ -1,24 +1,4 @@
 {
-  "include": ["./**/*"],
-  "compilerOptions": {
-    "module": "nodenext",
-    "target": "es2024",
-    "lib": ["ES2024"],
-    "noEmit": true,
-    "types": ["mikrojs/runtime"],
-    "sourceMap": true,
-    "noUncheckedIndexedAccess": true,
-    "erasableSyntaxOnly": true,
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowUnreachableCode": false
-  }
+  "extends": "mikrojs/tsconfig",
+  "include": ["./**/*"]
 }

--- a/examples/ble-beacon/tsconfig.json
+++ b/examples/ble-beacon/tsconfig.json
@@ -1,24 +1,4 @@
 {
-  "include": ["./**/*"],
-  "compilerOptions": {
-    "module": "nodenext",
-    "target": "es2024",
-    "lib": ["ES2024"],
-    "noEmit": true,
-    "types": ["mikrojs/runtime"],
-    "sourceMap": true,
-    "noUncheckedIndexedAccess": true,
-    "erasableSyntaxOnly": true,
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowUnreachableCode": false
-  }
+  "extends": "mikrojs/tsconfig",
+  "include": ["./**/*"]
 }

--- a/examples/ble-gatt/tsconfig.json
+++ b/examples/ble-gatt/tsconfig.json
@@ -1,24 +1,4 @@
 {
-  "include": ["./**/*"],
-  "compilerOptions": {
-    "module": "nodenext",
-    "target": "es2024",
-    "lib": ["ES2024"],
-    "noEmit": true,
-    "types": ["mikrojs/runtime"],
-    "sourceMap": true,
-    "noUncheckedIndexedAccess": true,
-    "erasableSyntaxOnly": true,
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowUnreachableCode": false
-  }
+  "extends": "mikrojs/tsconfig",
+  "include": ["./**/*"]
 }

--- a/examples/blinky/tsconfig.json
+++ b/examples/blinky/tsconfig.json
@@ -1,24 +1,4 @@
 {
-  "include": ["./**/*"],
-  "compilerOptions": {
-    "module": "nodenext",
-    "target": "es2024",
-    "lib": ["ES2024"],
-    "noEmit": true,
-    "types": ["mikrojs/runtime"],
-    "sourceMap": true,
-    "noUncheckedIndexedAccess": true,
-    "erasableSyntaxOnly": true,
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowUnreachableCode": false
-  }
+  "extends": "mikrojs/tsconfig",
+  "include": ["./**/*"]
 }

--- a/examples/neopixel/tsconfig.json
+++ b/examples/neopixel/tsconfig.json
@@ -1,24 +1,4 @@
 {
-  "include": ["./**/*"],
-  "compilerOptions": {
-    "module": "nodenext",
-    "target": "es2024",
-    "lib": ["ES2024"],
-    "noEmit": true,
-    "types": ["mikrojs/runtime"],
-    "sourceMap": true,
-    "noUncheckedIndexedAccess": true,
-    "erasableSyntaxOnly": true,
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowUnreachableCode": false
-  }
+  "extends": "mikrojs/tsconfig",
+  "include": ["./**/*"]
 }

--- a/examples/pwm-led/tsconfig.json
+++ b/examples/pwm-led/tsconfig.json
@@ -1,24 +1,4 @@
 {
-  "include": ["./**/*"],
-  "compilerOptions": {
-    "module": "nodenext",
-    "target": "es2024",
-    "lib": ["ES2024"],
-    "noEmit": true,
-    "types": ["mikrojs/runtime"],
-    "sourceMap": true,
-    "noUncheckedIndexedAccess": true,
-    "erasableSyntaxOnly": true,
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowUnreachableCode": false
-  }
+  "extends": "mikrojs/tsconfig",
+  "include": ["./**/*"]
 }

--- a/examples/rtc-counter/tsconfig.json
+++ b/examples/rtc-counter/tsconfig.json
@@ -1,24 +1,4 @@
 {
-  "include": ["./**/*"],
-  "compilerOptions": {
-    "module": "nodenext",
-    "target": "es2024",
-    "lib": ["ES2024"],
-    "noEmit": true,
-    "types": ["mikrojs/runtime"],
-    "sourceMap": true,
-    "noUncheckedIndexedAccess": true,
-    "erasableSyntaxOnly": true,
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowUnreachableCode": false
-  }
+  "extends": "mikrojs/tsconfig",
+  "include": ["./**/*"]
 }

--- a/examples/schema/tsconfig.json
+++ b/examples/schema/tsconfig.json
@@ -1,24 +1,4 @@
 {
-  "include": ["./**/*"],
-  "compilerOptions": {
-    "module": "nodenext",
-    "target": "es2024",
-    "lib": ["ES2024"],
-    "noEmit": true,
-    "types": ["mikrojs/runtime"],
-    "sourceMap": true,
-    "noUncheckedIndexedAccess": true,
-    "erasableSyntaxOnly": true,
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowUnreachableCode": false
-  }
+  "extends": "mikrojs/tsconfig",
+  "include": ["./**/*"]
 }

--- a/examples/sleep/tsconfig.json
+++ b/examples/sleep/tsconfig.json
@@ -1,24 +1,4 @@
 {
-  "include": ["./**/*"],
-  "compilerOptions": {
-    "module": "nodenext",
-    "target": "es2024",
-    "lib": ["ES2024"],
-    "noEmit": true,
-    "types": ["mikrojs/runtime"],
-    "sourceMap": true,
-    "noUncheckedIndexedAccess": true,
-    "erasableSyntaxOnly": true,
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowUnreachableCode": false
-  }
+  "extends": "mikrojs/tsconfig",
+  "include": ["./**/*"]
 }

--- a/examples/sntp/tsconfig.json
+++ b/examples/sntp/tsconfig.json
@@ -1,24 +1,4 @@
 {
-  "include": ["env.d.ts", "app/**/*", "mikro.config.ts"],
-  "compilerOptions": {
-    "module": "nodenext",
-    "target": "es2024",
-    "lib": ["ES2024"],
-    "noEmit": true,
-    "types": ["mikrojs/runtime"],
-    "sourceMap": true,
-    "noUncheckedIndexedAccess": true,
-    "erasableSyntaxOnly": true,
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowUnreachableCode": false
-  }
+  "extends": "mikrojs/tsconfig",
+  "include": ["env.d.ts", "app/**/*", "mikro.config.ts"]
 }

--- a/examples/uart/tsconfig.json
+++ b/examples/uart/tsconfig.json
@@ -1,24 +1,4 @@
 {
-  "include": ["./**/*"],
-  "compilerOptions": {
-    "module": "nodenext",
-    "target": "es2024",
-    "lib": ["ES2024"],
-    "noEmit": true,
-    "types": ["mikrojs/runtime"],
-    "sourceMap": true,
-    "noUncheckedIndexedAccess": true,
-    "erasableSyntaxOnly": true,
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowUnreachableCode": false
-  }
+  "extends": "mikrojs/tsconfig",
+  "include": ["./**/*"]
 }

--- a/examples/udp-discovery/tsconfig.json
+++ b/examples/udp-discovery/tsconfig.json
@@ -1,24 +1,4 @@
 {
-  "include": ["env.d.ts", "app/**/*", "scripts/**/*", "mikro.config.ts"],
-  "compilerOptions": {
-    "module": "nodenext",
-    "target": "es2024",
-    "lib": ["ES2024"],
-    "noEmit": true,
-    "types": ["mikrojs/runtime"],
-    "sourceMap": true,
-    "noUncheckedIndexedAccess": true,
-    "erasableSyntaxOnly": true,
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowUnreachableCode": false
-  }
+  "extends": "mikrojs/tsconfig",
+  "include": ["env.d.ts", "app/**/*", "scripts/**/*", "mikro.config.ts"]
 }

--- a/examples/wifi-access-point/tsconfig.json
+++ b/examples/wifi-access-point/tsconfig.json
@@ -1,24 +1,4 @@
 {
-  "include": ["./**/*"],
-  "compilerOptions": {
-    "module": "nodenext",
-    "target": "es2024",
-    "lib": ["ES2024"],
-    "noEmit": true,
-    "types": ["mikrojs/runtime"],
-    "sourceMap": true,
-    "noUncheckedIndexedAccess": true,
-    "erasableSyntaxOnly": true,
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowUnreachableCode": false
-  }
+  "extends": "mikrojs/tsconfig",
+  "include": ["./**/*"]
 }

--- a/examples/wifi-fetch/tsconfig.json
+++ b/examples/wifi-fetch/tsconfig.json
@@ -1,24 +1,4 @@
 {
-  "include": ["./**/*"],
-  "compilerOptions": {
-    "module": "nodenext",
-    "target": "es2024",
-    "lib": ["ES2024"],
-    "noEmit": true,
-    "types": ["mikrojs/runtime"],
-    "sourceMap": true,
-    "noUncheckedIndexedAccess": true,
-    "erasableSyntaxOnly": true,
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowUnreachableCode": false
-  }
+  "extends": "mikrojs/tsconfig",
+  "include": ["./**/*"]
 }

--- a/packages/create-mikrojs/src/scaffold.test.ts
+++ b/packages/create-mikrojs/src/scaffold.test.ts
@@ -94,9 +94,9 @@ describe.each(TEMPLATES)('template: $name', ({name}) => {
     expect(pkg.engines).toBeUndefined()
   })
 
-  it('creates tsconfig.json with mikrojs runtime types', () => {
+  it('creates tsconfig.json extending the mikrojs base config', () => {
     const tsconfig = JSON.parse(readFileSync(path.join(targetDir, 'tsconfig.json'), 'utf-8'))
-    expect(tsconfig.compilerOptions.types).toContain('mikrojs/runtime')
+    expect(tsconfig.extends).toBe('mikrojs/tsconfig')
     expect(tsconfig.include).toContain('app/**/*')
     expect(tsconfig.include).toContain('mikro.config.ts')
   })

--- a/packages/create-mikrojs/src/templates/_common/tsconfig.ts
+++ b/packages/create-mikrojs/src/templates/_common/tsconfig.ts
@@ -1,29 +1,8 @@
 export function tsconfigJson(extraIncludes: readonly string[] = []): string {
   const includes = [...extraIncludes, 'mikro.config.ts', 'app/**/*']
   return `{
-  "include": ${inlineStringArray(includes)},
-  "compilerOptions": {
-    "module": "nodenext",
-    "target": "es2024",
-    "lib": ${inlineStringArray(['es2024'])},
-    "noEmit": true,
-    "types": ${inlineStringArray(['mikrojs/runtime'])},
-    "sourceMap": true,
-    "noUncheckedIndexedAccess": true,
-    "allowUnreachableCode": false,
-    "erasableSyntaxOnly": true,
-    "strict": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "jsx": "preserve",
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
-  }
+  "extends": "mikrojs/tsconfig",
+  "include": ${inlineStringArray(includes)}
 }
 `
 }

--- a/packages/mikrojs/package.json
+++ b/packages/mikrojs/package.json
@@ -29,6 +29,7 @@
   "files": [
     "dist",
     "runtime.d.ts",
+    "tsconfig.base.json",
     "!**/__test__",
     "!**/*.test.js",
     "!**/*.test.d.ts"
@@ -158,6 +159,7 @@
       "development": "./src/_exports/test.ts",
       "import": "./dist/_exports/test.js"
     },
+    "./tsconfig": "./tsconfig.base.json",
     "./uart": {
       "development": "./src/_exports/uart.ts",
       "import": "./dist/_exports/uart.js"
@@ -204,6 +206,7 @@
       "./schema": "./dist/_exports/schema.js",
       "./sim": "./dist/_exports/sim.js",
       "./test": "./dist/_exports/test.js",
+      "./tsconfig": "./tsconfig.base.json",
       "./uart": "./dist/_exports/uart.js",
       "./udp": "./dist/_exports/udp.js",
       "./runtime": "./runtime.d.ts",

--- a/packages/mikrojs/tsconfig.base.json
+++ b/packages/mikrojs/tsconfig.base.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "target": "es2024",
+    "lib": ["es2024", "ESNext.Disposable"],
+    "noEmit": true,
+    "types": ["mikrojs/runtime"],
+    "sourceMap": true,
+    "noUncheckedIndexedAccess": true,
+    "allowUnreachableCode": false,
+    "erasableSyntaxOnly": true,
+    "strict": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noUncheckedSideEffectImports": true,
+    "moduleDetection": "force",
+    "jsx": "preserve",
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  }
+}


### PR DESCRIPTION
Adds shared `mikrojs/tsconfig` base config

usage:
```jsonc
{
  "extends": "mikrojs/tsconfig",
  "include": ["mikro.config.ts", "app/**/*"]
}
```
