### PR TITLE
fix(firmware)!: read the device id from the base MAC

### DIFF
--- a/packages/@mikrojs/firmware/components/mikrojs/platform_esp32.cpp
+++ b/packages/@mikrojs/firmware/components/mikrojs/platform_esp32.cpp
@@ -148,7 +148,12 @@ static const char* esp32_get_device_id(void) {
     static char id[11] = {0};  /* 6 bytes (48 bits) -> 10 x 5-bit chars + NUL */
     if (id[0] == '\0') {
         uint8_t m[6];
-        esp_efuse_mac_get_default(m);
+        /* Use the 48-bit base MAC, NOT esp_efuse_mac_get_default(): on 802.15.4
+         * chips (C6/H2) the factory MAC is an 8-byte EUI-64, so that call writes
+         * 8 bytes (overflowing this 6-byte buffer) and a 6-byte read yields the
+         * OUI+FF:FE prefix rather than a unique chip id. esp_read_mac(ESP_MAC_BASE)
+         * returns the proper 48-bit base MAC on every target. */
+        esp_read_mac(m, ESP_MAC_BASE);
         /* Pack 6 bytes into a 48-bit value, then extract 5 bits at a time
          * from the most significant end. */
         uint64_t v = ((uint64_t)m[0] << 40) | ((uint64_t)m[1] << 32) |


### PR DESCRIPTION
On chips with 802.15.4 (C6, H2, C5), esp_efuse_mac_get_default() returns an 8-byte EUI-64, not a 6-byte MAC. The old code read it into a 6-byte buffer. That overflowed the buffer and kept the wrong bytes: the OUI plus the EUI-64 FF:FE padding (54:32:04:FF:FE:22) instead of the chip's real MAC (54:32:04:22:7B:D4). The id was not unique and did not match the USB serial or the id the host computes from it.

esp_read_mac(ESP_MAC_BASE) returns the real 48-bit base MAC on every chip.

BREAKING CHANGE: the device id changes on 802.15.4 chips (C6, H2, C5, C61, H21, H4), from the old wrong value to the correct base-MAC id. Anything stored against the old id (device aliases, the device cache, deploy or console targeting by id, on-device kv) needs to be set again after updating firmware. Other chips (ESP32, S2, S3, C2, C3) are unchanged.