### PR TITLE
fix(cli): make `mikro test` survive slow devices and missing results

### DIFF
--- a/packages/@mikrojs/firmware/components/mikrojs/mik_main.cpp
+++ b/packages/@mikrojs/firmware/components/mikrojs/mik_main.cpp
@@ -75,7 +75,11 @@ static void mik__apply_nvs_log_level(void) {
 #define MIK_SUP_PATH_MAX 384
 static char s_sup_dbg[MIK_SUP_PATH_MAX + 64];
 static char s_sup_esc[MIK_SUP_PATH_MAX * 2 + 8];
-static char s_sup_buf[MIK_SUP_PATH_MAX * 2 + 128];
+static char s_sup_buf[MIK_SUP_PATH_MAX * 2 + 512];
+/* Exception text captured by MIK_RunEntryErr when a test file fails to
+ * evaluate, and its JSON-escaped form for the synthesized test event. */
+static char s_sup_err[192];
+static char s_sup_err_esc[sizeof(s_sup_err) * 2 + 8];
 
 /* Minimal JSON string-escape into a bounded buffer. Handles `"`, `\`, and
  * control characters; everything else copies verbatim. Returns bytes
@@ -484,7 +488,7 @@ void MIK_Main(void) {
             MIKRuntime* rt = create_runtime();
             MIK_EnableTestHelpers(rt);
             MIK_ProtocolAttach(rt);
-            int rc = MIK_RunEntry(rt, test_paths[i]);
+            int rc = MIK_RunEntryErr(rt, test_paths[i], s_sup_err, sizeof(s_sup_err));
             const char* fail_reason = nullptr;
             if (rc == -ENOENT) {
                 fail_reason = "Test file not found";
@@ -516,10 +520,26 @@ void MIK_Main(void) {
                         s_sup_esc[1] = '\0';
                     }
                 }
-                int n = snprintf(s_sup_buf, sizeof(s_sup_buf),
+                /* Append the captured exception text (escaped) so the CLI
+                 * shows the actual error, not just "Evaluation threw". */
+                s_sup_err_esc[0] = '\0';
+                if (rc == -EFAULT && s_sup_err[0] != '\0') {
+                    if (mik__json_escape(s_sup_err_esc, sizeof(s_sup_err_esc), s_sup_err) < 0) {
+                        s_sup_err_esc[0] = '\0';
+                    }
+                }
+                int n;
+                if (s_sup_err_esc[0] != '\0') {
+                    n = snprintf(s_sup_buf, sizeof(s_sup_buf),
+                                 "{\"e\":3,\"s\":\"<load>\",\"t\":\"%s\",\"d\":0,"
+                                 "\"m\":\"%s: %s\"}",
+                                 s_sup_esc, fail_reason, s_sup_err_esc);
+                } else {
+                    n = snprintf(s_sup_buf, sizeof(s_sup_buf),
                                  "{\"e\":3,\"s\":\"<load>\",\"t\":\"%s\",\"d\":0,"
                                  "\"m\":\"%s\"}",
                                  s_sup_esc, fail_reason);
+                }
                 if (n > 0 && n < (int)sizeof(s_sup_buf)) {
                     mik__proto_send(&transport, MIK_MSG_TEST, s_sup_buf, n);
                 }

--- a/packages/@mikrojs/native/include/mikrojs/mikrojs.h
+++ b/packages/@mikrojs/native/include/mikrojs/mikrojs.h
@@ -86,6 +86,13 @@ void MIK_FreeRuntime(MIKRuntime* mik_rt);
  * Emits no diagnostic output — callers decide whether and how to log. */
 int MIK_RunEntry(MIKRuntime* mik_rt, const char* entry);
 
+/* MIK_RunEntry variant that, on -EFAULT, copies the thrown exception's
+ * string form (or the sync-rejected promise's rejection value) into
+ * err_buf so callers can surface the real failure instead of a generic
+ * "evaluation threw". err_buf may be NULL; when given it is always
+ * NUL-terminated (empty when no message could be captured). */
+int MIK_RunEntryErr(MIKRuntime* mik_rt, const char* entry, char* err_buf, size_t err_buf_size);
+
 JSContext* MIK_GetJSContext(MIKRuntime* mik_rt);
 MIKRuntime* MIK_GetRuntime(JSContext* ctx);
 void MIK_SetFSBasePath(MIKRuntime* mik_rt, const char* base_path);

--- a/packages/@mikrojs/native/src/mikrojs.cpp
+++ b/packages/@mikrojs/native/src/mikrojs.cpp
@@ -993,6 +993,13 @@ JSValue MIK_EvalModule(JSContext* ctx, const char* filename, bool is_main) {
 }
 
 int MIK_RunEntry(MIKRuntime* mik_rt, const char* entry) {
+    return MIK_RunEntryErr(mik_rt, entry, NULL, 0);
+}
+
+int MIK_RunEntryErr(MIKRuntime* mik_rt, const char* entry, char* err_buf, size_t err_buf_size) {
+    if (err_buf && err_buf_size > 0) {
+        err_buf[0] = '\0';
+    }
     if (!mik_rt || !entry || entry[0] == '\0') {
         return -EINVAL;
     }
@@ -1019,6 +1026,7 @@ int MIK_RunEntry(MIKRuntime* mik_rt, const char* entry) {
 
     JSValue result = MIK_EvalModule(ctx, entry, true);
     bool failed = JS_IsException(result);
+    bool rejected = false;
     /* Modules with top-level await return a Promise. A module body that
      * throws synchronously rejects that promise before JS_EvalFunction
      * returns, but the value itself is still an Object (rejected Promise),
@@ -1030,7 +1038,25 @@ int MIK_RunEntry(MIKRuntime* mik_rt, const char* entry) {
         JSPromiseStateEnum state = JS_PromiseState(ctx, result);
         if (state == JS_PROMISE_REJECTED) {
             failed = true;
+            rejected = true;
         }
+    }
+    if (failed && err_buf && err_buf_size > 0) {
+        /* Capture the failure's string form for the caller. Without an
+         * err_buf the pending exception is intentionally left on ctx,
+         * matching MIK_RunEntry's historical behavior. */
+        JSValue exc = rejected ? JS_PromiseResult(ctx, result) : JS_GetException(ctx);
+        const char* msg = JS_ToCString(ctx, exc);
+        if (msg) {
+            snprintf(err_buf, err_buf_size, "%s", msg);
+            JS_FreeCString(ctx, msg);
+        } else {
+            /* Stringifying the exception itself threw (e.g. OOM) — drop
+             * the secondary exception so it can't leak into later evals. */
+            JSValue stray = JS_GetException(ctx);
+            JS_FreeValue(ctx, stray);
+        }
+        JS_FreeValue(ctx, exc);
     }
     JS_FreeValue(ctx, result);
     return failed ? -EFAULT : 0;

--- a/packages/mikro/src/cli/commands/test.tsx
+++ b/packages/mikro/src/cli/commands/test.tsx
@@ -217,8 +217,12 @@ export async function run(config: InferValue<typeof args>): Promise<void> {
           renderLeakReport(result)
         }
       },
-      onEvent: (event) => {
-        if (!jsonOutput) renderTestEvent(event, config.diagnostics === true)
+      onEvent: (event, file) => {
+        if (jsonOutput) {
+          emitAgentTestEvent(event, pathlib.relative(cwd, file), config.diagnostics === true)
+          return
+        }
+        renderTestEvent(event, config.diagnostics === true)
       },
       onDeployEvent: (event) => {
         if (jsonOutput) {
@@ -265,11 +269,17 @@ export async function run(config: InferValue<typeof args>): Promise<void> {
     }),
     {passed: 0, failed: 0, skipped: 0, todo: 0},
   )
+  // Files that ended with an error (timeout, crash, no results) instead
+  // of a run_done. They carry no per-test counts, so they must fail the
+  // run on their own — otherwise a file that dies at load (or a run that
+  // aborts mid-way) reports PASS over tests that never executed.
+  const erroredFiles = results.filter((r) => r.error)
 
   if (jsonOutput) {
     agentResult('test', {
       ...totals,
       total: totals.passed + totals.failed + totals.skipped + totals.todo,
+      erroredFiles: erroredFiles.length,
       files: results.map((r) => ({
         file: pathlib.relative(cwd, r.file),
         passed: r.passed,
@@ -290,13 +300,52 @@ export async function run(config: InferValue<typeof args>): Promise<void> {
     })
   } else {
     renderAlertSummary(results, cwd)
-    renderAggregate(totals, results.length, Date.now() - startTime)
+    renderAggregate(totals, erroredFiles.length, results.length, Date.now() - startTime)
   }
 
-  process.exit(totals.failed > 0 ? 1 : 0)
+  process.exit(totals.failed > 0 || erroredFiles.length > 0 ? 1 : 0)
 }
 
 // ── Rendering ───────────────────────────────────────────────────────
+
+/** Agent-mode (NDJSON) counterpart of renderTestEvent: per-test results
+ *  with names and failure messages, so a failing run is debuggable from
+ *  the stream without re-running under the human reporter. run_done
+ *  (e:6) is omitted — file_done already carries the file summary — and
+ *  heap samples (e:8) only emit under --diagnostics, mirroring the
+ *  human reporter's noise threshold. */
+function emitAgentTestEvent(event: TestEvent, file: string, diagnostics: boolean): void {
+  const d = event.data
+  const base = {type: 'test_event', file}
+  switch (d.e) {
+    case 1: // suite_start
+      agentEmit({...base, event: 'suite', suite: d.s})
+      break
+    case 2: // test_pass
+      agentEmit({...base, event: 'pass', name: d.t, duration: d.d})
+      break
+    case 3: // test_fail
+      agentEmit({...base, event: 'fail', name: d.t, duration: d.d, message: d.m})
+      break
+    case 4: // test_skip
+      agentEmit({...base, event: 'skip', name: d.t})
+      break
+    case 9: // test_todo
+      agentEmit({...base, event: 'todo', name: d.t})
+      break
+    case 8: // heap sample
+      if (!diagnostics) break
+      agentEmit({
+        ...base,
+        event: 'heap',
+        heapUsed: d.u,
+        heapTotal: d.t,
+        ...(typeof d.f === 'number' ? {systemFree: d.f} : {}),
+        ...(typeof d.mf === 'number' ? {systemMinFree: d.mf} : {}),
+      })
+      break
+  }
+}
 
 function renderTestEvent(event: TestEvent, diagnostics: boolean): void {
   const d = event.data
@@ -411,11 +460,13 @@ function formatDuration(ms: number): string {
 }
 
 function renderAlertSummary(results: TestFileResult[], cwd: string): void {
+  const errored = results.filter((r) => r.error)
   const exceeded = results.filter((r) => r.heapBaselineAction === 'exceeded')
   const stale = results.filter((r) => r.heapBaselineAction === 'stale')
   const timerLeaks = results.filter((r) => (r.timerDelta ?? 0) > 0)
   const httpLeaks = results.filter((r) => (r.pendingDelta ?? 0) > 0)
   if (
+    errored.length === 0 &&
     exceeded.length === 0 &&
     stale.length === 0 &&
     timerLeaks.length === 0 &&
@@ -426,6 +477,10 @@ function renderAlertSummary(results: TestFileResult[], cwd: string): void {
   const rel = (f: string) => pathlib.relative(cwd, f)
   // eslint-disable-next-line no-console
   console.error(`\n${bold('Alerts:')}`)
+  for (const r of errored) {
+    // eslint-disable-next-line no-console
+    console.error(`  ${red(`✗ ${rel(r.file)}: ${r.error}`)}`)
+  }
   if (exceeded.length > 0) {
     const items = exceeded
       .map(
@@ -460,14 +515,19 @@ function renderAlertSummary(results: TestFileResult[], cwd: string): void {
 
 function renderAggregate(
   totals: {passed: number; failed: number; skipped: number; todo: number},
+  erroredFileCount: number,
   fileCount: number,
   totalMs: number,
 ): void {
   const total = totals.passed + totals.failed + totals.skipped + totals.todo
-  const status = totals.failed === 0 ? green(bold('PASS')) : red(bold('FAIL'))
+  const ok = totals.failed === 0 && erroredFileCount === 0
+  const status = ok ? green(bold('PASS')) : red(bold('FAIL'))
   const parts: string[] = []
   if (totals.passed > 0) parts.push(green(`${totals.passed} passed`))
   if (totals.failed > 0) parts.push(red(`${totals.failed} failed`))
+  if (erroredFileCount > 0) {
+    parts.push(red(`${erroredFileCount} file${erroredFileCount === 1 ? '' : 's'} errored`))
+  }
   if (totals.skipped > 0) parts.push(yellow(`${totals.skipped} skipped`))
   if (totals.todo > 0) parts.push(blue(`${totals.todo} todo`))
 

--- a/packages/mikro/src/cli/lib/__test__/testRunner.test.ts
+++ b/packages/mikro/src/cli/lib/__test__/testRunner.test.ts
@@ -176,18 +176,21 @@ describe('collectManifestEvents', () => {
     expect(results[0]!.error).toBeUndefined()
     // File 1 was in flight when the crash happened — annotated with error.
     expect(results[1]!.error).toMatch(/restarted unexpectedly/i)
-    // File 2 never started.
+    // File 2 never started — the finalization pass marks it errored so
+    // the summary can't report PASS over a file that never ran.
     expect(results[2]!.passed).toBe(0)
-    expect(results[2]!.error).toBeUndefined()
+    expect(results[2]!.error).toMatch(/no results/i)
     // Only two onFileStart calls (files 0 and 1). No start for the re-run.
     expect(rec.starts.map((s) => s.index)).toEqual([0, 1])
   })
 
-  it('forward jump fires onFileStart for the target index', async () => {
-    // If an e:6 is missed (dropped frame, crash before emit), the next
-    // supervisor announcement may skip over an index. The reducer should
-    // fire onFileStart for the announced target, not silently continue
-    // attributing events to the earlier index.
+  it('forward jump fires onFileStart for the target and closes skipped files as errored', async () => {
+    // If an e:6 is missed (dropped frame, crash before emit, or a file
+    // that died at load without reporting), the next supervisor
+    // announcement may skip over an index. The reducer must fire
+    // onFileStart for the announced target AND close out the skipped
+    // index as errored — a file that produced no results must never
+    // count as a silent zero in the totals (the fs.test load-crash bug).
     const {session, emit} = mockSession()
     const {cb, rec} = recorder()
 
@@ -203,10 +206,14 @@ describe('collectManifestEvents', () => {
     emit(runDone())
     emit(manifestDone())
 
-    await promise
+    const results = await promise
 
     expect(rec.starts.map((s) => s.index)).toEqual([0, 2])
-    expect(rec.dones.map((d) => d.index)).toEqual([0, 2])
+    expect(rec.dones.map((d) => d.index)).toEqual([0, 1, 2])
+    expect(rec.dones.find((d) => d.index === 1)?.error).toMatch(/no results/i)
+    expect(results[1]!.error).toMatch(/no results/i)
+    expect(results[0]!.error).toBeUndefined()
+    expect(results[2]!.error).toBeUndefined()
   })
 
   it('per-file timeout resets on run_done so each file gets its full budget', async () => {
@@ -248,7 +255,12 @@ describe('collectManifestEvents', () => {
     }
   })
 
-  it('inactivity beyond per-file timeout produces a timeout error on the in-flight file', async () => {
+  it('two silent windows produce a timeout on the in-flight file and account the rest', async () => {
+    // One silent window is only a warning (a slow TLS handshake can stall
+    // 60s+ without emitting while the file is healthy — seen on esp32c6).
+    // A second consecutive silent window means the device is gone: the
+    // in-flight file fails with Timeout and every remaining file is
+    // closed as errored so the summary cannot report PASS over them.
     vi.useFakeTimers()
     try {
       const {session, emit} = mockSession()
@@ -263,12 +275,48 @@ describe('collectManifestEvents', () => {
       emit(runDone())
       emit(announce(2, 3, devicePaths[1]!))
       emit(testPass('suite', 'started'))
-      // Device goes silent for longer than the per-file timeout.
-      await vi.advanceTimersByTimeAsync(1500)
+      // Device goes silent through the grace window and beyond.
+      await vi.advanceTimersByTimeAsync(2500)
 
       const results = await promise
       expect(results[0]!.error).toBeUndefined()
       expect(results[1]!.error).toMatch(/Timeout/i)
+      expect(results[2]!.error).toMatch(/no results/i)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('a single silent window warns but the run continues when events resume', async () => {
+    vi.useFakeTimers()
+    try {
+      const {session, emit} = mockSession()
+      const logs: string[] = []
+      const {cb} = recorder()
+      cb.onLog = (level, text) => logs.push(`${level}:${text}`)
+      const PER_FILE_TIMEOUT = 1000
+
+      const promise = collectManifestEvents(session, testFiles, PER_FILE_TIMEOUT, cb)
+      await Promise.resolve()
+
+      emit(announce(1, 3, devicePaths[0]!))
+      emit(testPass('suite', 'slow start'))
+      // Silent past one window — grace warning, not a failure.
+      await vi.advanceTimersByTimeAsync(1500)
+      // Device comes back and finishes everything.
+      emit(testPass('suite', 'recovered'))
+      emit(runDone(2))
+      emit(announce(2, 3, devicePaths[1]!))
+      emit(testPass('suite', 'ok'))
+      emit(runDone())
+      emit(announce(3, 3, devicePaths[2]!))
+      emit(testPass('suite', 'ok'))
+      emit(runDone())
+      emit(manifestDone())
+
+      const results = await promise
+      expect(results.every((r) => r.error === undefined)).toBe(true)
+      expect(logs.some((l) => /no events for/i.test(l))).toBe(true)
     } finally {
       vi.useRealTimers()
     }

--- a/packages/mikro/src/cli/lib/testRunner.ts
+++ b/packages/mikro/src/cli/lib/testRunner.ts
@@ -4,14 +4,16 @@ import * as pathlib from 'node:path'
 
 import {
   catchError,
+  finalize,
   firstValueFrom,
   last,
   lastValueFrom,
+  merge,
   of,
   scan,
+  Subject,
   takeWhile,
   tap,
-  timeout,
 } from 'rxjs'
 
 import type {Minifier, MinifyLevel} from '../../_exports/index.js'
@@ -59,6 +61,11 @@ export interface TestFileResult {
   duration: number
   events: TestEvent[]
   error?: string
+  /** True once the file's run_done (e:6) arrived. A result without this
+   *  and without an error means the file was never accounted — the
+   *  finalization pass turns that into an error so totals can't report
+   *  PASS over files that silently never ran. */
+  completed?: boolean
   /** heapUsed delta (bytes) between run start and end, after gc on both
    *  sides. Relative to the (post-beforeAll) baseline; drives heap-baseline
    *  regression tracking. Surfaced as the "retained" figure (the only memory
@@ -345,6 +352,12 @@ export async function collectManifestEvents(
      * Used to decide whether to fire onFileStart on a supervisor-announce
      * transition — the initial file_start is emitted upfront. */
     seenAnyTestForIndex: boolean
+    /** True after one full silent window (no events for timeoutMs). The
+     * first window only warns: a slow TLS handshake can stall 60s+
+     * without emitting while the file is healthy (seen on esp32c6, where
+     * this used to abort the whole run). Any real event clears it; a
+     * second consecutive silent window is treated as a dead device. */
+    graceUsed: boolean
     results: TestFileResult[]
     done: boolean
     doneReason: 'manifest_done' | 'crash' | 'timeout' | 'disconnect' | null
@@ -390,6 +403,7 @@ export async function collectManifestEvents(
   const initialState: ManifestState = {
     index: 0,
     seenAnyTestForIndex: false,
+    graceUsed: false,
     results: testFiles.map(emptyResult),
     done: false,
     doneReason: null,
@@ -412,6 +426,20 @@ export async function collectManifestEvents(
     if (!currentFile) return {...prev, done: true, doneReason: 'manifest_done', emits: []}
 
     if ((event as {type: string}).type === '__timeout') {
+      if (!prev.graceUsed) {
+        return {
+          ...prev,
+          graceUsed: true,
+          emits: [
+            {
+              kind: 'log',
+              level: 'warn',
+              text: `no events for ${timeoutMs}ms — waiting one more window before giving up`,
+              file: currentFile,
+            },
+          ],
+        }
+      }
       const results = prev.results.slice()
       if (prev.index < testFiles.length && !results[prev.index]?.error) {
         results[prev.index] = {
@@ -421,6 +449,8 @@ export async function collectManifestEvents(
       }
       return {...prev, results, done: true, doneReason: 'timeout', emits: []}
     }
+    // Any real event proves the device is alive — re-arm the grace window.
+    if (prev.graceUsed) prev = {...prev, graceUsed: false}
 
     switch (event.type) {
       case 'ready':
@@ -468,20 +498,34 @@ export async function collectManifestEvents(
             }
             if (targetIndex !== prev.index) {
               /* Forward jump: the supervisor skipped over some files (or
-               * we missed their e:6 events). Start the new file. */
+               * we missed their e:6 events — e.g. a file that died at
+               * load without reporting). Close every skipped index as
+               * errored so it can't sit in the totals as a silent zero,
+               * then start the new file. */
+              const results = prev.results.slice()
+              const emits: Emit[] = []
+              for (let i = prev.index; i < targetIndex; i++) {
+                const r = results[i]!
+                if (!r.completed && !r.error) {
+                  results[i] = {...r, error: 'No results received from device'}
+                  emits.push({kind: 'file_done', result: results[i]!, index: i, file: r.file})
+                }
+              }
+              emits.push(
+                {
+                  kind: 'log',
+                  level: 'debug',
+                  text: event.text,
+                  file: testFiles[targetIndex]!,
+                },
+                {kind: 'file_start', file: testFiles[targetIndex]!, index: targetIndex},
+              )
               return {
                 ...prev,
+                results,
                 index: targetIndex,
                 seenAnyTestForIndex: false,
-                emits: [
-                  {
-                    kind: 'log',
-                    level: 'debug',
-                    text: event.text,
-                    file: testFiles[targetIndex]!,
-                  },
-                  {kind: 'file_start', file: testFiles[targetIndex]!, index: targetIndex},
-                ],
+                emits,
               }
             }
             /* Same index. If we haven't seen any test events for it yet,
@@ -559,6 +603,7 @@ export async function collectManifestEvents(
     const emits: Emit[] = [{kind: 'event', event, file: currentFile}]
 
     if (e === 6) {
+      result.completed = true
       result.passed = (d.p as number) ?? result.passed
       result.failed = (d.f as number) ?? result.failed
       result.skipped = (d.k as number) ?? result.skipped
@@ -602,17 +647,46 @@ export async function collectManifestEvents(
     return {...prev, results, seenAnyTestForIndex: true, emits}
   }
 
+  /* Indices that already produced an onFileDone callback, so the
+   * finalization pass below doesn't double-report them. */
+  const reportedDone = new Set<number>()
+
   function applyEmits(state: ManifestState): void {
     for (const e of state.emits) {
       if (e.kind === 'file_start') cb.onFileStart?.(e.file, e.index, testFiles.length)
-      else if (e.kind === 'file_done') cb.onFileDone?.(e.result, e.index, testFiles.length)
-      else if (e.kind === 'event') cb.onEvent?.(e.event, e.file)
+      else if (e.kind === 'file_done') {
+        reportedDone.add(e.index)
+        cb.onFileDone?.(e.result, e.index, testFiles.length)
+      } else if (e.kind === 'event') cb.onEvent?.(e.event, e.file)
       else if (e.kind === 'log') cb.onLog?.(e.level, e.text, e.file)
     }
   }
 
+  // Inactivity timer: if no event arrives for `timeoutMs`, inject a
+  // synthetic timeout event so the reducer can apply its grace logic.
+  // Deliberately NOT rxjs `timeout({each, with})` — that operator switches
+  // away from (unsubscribes) the source when it fires, so the run could
+  // never resume after a grace warning. A merged self-re-arming timer
+  // keeps the device stream alive across silent windows; consecutive
+  // fires with no real event in between let the reducer detect a dead
+  // device. Good-enough proxy for per-file: test.ts emits heap events
+  // around each test, so an actively-running file keeps re-arming this.
+  const sentinel$ = new Subject<ReplEvent>()
+  let inactivityTimer: ReturnType<typeof setTimeout> | undefined
+  const arm = () => {
+    if (inactivityTimer !== undefined) clearTimeout(inactivityTimer)
+    inactivityTimer = setTimeout(() => {
+      sentinel$.next(TIMEOUT_EVENT)
+      arm()
+    }, timeoutMs)
+  }
+  arm()
+
   const final = await lastValueFrom(
-    session.messages$.pipe(
+    merge(session.messages$.pipe(tap(() => arm())), sentinel$).pipe(
+      finalize(() => {
+        if (inactivityTimer !== undefined) clearTimeout(inactivityTimer)
+      }),
       // Raw-event diagnostic: logs every event before any filtering, so
       // we can tell whether session.messages$ is emitting at all or the
       // issue is further up the pipeline. No-op unless MIKRO_DEBUG_EVENTS=1.
@@ -622,13 +696,6 @@ export async function collectManifestEvents(
           console.error(`[raw-ev] ${event.type}`)
         }
       }),
-      // Per-emission timeout: if no event arrives for `timeoutMs`, inject
-      // a synthetic timeout event so the reducer can close out the current
-      // index with a real error message. Good-enough proxy for per-file:
-      // test.ts emits heap events around each test, so an actively-running
-      // file keeps ticking this timer; a hung/crashed device stops
-      // emitting and trips it.
-      timeout({each: timeoutMs, with: () => of(TIMEOUT_EVENT)}),
       scan<ReplEvent, ManifestState>(reduce, initialState),
       tap((state) => {
         if (debug) {
@@ -651,6 +718,7 @@ export async function collectManifestEvents(
         return of({
           index: 0,
           seenAnyTestForIndex: false,
+          graceUsed: false,
           results,
           done: true,
           doneReason: null as ManifestState['doneReason'],
@@ -660,5 +728,19 @@ export async function collectManifestEvents(
     ),
   )
 
-  return final.results
+  /* Integrity pass: a result with neither a run_done nor an error means
+   * the file was never accounted — the run ended (crash, timeout,
+   * disconnect, or early manifest_done) before it ran. Mark it errored so
+   * the summary can't report PASS over it, and report any errored file
+   * that never reached onFileDone so it appears in per-file output too. */
+  const results = final.results.map((r) =>
+    r.completed || r.error ? r : {...r, error: 'No results received from device'},
+  )
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i]!
+    if (r.error && !reportedDone.has(i)) {
+      cb.onFileDone?.(r, i, testFiles.length)
+    }
+  }
+  return results
 }


### PR DESCRIPTION
- The per-emission timeout used rxjs `timeout({each, with})`, which unsubscribes the device stream when it fires, so one silent window (a cold TLS handshake can stall for a minute while healthy) aborted the whole run. Replaced with a self-re-arming inactivity timer and a grace window: the first silent window warns, a second consecutive one is treated as a dead device.
- A file that never reported results sat in the totals as a silent zero, so an aborted run could still print PASS. Such files are now closed as errored, and errored files fail the totals, the exit code, and the summary.
- A test file that failed module eval reported only "Evaluation threw", dropping the exception text. `MIK_RunEntryErr` now captures the exception or sync-rejection text and the supervisor appends it to the synthesized <load> failure event.
- Agent/NDJSON mode dropped all per-test detail; it now emits test_event frames with names, durations, and failure messages, plus heap samples under `--diagnostics`.