### PR TITLE
fix(native): unbreak the simulator after the quickjs-ng v0.15 upgrade

### DIFF
--- a/packages/@mikrojs/native/CMakeLists.txt
+++ b/packages/@mikrojs/native/CMakeLists.txt
@@ -152,6 +152,7 @@ if(BUILD_TESTING)
         test/main.cpp
         test/runtime_test.cpp
         test/modules_test.cpp
+        test/virtual_modules_test.cpp
         test/text_encoding_test.cpp
         test/cbor_test.cpp
         test/abort_test.cpp

--- a/packages/@mikrojs/native/addon/platform_node.cpp
+++ b/packages/@mikrojs/native/addon/platform_node.cpp
@@ -105,6 +105,10 @@ static int node_log_min_level(void) {
     return cached;
 }
 
+static const char* node_get_reset_reason(void) {
+    return "unknown"; /* Host processes have no chip reset concept */
+}
+
 /* Derive a stable device ID from the hostname. FNV-1a hash truncated to
  * 6 bytes, then Crockford's Base32 encoded (10 lowercase chars).
  * Deterministic across restarts on the same machine. */
@@ -178,6 +182,7 @@ static const MIKPlatform node_platform = {
     .stderr_write = node_stderr_write,
     .stdin_read = node_stdin_read,
     .get_device_id = node_get_device_id,
+    .get_reset_reason = node_get_reset_reason,
 };
 
 extern "C" const MIKPlatform* MIK_NodePlatform(void) {

--- a/packages/@mikrojs/native/src/builtins.cpp
+++ b/packages/@mikrojs/native/src/builtins.cpp
@@ -32,11 +32,16 @@ static JSModuleDef* mik__deserialize_builtin(JSContext* ctx, const char* name,
     JSValue obj = JS_ReadObject(ctx, data, data_size, JS_READ_OBJ_BYTECODE);
 
     if (JS_IsException(obj)) {
-        platform->log(MIK_LOG_ERROR, "mikrojs", "Failed to deserialize bytecode for builtin '%s' (%u bytes)", name,
-                 data_size);
-        /* Leave the JS exception on ctx so the caller can propagate the
-         * real error (e.g. "Maximum call stack size exceeded") instead of
-         * replacing it with a generic "not available" message. */
+        /* Peek the exception for the log, then re-throw it so the caller
+         * can still propagate the real error (e.g. "Maximum call stack
+         * size exceeded") instead of a generic "not available" message. */
+        JSValue exc = JS_GetException(ctx);
+        const char* msg = JS_ToCString(ctx, exc);
+        platform->log(MIK_LOG_ERROR, "mikrojs",
+                 "Failed to deserialize bytecode for builtin '%s' (%u bytes): %s", name,
+                 data_size, msg ? msg : "unknown error");
+        if (msg) JS_FreeCString(ctx, msg);
+        JS_Throw(ctx, exc);
         return NULL;
     }
 

--- a/packages/@mikrojs/native/src/mik_inspect.cpp
+++ b/packages/@mikrojs/native/src/mik_inspect.cpp
@@ -805,7 +805,7 @@ std::string mik_inspect(JSContext* ctx, JSValue value, int depth, bool colors, b
     return inspect_value(ctx, value, opts, depth);
 }
 
-/* ── JS-callable inspect function (for mikrojs/inspect module) ───── */
+/* ── JS-callable inspect function (for mikro/inspect module) ───── */
 
 static JSValue mik__inspect_js(JSContext* ctx, JSValue this_val, int argc, JSValue* argv) {
     if (argc < 1) return JS_NewString(ctx, "undefined");
@@ -836,14 +836,14 @@ static JSValue mik__inspect_js(JSContext* ctx, JSValue this_val, int argc, JSVal
     return JS_NewString(ctx, result.c_str());
 }
 
-/* Module init for 'mikrojs/inspect' native C module */
+/* Module init for 'mikro/inspect' native C module */
 int mik__inspect_module_init(JSContext* ctx, JSModuleDef* m) {
     return JS_SetModuleExport(ctx, m, "inspect",
                               JS_NewCFunction(ctx, mik__inspect_js, "inspect", 1));
 }
 
 void mik__inspect_register(JSContext* ctx) {
-    JSModuleDef* m = JS_NewCModule(ctx, "mikrojs/inspect", mik__inspect_module_init);
+    JSModuleDef* m = JS_NewCModule(ctx, "mikro/inspect", mik__inspect_module_init);
     if (m) {
         JS_AddModuleExport(ctx, m, "inspect");
     }

--- a/packages/@mikrojs/native/src/mik_sys.cpp
+++ b/packages/@mikrojs/native/src/mik_sys.cpp
@@ -260,10 +260,17 @@ void mik__sys_api_init(JSContext* ctx, JSValue ns) {
     JS_SetPropertyStr(ctx, ns, "board", mik__sys_board(ctx));
     JS_SetPropertyStr(ctx, ns, "firmware", mik__sys_firmware(ctx));
 
-    const char* device_id = MIK_GetPlatform()->get_device_id();
+    /* Guard the platform function POINTERS, not just their results: a
+     * platform that omits an optional hook leaves a NULL pointer, and
+     * calling it is a segfault with no diagnostics (the sim was down for
+     * weeks because platform_node lacked get_reset_reason). */
+    const MIKPlatform* platform = MIK_GetPlatform();
+    const char* device_id = platform->get_device_id ? platform->get_device_id() : NULL;
     JS_SetPropertyStr(ctx, ns, "deviceId",
                       device_id ? JS_NewString(ctx, device_id) : JS_UNDEFINED);
 
+    const char* reset_reason =
+        platform->get_reset_reason ? platform->get_reset_reason() : NULL;
     JS_SetPropertyStr(ctx, ns, "resetReason",
-                      JS_NewString(ctx, MIK_GetPlatform()->get_reset_reason()));
+                      JS_NewString(ctx, reset_reason ? reset_reason : "unknown"));
 }

--- a/packages/@mikrojs/native/src/modules.cpp
+++ b/packages/@mikrojs/native/src/modules.cpp
@@ -245,11 +245,11 @@ static JSModuleDef* mik_module_loader_inner(JSContext* ctx, const char* module_n
         /* mik__load_builtin returns NULL either because the module isn't in
          * the table, or because deserialization failed (e.g. stack overflow
          * from deeply nested .bjs loading). If deserialization failed, the
-         * real exception is already on ctx — don't replace it. */
-        JSValue pending = JS_GetException(ctx);
-        if (!JS_IsNull(pending)) {
-            JS_Throw(ctx, pending);
-        } else {
+         * real exception is already on ctx — don't replace it. Probe with
+         * JS_HasException, NOT JS_GetException + JS_IsNull: quickjs-ng
+         * returns JS_UNINITIALIZED from an empty exception slot, and
+         * re-throwing that surfaced as a bare "[uninitialized]" error. */
+        if (!JS_HasException(ctx)) {
             JS_ThrowReferenceError(ctx, "Builtin module '%s' is not available in this build",
                                    module_name);
         }
@@ -285,13 +285,8 @@ JSModuleDef* mik_module_loader(JSContext* ctx, const char* module_name, void* op
         JSModuleDef* result = mik_module_loader_inner(ctx, module_name, opaque);
         if (debug) {
             if (result == nullptr) {
-                JSValue exc = JS_GetException(ctx);
-                bool has_exc = !JS_IsNull(exc) && !JS_IsUndefined(exc);
                 fprintf(stderr, "[mik-modules] FAIL: %s (exception=%s)\n", module_name,
-                        has_exc ? "set" : "NULL");
-                /* Re-throw so the caller still sees the exception. */
-                if (has_exc) JS_Throw(ctx, exc);
-                else JS_FreeValue(ctx, exc);
+                        JS_HasException(ctx) ? "set" : "NULL");
             } else {
                 fprintf(stderr, "[mik-modules] ok:   %s\n", module_name);
             }
@@ -319,12 +314,8 @@ JSModuleDef* mik_module_loader(JSContext* ctx, const char* module_name, void* op
     JSModuleDef* m = mik_module_loader_inner(ctx, module_name, opaque);
     if (debug) {
         if (m == nullptr) {
-            JSValue exc = JS_GetException(ctx);
-            bool has_exc = !JS_IsNull(exc) && !JS_IsUndefined(exc);
             fprintf(stderr, "[mik-modules] FAIL: %s (exception=%s)\n", module_name,
-                    has_exc ? "set" : "NULL");
-            if (has_exc) JS_Throw(ctx, exc);
-            else JS_FreeValue(ctx, exc);
+                    JS_HasException(ctx) ? "set" : "NULL");
         } else {
             fprintf(stderr, "[mik-modules] ok:   %s\n", module_name);
         }

--- a/packages/@mikrojs/native/test/virtual_modules_test.cpp
+++ b/packages/@mikrojs/native/test/virtual_modules_test.cpp
@@ -1,0 +1,69 @@
+#include <cstring>
+
+#include <mikrojs/mikrojs.h>
+#include <quickjs.h>
+
+#include <doctest.h>
+
+/* Virtual modules (MIK_RegisterVirtualModule) replace native:* C modules
+ * with JS source compiled on demand — the simulator uses them for every
+ * device stub. Critically, they get compiled from INSIDE bytecode
+ * deserialization: quickjs-ng resolves a module's imports while
+ * JS_ReadObject is still reading it, so loading a builtin like mikro/sys
+ * re-enters JS_Eval for the virtual native:sleep it imports. These tests
+ * pin that path; it used to segfault (sim's only coverage was e2e). */
+
+static const char* SLEEP_STUB = R"JS(
+export function deepSleep() {}
+export function lightSleep() {}
+export function getWakeupCause() { return 'undefined' }
+export function canWakeFromExt0() { return false }
+export function canWakeFromExt1() { return true }
+)JS";
+
+TEST_CASE("virtual module shadows a native module inside builtin deserialization" *
+          doctest::test_suite("modules")) {
+    auto* rt = MIK_NewRuntime();
+    auto* ctx = MIK_GetJSContext(rt);
+    MIK_RegisterVirtualModule(rt, "native:sleep", SLEEP_STUB, strlen(SLEEP_STUB));
+
+    /* mikro/sys imports native:sleep; deserializing its bytecode resolves
+     * (and compiles) the virtual module re-entrantly. */
+    const char* code = "import {memoryUsage} from 'mikro/sys'\n"
+                       "globalThis.__ok = typeof memoryUsage === 'function'\n";
+    JSValue ret = MIK_EvalModuleContent(ctx, "/app/main.js", code, strlen(code));
+    CHECK(!JS_IsException(ret));
+    JS_FreeValue(ctx, ret);
+    MIK_Loop(rt);
+
+    JSValue global = JS_GetGlobalObject(ctx);
+    JSValue ok = JS_GetPropertyStr(ctx, global, "__ok");
+    CHECK(JS_ToBool(ctx, ok) == 1);
+    JS_FreeValue(ctx, ok);
+    JS_FreeValue(ctx, global);
+    MIK_FreeRuntime(rt);
+}
+
+TEST_CASE("test runner builtin loads and runs with virtual native modules" *
+          doctest::test_suite("modules")) {
+    auto* rt = MIK_NewRuntime();
+    auto* ctx = MIK_GetJSContext(rt);
+    MIK_RegisterVirtualModule(rt, "native:sleep", SLEEP_STUB, strlen(SLEEP_STUB));
+    static const char* HTTP_STUB = "export function pendingCount() { return 0 }\n";
+    MIK_RegisterVirtualModule(rt, "native:http", HTTP_STUB, strlen(HTTP_STUB));
+
+    /* Mirrors what the simulator does per test file: evaluate a module
+     * that registers a test through mikro/test (which pulls mikro/sys,
+     * native:sleep, native:http) and pump until the suite reports. */
+    const char* code = "import {assert, describe, test} from 'mikro/test'\n"
+                       "describe('smoke', () => {\n"
+                       "  test('1+1', () => { assert.equal(1 + 1, 2) })\n"
+                       "})\n";
+    JSValue ret = MIK_EvalModuleContent(ctx, "/app/test/x.test.js", code, strlen(code));
+    CHECK(!JS_IsException(ret));
+    JS_FreeValue(ctx, ret);
+    for (int i = 0; i < 50; i++) {
+        MIK_Loop(rt);
+    }
+    MIK_FreeRuntime(rt);
+}


### PR DESCRIPTION
The sim died on every run with a bare "[uninitialized]". Three stacked causes:

- platform_node never implemented get_reset_reason, so mik__sys_api_init called a NULL function pointer and the sim subprocess crashed on the first mikro/sys import. The node platform now implements it, and mik__sys_api_init guards optional platform hooks instead of trusting every pointer.
- quickjs-ng v0.15 changed JS_GetException to return JS_UNINITIALIZED when no exception is pending; the module loader's JS_IsNull checks then re-threw that value, replacing real errors with "[uninitialized]". All sites now use JS_HasException.
- mik_inspect still registered its C module as 'mikrojs/inspect', but the sim's console stub imports 'mikro/inspect'.

Builtin deserialize failures now log the exception text, and virtual_modules_test.cpp covers the virtual-module path the sim relies on, which had no host test.