### PR TITLE
feat(cli): read devices on mismatched firmware for post-mortem

### DIFF
--- a/packages/mikro/src/cli/commands/env.tsx
+++ b/packages/mikro/src/cli/commands/env.tsx
@@ -83,8 +83,9 @@ export const args = command(
 async function withSession<T>(
   portArg: string | undefined,
   fn: (session: ReplSession) => Promise<T>,
+  compat: 'enforce' | 'best-effort' = 'enforce',
 ): Promise<T> {
-  const handles = await openSession({port: portArg})
+  const handles = await openSession({port: portArg, compat})
   try {
     return await fn(handles.session)
   } finally {
@@ -101,45 +102,51 @@ export async function run(config: InferValue<typeof args>) {
 
   switch (sub.subcommand) {
     case 'list': {
-      await withSession(sub.port, async (session) => {
-        const entries = await session.config.list()
+      // Read-only diagnostic: list a mismatched device's env anyway (warn,
+      // don't hard-fail). set/delete below mutate state, so they stay strict.
+      await withSession(
+        sub.port,
+        async (session) => {
+          const entries = await session.config.list()
 
-        if (jsonOutput) {
-          agentResult(
-            'env list',
-            entries.map((e) => ({
-              key: e.key,
-              value: e.secret ? undefined : e.value,
-              secret: e.secret,
-            })),
-            [
-              {command: 'mikro env set <KEY> <VALUE>', description: 'Set an env variable'},
-              {command: 'mikro env delete <KEY>', description: 'Delete an env variable'},
-            ],
-          )
-          return
-        }
-
-        if (entries.length === 0) {
-          console.log('No env variables configured')
-          return
-        }
-
-        const envEntries = entries.filter((e) => !e.secret)
-        const secretEntries = entries.filter((e) => e.secret)
-
-        if (envEntries.length > 0) {
-          const maxKeyLen = Math.max(...envEntries.map((e) => e.key.length))
-          for (const e of envEntries) {
-            console.log(`${e.key.padEnd(maxKeyLen)}  ${e.value}`)
+          if (jsonOutput) {
+            agentResult(
+              'env list',
+              entries.map((e) => ({
+                key: e.key,
+                value: e.secret ? undefined : e.value,
+                secret: e.secret,
+              })),
+              [
+                {command: 'mikro env set <KEY> <VALUE>', description: 'Set an env variable'},
+                {command: 'mikro env delete <KEY>', description: 'Delete an env variable'},
+              ],
+            )
+            return
           }
-        }
-        if (secretEntries.length > 0) {
-          for (const e of secretEntries) {
-            console.log(`${e.key}  ********`)
+
+          if (entries.length === 0) {
+            console.log('No env variables configured')
+            return
           }
-        }
-      })
+
+          const envEntries = entries.filter((e) => !e.secret)
+          const secretEntries = entries.filter((e) => e.secret)
+
+          if (envEntries.length > 0) {
+            const maxKeyLen = Math.max(...envEntries.map((e) => e.key.length))
+            for (const e of envEntries) {
+              console.log(`${e.key.padEnd(maxKeyLen)}  ${e.value}`)
+            }
+          }
+          if (secretEntries.length > 0) {
+            for (const e of secretEntries) {
+              console.log(`${e.key}  ********`)
+            }
+          }
+        },
+        'best-effort',
+      )
       break
     }
 

--- a/packages/mikro/src/cli/commands/logs.ts
+++ b/packages/mikro/src/cli/commands/logs.ts
@@ -79,7 +79,9 @@ async function runTail(sub: {
   logLevel: string | undefined
 }): Promise<void> {
   const logLevel = parseLogLevel(sub.logLevel) ?? 'debug'
-  const handles = await openSession({port: sub.port})
+  // Diagnostics: read the device's output even if its firmware version is
+  // out of range — pulling logs off a mismatched unit is the whole point.
+  const handles = await openSession({port: sub.port, compat: 'best-effort'})
 
   if (sub.restart) {
     handles.session.restart()
@@ -117,7 +119,9 @@ async function runPull(sub: {dest: string | undefined; port: string | undefined}
   const mainPath = `${logDir}/log.txt`
   const rotatedPath = `${mainPath}.1`
 
-  const handles = await openSession({port})
+  // Best-effort: a deployed unit on older firmware should still surrender
+  // its logs (see runTail).
+  const handles = await openSession({port, compat: 'best-effort'})
   try {
     if (dest === undefined) {
       /* Stream to stdout. Pull older rotated generation first so the dump

--- a/packages/mikro/src/cli/lib/__test__/firmwareCompat.test.ts
+++ b/packages/mikro/src/cli/lib/__test__/firmwareCompat.test.ts
@@ -2,7 +2,12 @@ import {createRequire} from 'node:module'
 
 import {describe, expect, it} from 'vitest'
 
-import {checkFirmwareCompat, formatAdvisory, formatIncompatibleError} from '../firmwareCompat.js'
+import {
+  checkFirmwareCompat,
+  formatAdvisory,
+  formatBestEffortWarning,
+  formatIncompatibleError,
+} from '../firmwareCompat.js'
 
 const require = createRequire(import.meta.url)
 const cliVersion = (require('../../../../package.json') as {version: string}).version
@@ -102,5 +107,24 @@ describe('formatIncompatibleError', () => {
     const msg = formatIncompatibleError(result, 'npm')
     expect(msg).to.contain('vunknown')
     expect(msg).to.contain('npx mikro flash')
+  })
+})
+
+describe('formatBestEffortWarning', () => {
+  it('suggests installing a matching CLI version when the device reported one', () => {
+    const result = checkFirmwareCompat('0.5.0')
+    const msg = formatBestEffortWarning(result, 'pnpm')
+    expect(msg).to.contain('v0.5.0')
+    expect(msg).to.contain('Attempting anyway')
+    expect(msg).to.contain('pnpm add mikro@0.5.0')
+    expect(msg).to.contain('pnpm mikro flash')
+  })
+
+  it('only suggests reflashing when the device reported no version', () => {
+    const result = checkFirmwareCompat(null)
+    const msg = formatBestEffortWarning(result, 'npm')
+    expect(msg).to.contain('did not report a version')
+    expect(msg).to.contain('npx mikro flash')
+    expect(msg).to.not.contain('mikro@')
   })
 })

--- a/packages/mikro/src/cli/lib/firmwareCompat.ts
+++ b/packages/mikro/src/cli/lib/firmwareCompat.ts
@@ -2,7 +2,12 @@ import {createRequire} from 'node:module'
 
 import {lt, major, minor, patch, satisfies} from 'semver'
 
-import {installLatestCommand, mikroCommand, type PkgManager} from './pkgManager.js'
+import {
+  installLatestCommand,
+  installVersionCommand,
+  mikroCommand,
+  type PkgManager,
+} from './pkgManager.js'
 
 export type FirmwareCompatStatus = 'match' | 'update_available' | 'incompatible'
 export type FirmwareCompatDirection = 'device_older' | 'device_newer'
@@ -88,4 +93,27 @@ export class FirmwareIncompatibleError extends Error {
 export function formatIncompatibleError(result: FirmwareCompatResult, pm: PkgManager): string {
   const got = result.deviceVersion ?? 'unknown'
   return `Device is running mikrojs v${got}, which is not compatible with this CLI (v${result.cliVersion}). Run ${mikroCommand(pm, 'flash')} to update device.`
+}
+
+/**
+ * Format the warning shown when a read-only diagnostic command proceeds
+ * against incompatible firmware (best-effort mode). Unlike the hard error,
+ * this points the user at matching the CLI to the device — the device may be
+ * a deployed unit you can't reflash, and the goal is to read its state. When
+ * the device reported a concrete version we suggest installing that exact CLI;
+ * otherwise (no version reported) the firmware predates version reporting, so
+ * only reflashing can help.
+ */
+export function formatBestEffortWarning(result: FirmwareCompatResult, pm: PkgManager): string {
+  const {deviceVersion, cliVersion: cli} = result
+  if (!deviceVersion) {
+    return [
+      `Device firmware did not report a version and may be too old for this CLI (v${cli}).`,
+      `Attempting anyway. If it fails, run ${mikroCommand(pm, 'flash')} to update the device.`,
+    ].join('\n')
+  }
+  return [
+    `Device is running mikrojs v${deviceVersion}, which is not compatible with this CLI (v${cli}).`,
+    `Attempting anyway. If it fails, install a matching CLI (${installVersionCommand(pm, 'mikro', deviceVersion)}) or run ${mikroCommand(pm, 'flash')} to update the device.`,
+  ].join('\n')
 }

--- a/packages/mikro/src/cli/lib/pkgManager.ts
+++ b/packages/mikro/src/cli/lib/pkgManager.ts
@@ -29,3 +29,9 @@ export function installLatestCommand(pm: PkgManager, pkg: string): string {
   const verb = pm === 'npm' ? 'install' : 'add'
   return `${pm} ${verb} ${pkg}@latest`
 }
+
+/** Render an "install a specific version of <pkg>" command appropriate for the pm. */
+export function installVersionCommand(pm: PkgManager, pkg: string, version: string): string {
+  const verb = pm === 'npm' ? 'install' : 'add'
+  return `${pm} ${verb} ${pkg}@${version}`
+}

--- a/packages/mikro/src/cli/lib/serial/openSession.ts
+++ b/packages/mikro/src/cli/lib/serial/openSession.ts
@@ -23,6 +23,12 @@ export interface OpenSessionOptions {
   recover?: boolean
   /** Called with the resolved device path before the serial is opened. */
   onConnecting?: (path: string) => void
+  /**
+   * Firmware-version policy. 'best-effort' lets read-only diagnostic
+   * commands proceed against incompatible firmware with a warning instead
+   * of a hard error. Defaults to 'enforce'. See ConnectReplOptions.compat.
+   */
+  compat?: 'enforce' | 'best-effort'
 }
 
 /**
@@ -41,7 +47,7 @@ export async function openSession(options: OpenSessionOptions): Promise<SessionH
   })
 
   const transport = createSerialTransport(serial)
-  const session = connectRepl(transport)
+  const session = connectRepl(transport, {compat: options.compat})
 
   if (options.recover === true) {
     await triggerSafeMode(serial)

--- a/packages/mikro/src/cli/lib/session.ts
+++ b/packages/mikro/src/cli/lib/session.ts
@@ -43,6 +43,7 @@ import {
   type FirmwareCompatDirection,
   FirmwareIncompatibleError,
   formatAdvisory,
+  formatBestEffortWarning,
   formatIncompatibleError,
 } from './firmwareCompat.js'
 import {detectPreferredPm} from './pkgManager.js'
@@ -78,7 +79,9 @@ import {TROUBLESHOOTING_URL} from './troubleshooting.js'
 // ── Event types ────────────────────────────────────────────────────
 
 export interface FirmwareAdvisory {
-  kind: FirmwareCompatDirection
+  /** 'incompatible' is only set in best-effort mode, where an out-of-range
+   *  firmware is downgraded from a hard error to a warning. */
+  kind: FirmwareCompatDirection | 'incompatible'
   message: string
 }
 
@@ -358,12 +361,24 @@ export class DeviceTimeoutError extends Error {
   }
 }
 
-export interface ConnectReplOptions {}
+export interface ConnectReplOptions {
+  /**
+   * Firmware-version policy for the handshake:
+   *   - 'enforce' (default): an incompatible firmware version throws
+   *     FirmwareIncompatibleError, blocking the command.
+   *   - 'best-effort': an incompatible version is downgraded to a one-time
+   *     warning and the command proceeds anyway. For read-only diagnostic
+   *     commands (logs, env list) where reading a mismatched device's state
+   *     is worth attempting even if the wire protocol may have drifted.
+   */
+  compat?: 'enforce' | 'best-effort'
+}
 
 export function connectRepl(
   transport: Transport,
-  _connectOptions: ConnectReplOptions = {},
+  connectOptions: ConnectReplOptions = {},
 ): ReplSession {
+  const compatPolicy = connectOptions.compat ?? 'enforce'
   const frameParser = new FrameParser()
   let sub: Subscription | undefined
   // Fires once when session.close() runs; lets per-call pipelines (notably
@@ -507,7 +522,16 @@ export function connectRepl(
       }
       const pm = await detectPreferredPm()
       if (compat.status === 'incompatible') {
-        throw new FirmwareIncompatibleError(formatIncompatibleError(compat, pm))
+        if (compatPolicy === 'enforce') {
+          throw new FirmwareIncompatibleError(formatIncompatibleError(compat, pm))
+        }
+        // best-effort: warn once and proceed anyway.
+        const warning = formatBestEffortWarning(compat, pm)
+        if (!advisoryShown) {
+          advisoryShown = true
+          process.stderr.write(warning + '\n')
+        }
+        return {...event, advisory: {kind: 'incompatible', message: warning}}
       }
       // status === 'update_available'
       const message = formatAdvisory(compat, pm)


### PR DESCRIPTION
logs and env list previously hard-failed when the device firmware was outside the CLI's compatible range. They now attempt the read anyway and warn the user to install a matching CLI, so a deployed unit's logs and env stay reachable for debugging. Mutating commands stay strict.

Adds a per-session 'best-effort' compat policy to connectRepl/openSession.