### PR TITLE
fix(native): keep cycle GC and the idle task alive through long job storms

### DIFF
--- a/packages/@mikrojs/native/src/mikrojs.cpp
+++ b/packages/@mikrojs/native/src/mikrojs.cpp
@@ -2,6 +2,7 @@
 
 #include <quickjs.h>
 
+#include <atomic>
 #include <cerrno>
 #include <cstdio>
 #include <fcntl.h>
@@ -218,6 +219,27 @@ void mik__flush_unhandled_rejections(JSContext* ctx) {
     }
 }
 
+/* QuickJS only runs the cycle collector automatically once malloc_size
+ * crosses the runtime's GC threshold (256 KB by default), and js_malloc_rt
+ * fails against the memory limit without attempting a GC first. On devices
+ * where mem_limit is below the default threshold the collector would never
+ * fire before allocations start failing, so cyclic garbage (promise chains,
+ * closures) accumulates straight into OOM with collectable memory still
+ * alive. Cap the threshold below the limit so collection happens first.
+ * QuickJS raises the threshold to 1.5x the live size after every GC pass,
+ * which can push it back above the limit, so MIK_Loop re-applies the cap
+ * each turn. */
+static void mik__clamp_gc_threshold(MIKRuntime* mik_rt) {
+    if (mik_rt->options.mem_limit <= 0) {
+        return;
+    }
+    size_t limit = (size_t)mik_rt->options.mem_limit;
+    size_t cap = limit - limit / 8;
+    if (JS_GetGCThreshold(mik_rt->rt) > cap) {
+        JS_SetGCThreshold(mik_rt->rt, cap);
+    }
+}
+
 void MIK_DefaultOptions(MIKRunOptions* options) {
     static MIKRunOptions default_options = {
         .mem_limit = 0,
@@ -321,6 +343,10 @@ MIKRuntime* MIK_NewRuntimeInternal(MIKRunOptions* options) {
 
     /* Set memory limit */
     JS_SetMemoryLimit(rt, options->mem_limit);
+
+    /* Make sure the cycle collector fires before the memory limit does
+     * (see mik__clamp_gc_threshold). */
+    mik__clamp_gc_threshold(mik_rt);
 
     /* Set stack size */
     JS_SetMaxStackSize(rt, options->stack_size);
@@ -535,9 +561,43 @@ static void mik__check_module_collisions(void) {
     }
 }
 
+/* A chain of already-settled promises drains as one uninterrupted storm of
+ * jobs, and the test supervisor strings whole files of such chains together
+ * with runtime recycles in between. On ESP32 the main task runs above the
+ * idle task, so a multi-second stretch like that starves idle: the task
+ * watchdog (5 s, watching IDLE0) prints a register dump, and FreeRTOS
+ * housekeeping (freeing TCBs of exited tasks, e.g. per-request HTTP tasks)
+ * stalls. Force one platform yield per second of continuous job execution
+ * so idle always gets a slice. The timestamp is global on purpose: the
+ * starvation accumulates across MIK_Loop calls and across runtime recycles.
+ * Costs at most one tick (~10 ms) per second of busy work. */
+#define MIK__YIELD_INTERVAL_US (1000 * 1000)
+
+/* Atomic because the Node addon can pump two runtimes' loops from
+ * different worker threads; relaxed ordering is enough — a missed or
+ * extra yield is harmless, a torn 64-bit write is not. */
+static std::atomic<int64_t> mik__last_yield_us{0};
+
+static void mik__maybe_yield(void) {
+    const MIKPlatform* platform = MIK_GetPlatform();
+    int64_t now = platform->get_boot_us();
+    int64_t last = mik__last_yield_us.load(std::memory_order_relaxed);
+    /* now < last happens when the boot clock resets (deep sleep) or a test
+     * swaps in a platform with a different clock; restart the interval. */
+    if (last == 0 || now < last) {
+        mik__last_yield_us.store(now, std::memory_order_relaxed);
+        return;
+    }
+    if (now - last >= MIK__YIELD_INTERVAL_US) {
+        platform->yield();
+        mik__last_yield_us.store(platform->get_boot_us(), std::memory_order_relaxed);
+    }
+}
+
 void mik__execute_jobs(JSContext* ctx) {
     JSContext* ctx1;
     int err;
+    bool ran_any = false;
 
     /* execute the pending jobs */
     for (;;) {
@@ -554,6 +614,26 @@ void mik__execute_jobs(JSContext* ctx) {
             }
             break;
         }
+        ran_any = true;
+        /* A GC pass inside this job raises the threshold to 1.5x live size,
+         * which lands above mem_limit whenever live >= ~2/3 of the limit —
+         * silently disabling cycle GC for the rest of the storm. Re-clamp
+         * between jobs so collection keeps firing; the check is a field
+         * read + compare when no GC ran. */
+        MIKRuntime* job_rt = MIK_GetRuntime(ctx1);
+        if (job_rt) {
+            mik__clamp_gc_threshold(job_rt);
+        }
+        mik__maybe_yield();
+    }
+
+    /* The yield interval measures continuous BUSY work. An empty drain
+     * means the loop is idling (the idle task is getting time between
+     * turns), so re-arm the interval — otherwise the first job after a
+     * quiet period pays a spurious ~10 ms yield for wall-clock time spent
+     * doing nothing. */
+    if (!ran_any) {
+        mik__last_yield_us.store(MIK_GetPlatform()->get_boot_us(), std::memory_order_relaxed);
     }
 
     /* Microtask checkpoint: every reject/handle transition for this turn has
@@ -605,6 +685,14 @@ int MIK_Loop(MIKRuntime* mik_rt) {
     }
 
     mik__execute_jobs(mik_rt->ctx);
+
+    /* Backstop for GC passes outside the job drain (timer callbacks, loop
+     * consumers, top-level eval): a pass there may have raised the
+     * threshold above the memory limit; pull it back so the next turn's
+     * collection still fires before allocations fail. Within the job
+     * drain, mik__execute_jobs re-clamps after every job. */
+    mik__clamp_gc_threshold(mik_rt);
+
     /* The end-of-turn unhandled-rejection flush inside mik__execute_jobs may
      * have requested a stop; surface it this iteration rather than making the
      * caller loop once more to notice. */

--- a/packages/@mikrojs/native/test/oom_test.cpp
+++ b/packages/@mikrojs/native/test/oom_test.cpp
@@ -121,6 +121,162 @@ TEST_CASE("No OOM event when memory limit is generous" * doctest::test_suite("oo
     MIK_FreeRuntime(rt);
 }
 
+TEST_CASE("Cycle GC fires before a mem_limit below the QuickJS default threshold" *
+          doctest::test_suite("oom")) {
+    /* QuickJS's automatic cycle collector only runs once the heap crosses
+     * the GC threshold (256 KB default), and allocations fail hard against
+     * the memory limit without a GC retry. With a mem_limit below 256 KB
+     * (the norm on no-PSRAM chips), cyclic garbage would accumulate
+     * straight into OOM unless runtime creation caps the threshold below
+     * the limit. This builds ~480 KB of cyclic garbage under a ~192 KB
+     * limit; it only survives if the collector fires along the way. */
+    MIKRunOptions options;
+    MIK_DefaultOptions(&options);
+    options.mem_limit = 192 * 1024;
+    MIKRuntime* rt = MIK_NewRuntimeOptions(&options);
+    REQUIRE(rt != nullptr);
+    JSContext* ctx = MIK_GetJSContext(rt);
+
+    /* The threshold cap is the fix's contract: below the limit, with margin
+     * for garbage created between trigger checks. */
+    CHECK_MESSAGE(JS_GetGCThreshold(JS_GetRuntime(ctx)) < (size_t)options.mem_limit,
+                  "Expected GC threshold to be capped below mem_limit at creation");
+
+    OOMRecorder recorder;
+    MIK_SetOOMHandler(rt, record_oom, &recorder);
+
+    /* Each iteration leaks one a<->b reference cycle pinning a 1 KB buffer.
+     * Refcounting alone never frees these; only the cycle collector can. */
+    const char* src =
+        "for (let i = 0; i < 400; i++) {\n"
+        "  const a = { buf: new ArrayBuffer(1024) };\n"
+        "  const b = { a };\n"
+        "  a.b = b;\n"
+        "}\n"
+        "export const ok = true;\n";
+    JSValue result = MIK_EvalModuleContent(ctx, "<cycles>", src, strlen(src));
+    /* Module evaluation returns a promise; an OOM during top-level
+     * execution rejects it rather than raising a synchronous exception. */
+    CHECK_MESSAGE(!JS_IsException(result), "Expected module compilation to succeed");
+    CHECK_MESSAGE(JS_PromiseState(ctx, result) == JS_PROMISE_FULFILLED,
+                  "Expected cyclic garbage to be collected before the memory limit");
+    JS_FreeValue(ctx, result);
+    if (JS_HasException(ctx)) {
+        JS_FreeValue(ctx, JS_GetException(ctx));
+    }
+
+    CHECK_MESSAGE(recorder.events.empty(), "Expected no OOM events");
+    CHECK_MESSAGE(!MIK_ConsumeOOMFlag(rt), "Expected OOM flag to be clear");
+
+    MIK_FreeRuntime(rt);
+}
+
+TEST_CASE("Cycle GC keeps firing within a single long job storm" * doctest::test_suite("oom")) {
+    /* QuickJS raises the GC threshold to 1.5x live size after every GC
+     * pass. With live data >= ~2/3 of mem_limit (the norm on esp32c3),
+     * one mid-turn GC pushes the threshold past the limit, and without a
+     * re-clamp between jobs the rest of that same turn allocates cyclic
+     * garbage straight into the hard limit. The per-job re-clamp in
+     * mik__execute_jobs is what this pins: the setup retains ~130 KB
+     * (90 ArrayBuffer ballast plus the 60-promise chain) above the
+     * measured base runtime size, leaving ~70 KB that a 60-job storm
+     * leaking ~4 KB of cycles each overruns unless GC keeps firing.
+     * The limit is derived from a probe runtime because an absolute
+     * limit is not portable: glibc and macOS account different usable
+     * sizes for the same workload. */
+    size_t base_size = 0;
+    {
+        MIKRunOptions probe_options;
+        MIK_DefaultOptions(&probe_options);
+        MIKRuntime* probe = MIK_NewRuntimeOptions(&probe_options);
+        REQUIRE(probe != nullptr);
+        JSMemoryUsage usage;
+        JS_ComputeMemoryUsage(JS_GetRuntime(MIK_GetJSContext(probe)), &usage);
+        base_size = (size_t)usage.malloc_size;
+        MIK_FreeRuntime(probe);
+    }
+
+    MIKRunOptions options;
+    MIK_DefaultOptions(&options);
+    options.mem_limit = (int)(base_size + 200 * 1024);
+    MIKRuntime* rt = MIK_NewRuntimeOptions(&options);
+    REQUIRE(rt != nullptr);
+    JSContext* ctx = MIK_GetJSContext(rt);
+
+    OOMRecorder recorder;
+    MIK_SetOOMHandler(rt, record_oom, &recorder);
+
+    const char* src =
+        "globalThis.live = Array.from({length: 90}, () => new ArrayBuffer(1024));\n"
+        "let p = Promise.resolve();\n"
+        "for (let i = 0; i < 60; i++) {\n"
+        "  p = p.then(() => {\n"
+        "    for (let j = 0; j < 4; j++) {\n"
+        "      const a = { buf: new ArrayBuffer(1024) };\n"
+        "      const b = { a };\n"
+        "      a.b = b;\n"
+        "    }\n"
+        "  });\n"
+        "}\n"
+        "p.then(() => { globalThis.stormDone = true; });\n";
+    JSValue result = JS_Eval(ctx, src, strlen(src), "main.js", JS_EVAL_TYPE_GLOBAL);
+    CHECK_MESSAGE(!JS_IsException(result), "Expected storm setup to evaluate");
+    JS_FreeValue(ctx, result);
+
+    /* One MIK_Loop turn drains the whole chain. */
+    MIK_Loop(rt);
+
+    JSValue global = JS_GetGlobalObject(ctx);
+    JSValue done = JS_GetPropertyStr(ctx, global, "stormDone");
+    CHECK_MESSAGE(JS_ToBool(ctx, done) == 1,
+                  "Expected the storm to finish without an OOM rejection");
+    JS_FreeValue(ctx, done);
+    JS_FreeValue(ctx, global);
+    CHECK_MESSAGE(recorder.events.empty(), "Expected no OOM events during the storm");
+    CHECK_MESSAGE(!MIK_ConsumeOOMFlag(rt), "Expected OOM flag to be clear");
+
+    MIK_FreeRuntime(rt);
+}
+
+TEST_CASE("MIK_Loop re-clamps the GC threshold after adaptive growth" *
+          doctest::test_suite("oom")) {
+    /* After every GC pass QuickJS raises the threshold to 1.5x the live
+     * size, which can push it back above mem_limit and silently re-disable
+     * automatic collection. MIK_Loop must pull it back under the limit. */
+    MIKRunOptions options;
+    MIK_DefaultOptions(&options);
+    options.mem_limit = 192 * 1024;
+    MIKRuntime* rt = MIK_NewRuntimeOptions(&options);
+    REQUIRE(rt != nullptr);
+    JSRuntime* js_rt = JS_GetRuntime(MIK_GetJSContext(rt));
+
+    /* Simulate the post-GC adaptive update overshooting the limit. */
+    JS_SetGCThreshold(js_rt, 10 * 1024 * 1024);
+    MIK_Loop(rt);
+    CHECK_MESSAGE(JS_GetGCThreshold(js_rt) < (size_t)options.mem_limit,
+                  "Expected MIK_Loop to re-clamp the GC threshold below mem_limit");
+
+    MIK_FreeRuntime(rt);
+}
+
+TEST_CASE("GC threshold untouched when mem_limit is 0 (unlimited)" *
+          doctest::test_suite("oom")) {
+    /* Hosts (Node addon, tests) run unlimited; the QuickJS default
+     * threshold must stay in effect there. */
+    MIKRuntime* rt = MIK_NewRuntime();
+    REQUIRE(rt != nullptr);
+    JSRuntime* js_rt = JS_GetRuntime(MIK_GetJSContext(rt));
+    /* Compare against a vanilla runtime's default rather than pinning the
+     * upstream constant, so a quickjs-ng bump that retunes the default
+     * doesn't fail this test while mikrojs behavior is still correct. */
+    JSRuntime* vanilla = JS_NewRuntime();
+    size_t vanilla_threshold = JS_GetGCThreshold(vanilla);
+    JS_FreeRuntime(vanilla);
+    CHECK_MESSAGE(JS_GetGCThreshold(js_rt) == vanilla_threshold,
+                  "Expected the QuickJS default GC threshold with no mem_limit");
+    MIK_FreeRuntime(rt);
+}
+
 TEST_CASE("No OOM event when mem_limit is 0 (unlimited)" * doctest::test_suite("oom")) {
     /* mem_limit == 0 means no soft cap. The pre-eval check should
      * short-circuit and never fire. */

--- a/packages/@mikrojs/native/test/runtime_test.cpp
+++ b/packages/@mikrojs/native/test/runtime_test.cpp
@@ -2,6 +2,7 @@
 #include <string>
 
 #include <mikrojs/mikrojs.h>
+#include <mikrojs/platform.h>
 #include <quickjs.h>
 
 #include <doctest.h>
@@ -118,4 +119,128 @@ TEST_CASE("Does not leak memory when running timers" * doctest::test_suite("runt
 
     JS_FreeValue(ctx, result);
     MIK_FreeRuntime(rt);
+}
+
+/* Instrumented platform for the yield tests: a fake boot clock that jumps
+ * forward on every read, and a yield counter. Lets the test simulate seconds
+ * of continuous job execution in microseconds of real time. */
+static int64_t s_fake_boot_us = 0;
+static int64_t s_fake_step_us = 0;
+static int s_yield_count = 0;
+
+static int64_t fake_get_boot_us(void) {
+    s_fake_boot_us += s_fake_step_us;
+    return s_fake_boot_us;
+}
+
+static void counting_yield(void) {
+    s_yield_count++;
+}
+
+TEST_CASE("Long promise-job storms yield to the platform periodically" *
+          doctest::test_suite("runtime")) {
+    /* A chain of already-settled promises drains as one synchronous storm of
+     * jobs. On ESP32 that starves the FreeRTOS idle task and trips the task
+     * watchdog, so mik__execute_jobs must call platform->yield() about once
+     * per second of continuous work. */
+    const MIKPlatform* orig = MIK_GetPlatform();
+    MIKPlatform fake = *orig;
+    fake.get_boot_us = fake_get_boot_us;
+    fake.yield = counting_yield;
+    s_fake_boot_us = 1000;
+    s_fake_step_us = 300 * 1000; /* every clock read advances 300 ms */
+    s_yield_count = 0;
+    MIK_SetPlatform(&fake);
+
+    MIKRuntime* rt = MIK_NewRuntime();
+    JSContext* ctx = MIK_GetJSContext(rt);
+    const char* src =
+        "let p = Promise.resolve();"
+        "for (let i = 0; i < 30; i++) p = p.then(() => {});";
+    JSValue result = JS_Eval(ctx, src, strlen(src), "main.js", JS_EVAL_TYPE_GLOBAL);
+    JS_FreeValue(ctx, result);
+    MIK_Loop(rt); /* drains all 30 jobs; ~9 s of fake clock elapse */
+    int yields_during_storm = s_yield_count;
+
+    MIK_FreeRuntime(rt);
+    MIK_SetPlatform(orig);
+
+    CHECK_MESSAGE(yields_during_storm >= 3,
+                  "Expected periodic yields during a long job storm, got "
+                      << yields_during_storm);
+}
+
+TEST_CASE("Waking after a long idle period does not inject a spurious yield" *
+          doctest::test_suite("runtime")) {
+    /* The yield interval measures continuous BUSY work. An app that idles
+     * between timer wakes must not pay a yield (one ~10 ms tick) on the
+     * first job of every wake just because wall-clock time passed while
+     * the queue was empty: empty drains re-arm the interval. */
+    const MIKPlatform* orig = MIK_GetPlatform();
+    MIKPlatform fake = *orig;
+    fake.get_boot_us = fake_get_boot_us;
+    fake.yield = counting_yield;
+    s_fake_boot_us = 1000;
+    /* Small per-read step: a single turn's handful of clock reads must
+     * stay inside the 1 s interval, while ten idle turns add up to
+     * several fake seconds. */
+    s_fake_step_us = 200 * 1000;
+    s_yield_count = 0;
+    MIK_SetPlatform(&fake);
+
+    MIKRuntime* rt = MIK_NewRuntime();
+    JSContext* ctx = MIK_GetJSContext(rt);
+
+    /* A short burst to seed the busy-interval timestamp. */
+    const char* burst = "Promise.resolve().then(() => {});";
+    JSValue r1 = JS_Eval(ctx, burst, strlen(burst), "main.js", JS_EVAL_TYPE_GLOBAL);
+    JS_FreeValue(ctx, r1);
+    MIK_Loop(rt);
+    s_yield_count = 0;
+
+    /* Simulate several seconds of idle: empty MIK_Loop turns while the
+     * fake clock marches 0.6 s per read. */
+    for (int i = 0; i < 10; i++) {
+        MIK_Loop(rt);
+    }
+
+    /* First job after the idle stretch must not yield. */
+    JSValue r2 = JS_Eval(ctx, burst, strlen(burst), "main.js", JS_EVAL_TYPE_GLOBAL);
+    JS_FreeValue(ctx, r2);
+    MIK_Loop(rt);
+
+    MIK_FreeRuntime(rt);
+    MIK_SetPlatform(orig);
+
+    CHECK_MESSAGE(s_yield_count == 0,
+                  "Expected no yield on the first job after idle, got " << s_yield_count);
+}
+
+TEST_CASE("Short job bursts do not force a yield" * doctest::test_suite("runtime")) {
+    /* With a frozen clock no interval ever elapses; the job drain must not
+     * inject yields (and their ~10 ms tick latency) into short bursts. */
+    const MIKPlatform* orig = MIK_GetPlatform();
+    MIKPlatform fake = *orig;
+    fake.get_boot_us = fake_get_boot_us;
+    fake.yield = counting_yield;
+    s_fake_boot_us = 1000;
+    s_fake_step_us = 0;
+    s_yield_count = 0;
+    MIK_SetPlatform(&fake);
+
+    MIKRuntime* rt = MIK_NewRuntime();
+    JSContext* ctx = MIK_GetJSContext(rt);
+    const char* src =
+        "let p = Promise.resolve();"
+        "for (let i = 0; i < 30; i++) p = p.then(() => {});";
+    JSValue result = JS_Eval(ctx, src, strlen(src), "main.js", JS_EVAL_TYPE_GLOBAL);
+    JS_FreeValue(ctx, result);
+    MIK_Loop(rt);
+    int yields_during_burst = s_yield_count;
+
+    MIK_FreeRuntime(rt);
+    MIK_SetPlatform(orig);
+
+    CHECK_MESSAGE(yields_during_burst == 0,
+                  "Expected no yields with no elapsed time, got " << yields_during_burst);
 }


### PR DESCRIPTION
QuickJS-NG only collects cycles once the heap crosses its GC threshold (256KB by default), so on chips whose mem_limit is below that, cyclic garbage accumulated straight into OOM. Clamp the threshold below mem_limit and re-apply it whenever a GC pass raises it back above.

Long drains of promise jobs also starved the ESP32 idle task, tripping the task watchdog. Yield once per second of busy job execution.