### PR TITLE
test(e2e): fit the suite on esp32c3's ~172KB JS heap

### DIFF
--- a/dev/e2e/test/abort.test.heap-baseline.json
+++ b/dev/e2e/test/abort.test.heap-baseline.json
@@ -1,0 +1,14 @@
+{
+  "esp32c3": {
+    "heapDelta": 14244
+  },
+  "esp32c5": {
+    "heapDelta": 13921
+  },
+  "esp32c6": {
+    "heapDelta": 13921
+  },
+  "simulator": {
+    "heapDelta": 15769
+  }
+}

--- a/dev/e2e/test/abort.test.ts
+++ b/dev/e2e/test/abort.test.ts
@@ -1,0 +1,61 @@
+import {assert, describe, test} from 'mikro/test'
+
+describe('AbortController', () => {
+  test('signal starts not aborted', () => {
+    const ac = new AbortController()
+    assert.equal(ac.signal.aborted, false)
+  })
+
+  test('abort sets signal.aborted', () => {
+    const ac = new AbortController()
+    ac.abort()
+    assert.equal(ac.signal.aborted, true)
+  })
+
+  test('abort with reason', () => {
+    const ac = new AbortController()
+    ac.abort('test reason')
+    assert.equal(ac.signal.reason, 'test reason')
+  })
+
+  test('signal fires abort event', () => {
+    const ac = new AbortController()
+    let fired = false
+    ac.signal.addEventListener('abort', () => {
+      fired = true
+    })
+    ac.abort()
+    assert.equal(fired, true)
+  })
+
+  test('throwIfAborted throws when aborted', () => {
+    const ac = new AbortController()
+    ac.abort()
+    assert.throws(() => ac.signal.throwIfAborted())
+  })
+
+  test('throwIfAborted does not throw when not aborted', () => {
+    const ac = new AbortController()
+    ac.signal.throwIfAborted() // should not throw
+  })
+
+  test('AbortSignal.abort() creates pre-aborted signal', () => {
+    const signal = AbortSignal.abort()
+    assert.equal(signal.aborted, true)
+  })
+
+  test('AbortSignal.timeout() aborts after delay', async () => {
+    const signal = AbortSignal.timeout(20)
+    assert.equal(signal.aborted, false)
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    assert.equal(signal.aborted, true)
+  })
+
+  test('AbortSignal.any() aborts when any child aborts', () => {
+    const ac = new AbortController()
+    const combined = AbortSignal.any([ac.signal])
+    assert.equal(combined.aborted, false)
+    ac.abort()
+    assert.equal(combined.aborted, true)
+  })
+})

--- a/dev/e2e/test/cbor.test.heap-baseline.json
+++ b/dev/e2e/test/cbor.test.heap-baseline.json
@@ -1,4 +1,7 @@
 {
+  "esp32c3": {
+    "heapDelta": 4050
+  },
   "esp32c5": {
     "heapDelta": 4050
   },

--- a/dev/e2e/test/env.test.heap-baseline.json
+++ b/dev/e2e/test/env.test.heap-baseline.json
@@ -1,4 +1,7 @@
 {
+  "esp32c3": {
+    "heapDelta": 4130
+  },
   "esp32c5": {
     "heapDelta": 4130
   },

--- a/dev/e2e/test/fs-stream.test.heap-baseline.json
+++ b/dev/e2e/test/fs-stream.test.heap-baseline.json
@@ -1,0 +1,14 @@
+{
+  "esp32c3": {
+    "heapDelta": 4612
+  },
+  "esp32c5": {
+    "heapDelta": 4612
+  },
+  "esp32c6": {
+    "heapDelta": 4612
+  },
+  "simulator": {
+    "heapDelta": 4984
+  }
+}

--- a/dev/e2e/test/fs-stream.test.ts
+++ b/dev/e2e/test/fs-stream.test.ts
@@ -1,0 +1,89 @@
+import {exists, mkdir, readDir, readStream, rmdir, stat, unlink, writeFile} from 'mikro/fs'
+import {decodeUtf8, splitLines} from 'mikro/stream'
+import {afterEach, assert, describe, test} from 'mikro/test'
+
+// Split out of fs.test.ts: that file's bytecode alone sat right at the
+// load-OOM line on esp32c3 (~171KB mem_limit), making the whole file
+// flaky at load. Two smaller files each fit comfortably.
+
+// All test paths live under /e2e-fs/ so cleanup is a single recursive walk
+// and stray files from a crashed run don't leak into the next suite.
+const ROOT = '/e2e-fs'
+
+function rmrf(path: string): void {
+  const s = stat(path)
+  if (!s.ok) return
+  if (s.value.isDirectory) {
+    const entries = readDir(path)
+    if (entries.ok) {
+      for (const child of entries.value) rmrf(`${path}/${child.name}`)
+    }
+    // Best-effort cleanup — ignore failures.
+    void rmdir(path).ok
+  } else {
+    void unlink(path).ok
+  }
+}
+
+function cleanup(): void {
+  if (exists(ROOT)) rmrf(ROOT)
+}
+
+function setup(): void {
+  cleanup()
+  const r = mkdir(ROOT)
+  assert.ok(r)
+}
+
+describe('fs: readStream', () => {
+  afterEach(cleanup)
+
+  test('yields chunks until EOF', async () => {
+    setup()
+    const payload = 'The quick brown fox jumps over the lazy dog.'
+    assert.ok(writeFile(`${ROOT}/fox.txt`, payload))
+
+    const r = readStream(`${ROOT}/fox.txt`, {chunkSize: 8})
+    assert.ok(r)
+    const decoder = new TextDecoder()
+    let out = ''
+    for await (const chunk of r.value) {
+      assert.ok(chunk)
+      out += decoder.decode(chunk.value)
+    }
+    assert.equal(out, payload)
+  })
+
+  test('composes with decodeUtf8 and splitLines', async () => {
+    setup()
+    assert.ok(writeFile(`${ROOT}/lines.txt`, 'one\ntwo\nthree\n'))
+
+    const r = readStream(`${ROOT}/lines.txt`)
+    assert.ok(r)
+    const lines: string[] = []
+    for await (const line of splitLines(decodeUtf8(r.value))) {
+      assert.ok(line)
+      lines.push(line.value)
+    }
+    assert.deepEqual(lines, ['one', 'two', 'three'])
+  })
+
+  test('empty file yields no chunks', async () => {
+    setup()
+    assert.ok(writeFile(`${ROOT}/empty.txt`, ''))
+
+    const r = readStream(`${ROOT}/empty.txt`)
+    assert.ok(r)
+    let chunks = 0
+    for await (const _ of r.value) {
+      chunks++
+    }
+    assert.equal(chunks, 0)
+  })
+
+  test('missing file returns FSError.NotFound', () => {
+    const r = readStream(`${ROOT}/nope.txt`)
+    assert.err(r)
+    assert.equal(r.error.name, 'NotFound')
+  })
+})

--- a/dev/e2e/test/fs.test.heap-baseline.json
+++ b/dev/e2e/test/fs.test.heap-baseline.json
@@ -1,11 +1,14 @@
 {
+  "esp32c3": {
+    "heapDelta": 4370
+  },
   "esp32c5": {
-    "heapDelta": 5069
+    "heapDelta": 4370
   },
   "esp32c6": {
-    "heapDelta": 5069
+    "heapDelta": 4370
   },
   "simulator": {
-    "heapDelta": 5549
+    "heapDelta": 4670
   }
 }

--- a/dev/e2e/test/fs.test.ts
+++ b/dev/e2e/test/fs.test.ts
@@ -1,16 +1,4 @@
-import {
-  exists,
-  mkdir,
-  readDir,
-  readFile,
-  readStream,
-  rename,
-  rmdir,
-  stat,
-  unlink,
-  writeFile,
-} from 'mikro/fs'
-import {decodeUtf8, splitLines} from 'mikro/stream'
+import {exists, mkdir, readDir, readFile, rename, rmdir, stat, unlink, writeFile} from 'mikro/fs'
 import {afterEach, assert, describe, test} from 'mikro/test'
 
 // All test paths live under /e2e-fs/ so cleanup is a single recursive walk
@@ -242,58 +230,5 @@ describe('fs: FSError variants', () => {
     const r = writeFile('/app/should-not-write', 'x')
     assert.err(r)
     assert.equal(r.error.name, 'AccessDenied')
-  })
-})
-
-describe('fs: readStream', () => {
-  afterEach(cleanup)
-
-  test('yields chunks until EOF', async () => {
-    setup()
-    const payload = 'The quick brown fox jumps over the lazy dog.'
-    assert.ok(writeFile(`${ROOT}/fox.txt`, payload))
-
-    const r = readStream(`${ROOT}/fox.txt`, {chunkSize: 8})
-    assert.ok(r)
-    const decoder = new TextDecoder()
-    let out = ''
-    for await (const chunk of r.value) {
-      assert.ok(chunk)
-      out += decoder.decode(chunk.value)
-    }
-    assert.equal(out, payload)
-  })
-
-  test('composes with decodeUtf8 and splitLines', async () => {
-    setup()
-    assert.ok(writeFile(`${ROOT}/lines.txt`, 'one\ntwo\nthree\n'))
-
-    const r = readStream(`${ROOT}/lines.txt`)
-    assert.ok(r)
-    const lines: string[] = []
-    for await (const line of splitLines(decodeUtf8(r.value))) {
-      assert.ok(line)
-      lines.push(line.value)
-    }
-    assert.deepEqual(lines, ['one', 'two', 'three'])
-  })
-
-  test('empty file yields no chunks', async () => {
-    setup()
-    assert.ok(writeFile(`${ROOT}/empty.txt`, ''))
-
-    const r = readStream(`${ROOT}/empty.txt`)
-    assert.ok(r)
-    let chunks = 0
-    for await (const _ of r.value) {
-      chunks++
-    }
-    assert.equal(chunks, 0)
-  })
-
-  test('missing file returns FSError.NotFound', () => {
-    const r = readStream(`${ROOT}/nope.txt`)
-    assert.err(r)
-    assert.equal(r.error.name, 'NotFound')
   })
 })

--- a/dev/e2e/test/globals.test.heap-baseline.json
+++ b/dev/e2e/test/globals.test.heap-baseline.json
@@ -1,11 +1,14 @@
 {
+  "esp32c3": {
+    "heapDelta": 4887
+  },
   "esp32c5": {
-    "heapDelta": 16033
+    "heapDelta": 4887
   },
   "esp32c6": {
-    "heapDelta": 15945
+    "heapDelta": 4887
   },
   "simulator": {
-    "heapDelta": 17285
+    "heapDelta": 5235
   }
 }

--- a/dev/e2e/test/globals.test.ts
+++ b/dev/e2e/test/globals.test.ts
@@ -130,66 +130,6 @@ describe('timers', () => {
   })
 })
 
-describe('AbortController', () => {
-  test('signal starts not aborted', () => {
-    const ac = new AbortController()
-    assert.equal(ac.signal.aborted, false)
-  })
-
-  test('abort sets signal.aborted', () => {
-    const ac = new AbortController()
-    ac.abort()
-    assert.equal(ac.signal.aborted, true)
-  })
-
-  test('abort with reason', () => {
-    const ac = new AbortController()
-    ac.abort('test reason')
-    assert.equal(ac.signal.reason, 'test reason')
-  })
-
-  test('signal fires abort event', () => {
-    const ac = new AbortController()
-    let fired = false
-    ac.signal.addEventListener('abort', () => {
-      fired = true
-    })
-    ac.abort()
-    assert.equal(fired, true)
-  })
-
-  test('throwIfAborted throws when aborted', () => {
-    const ac = new AbortController()
-    ac.abort()
-    assert.throws(() => ac.signal.throwIfAborted())
-  })
-
-  test('throwIfAborted does not throw when not aborted', () => {
-    const ac = new AbortController()
-    ac.signal.throwIfAborted() // should not throw
-  })
-
-  test('AbortSignal.abort() creates pre-aborted signal', () => {
-    const signal = AbortSignal.abort()
-    assert.equal(signal.aborted, true)
-  })
-
-  test('AbortSignal.timeout() aborts after delay', async () => {
-    const signal = AbortSignal.timeout(20)
-    assert.equal(signal.aborted, false)
-    await new Promise((resolve) => setTimeout(resolve, 50))
-    assert.equal(signal.aborted, true)
-  })
-
-  test('AbortSignal.any() aborts when any child aborts', () => {
-    const ac = new AbortController()
-    const combined = AbortSignal.any([ac.signal])
-    assert.equal(combined.aborted, false)
-    ac.abort()
-    assert.equal(combined.aborted, true)
-  })
-})
-
 /* eslint-disable no-console */
 describe('console', () => {
   test('console.log exists', () => {

--- a/dev/e2e/test/http-request-e2e.test.heap-baseline.json
+++ b/dev/e2e/test/http-request-e2e.test.heap-baseline.json
@@ -1,11 +1,14 @@
 {
+  "esp32c3": {
+    "heapDelta": 518
+  },
   "esp32c5": {
-    "heapDelta": 3101
+    "heapDelta": 5097
   },
   "esp32c6": {
-    "heapDelta": 3101
+    "heapDelta": 5097
   },
   "simulator": {
-    "heapDelta": 530
+    "heapDelta": 634
   }
 }

--- a/dev/e2e/test/http-request-e2e.test.ts
+++ b/dev/e2e/test/http-request-e2e.test.ts
@@ -1,8 +1,7 @@
 /* eslint-disable no-console */
 import {env} from 'mikro/env'
-import {request} from 'mikro/http/request'
+import {memoryUsage} from 'mikro/sys'
 import {assert, beforeAll, describe, test} from 'mikro/test'
-import {wifi} from 'mikro/wifi'
 
 // These tests require WIFI_SSID and WIFI_PASSPHRASE env vars to run on
 // the device. They exercise the full JS → native:http → esp_http_client
@@ -22,8 +21,18 @@ const hasWifi = WIFI_SSID && WIFI_PASSPHRASE
 // produce realistic responses for them, so skip in simulator mode.
 const isSim = env.get('MIKRO_ENV') === 'simulator'
 
-describe.runIf(hasWifi && !isSim)('http request e2e', () => {
+// The request/wifi module graph plus TLS working room needs ~48KB of
+// free JS heap (estimate; the graph alone retains ~30KB). Chips whose
+// per-file runtime has less than that skip this file (e.g. esp32c3).
+const m = memoryUsage()
+const fitsHttp = m.heapTotal - m.heapUsed > 48 * 1024
+
+let request: typeof import('mikro/http/request').request
+
+describe.runIf(hasWifi && !isSim && fitsHttp)('http request e2e', () => {
   beforeAll(async () => {
+    ;({request} = await import('mikro/http/request'))
+    const {wifi} = await import('mikro/wifi')
     const connected = await wifi.connect(WIFI_SSID!, WIFI_PASSPHRASE!)
     assert.equal(connected.ok, true, 'wifi connect')
     if (connected.ok) console.log(`connected: ${connected.value.ip}`)

--- a/dev/e2e/test/http-request-streaming.test.ts
+++ b/dev/e2e/test/http-request-streaming.test.ts
@@ -1,9 +1,7 @@
 /* eslint-disable no-console */
 import {env} from 'mikro/env'
-import {request} from 'mikro/http/request'
-import {decodeUtf8, splitLines} from 'mikro/stream'
+import {memoryUsage} from 'mikro/sys'
 import {assert, beforeAll, describe, test} from 'mikro/test'
-import {wifi} from 'mikro/wifi'
 
 // Streaming tests live in their own file because each one does a full TLS
 // handshake + body drain that peaks heap usage heavily. Running them
@@ -20,8 +18,21 @@ const WIFI_PASSPHRASE = env.get('WIFI_PASSPHRASE')
 const hasWifi = WIFI_SSID && WIFI_PASSPHRASE
 const isSim = env.get('MIKRO_ENV') === 'simulator'
 
-describe.runIf(hasWifi && !isSim)('http request streaming', () => {
+// The request/wifi module graph plus TLS working room needs ~48KB of
+// free JS heap (estimate; the graph alone retains ~30KB). Chips whose
+// per-file runtime has less than that skip this file (e.g. esp32c3).
+const m = memoryUsage()
+const fitsHttp = m.heapTotal - m.heapUsed > 48 * 1024
+
+let request: typeof import('mikro/http/request').request
+let decodeUtf8: typeof import('mikro/stream').decodeUtf8
+let splitLines: typeof import('mikro/stream').splitLines
+
+describe.runIf(hasWifi && !isSim && fitsHttp)('http request streaming', () => {
   beforeAll(async () => {
+    ;({request} = await import('mikro/http/request'))
+    ;({decodeUtf8, splitLines} = await import('mikro/stream'))
+    const {wifi} = await import('mikro/wifi')
     const connected = await wifi.connect(WIFI_SSID!, WIFI_PASSPHRASE!)
     assert.equal(connected.ok, true, 'wifi connect')
     if (connected.ok) console.log(`connected: ${connected.value.ip}`)

--- a/dev/e2e/test/http-server-e2e.test.heap-baseline.json
+++ b/dev/e2e/test/http-server-e2e.test.heap-baseline.json
@@ -1,5 +1,14 @@
 {
+  "esp32c3": {
+    "heapDelta": 518
+  },
+  "esp32c5": {
+    "heapDelta": 1307
+  },
   "esp32c6": {
-    "heapDelta": 1843
+    "heapDelta": 1307
+  },
+  "simulator": {
+    "heapDelta": 634
   }
 }

--- a/dev/e2e/test/http-server-e2e.test.ts
+++ b/dev/e2e/test/http-server-e2e.test.ts
@@ -1,21 +1,30 @@
 /* eslint-disable no-console */
 import {env} from 'mikro/env'
-import {request} from 'mikro/http/request'
+import {memoryUsage} from 'mikro/sys'
 import {afterAll, assert, beforeAll, describe, test} from 'mikro/test'
-import {wifi} from 'mikro/wifi'
 
 const WIFI_SSID = env.get('WIFI_SSID')
 const WIFI_PASSPHRASE = env.get('WIFI_PASSPHRASE')
 const hasWifi = WIFI_SSID && WIFI_PASSPHRASE
 const isSim = env.get('MIKRO_ENV') === 'simulator'
 
+// The request/wifi module graph plus TLS working room needs ~48KB of
+// free JS heap (estimate; the graph alone retains ~30KB). Chips whose
+// per-file runtime has less than that skip this file (e.g. esp32c3).
+const m = memoryUsage()
+const fitsHttp = m.heapTotal - m.heapUsed > 48 * 1024
+
 const PORT = 8088
 
-describe.runIf(hasWifi && !isSim)('http server e2e', () => {
+let request: typeof import('mikro/http/request').request
+
+describe.runIf(hasWifi && !isSim && fitsHttp)('http server e2e', () => {
   let base = ''
   let server: import('mikro/http/server').Server | undefined
 
   beforeAll(async () => {
+    ;({request} = await import('mikro/http/request'))
+    const {wifi} = await import('mikro/wifi')
     const connected = await wifi.connect(WIFI_SSID!, WIFI_PASSPHRASE!)
     assert.equal(connected.ok, true, 'wifi connect')
     if (!connected.ok) return

--- a/dev/e2e/test/import-meta.test.heap-baseline.json
+++ b/dev/e2e/test/import-meta.test.heap-baseline.json
@@ -1,4 +1,7 @@
 {
+  "esp32c3": {
+    "heapDelta": 3833
+  },
   "esp32c5": {
     "heapDelta": 3833
   },

--- a/dev/e2e/test/kv.test.heap-baseline.json
+++ b/dev/e2e/test/kv.test.heap-baseline.json
@@ -1,4 +1,7 @@
 {
+  "esp32c3": {
+    "heapDelta": 4153
+  },
   "esp32c5": {
     "heapDelta": 4153
   },

--- a/dev/e2e/test/modules-hw.test.heap-baseline.json
+++ b/dev/e2e/test/modules-hw.test.heap-baseline.json
@@ -3,12 +3,12 @@
     "heapDelta": 518
   },
   "esp32c5": {
-    "heapDelta": 2706
+    "heapDelta": 30157
   },
   "esp32c6": {
-    "heapDelta": 2706
+    "heapDelta": 30157
   },
   "simulator": {
-    "heapDelta": 634
+    "heapDelta": 49489
   }
 }

--- a/dev/e2e/test/modules-hw.test.ts
+++ b/dev/e2e/test/modules-hw.test.ts
@@ -1,0 +1,77 @@
+import {memoryUsage} from 'mikro/sys'
+import {assert, describe, test} from 'mikro/test'
+
+// Hardware modules loaded together: each costs ~6KB of heap once
+// imported, ~40KB retained for the whole set (measured on esp32c6).
+// The gate adds ~8KB of margin for import-time evaluation peaks, so
+// chips whose per-file runtime has less free heap (e.g. esp32c3) skip
+// this file. Note: when skipped, spi and neopixel have no other
+// JS-level e2e coverage (pin/pwm/i2c/sleep are also covered by the
+// firmware's C doctest suite).
+
+const m = memoryUsage()
+const runsHwModules = m.heapTotal - m.heapUsed > 48 * 1024
+
+describe.runIf(runsHwModules)('module: pin', () => {
+  test('exports exist', async () => {
+    const mod = await import('mikro/pin')
+    assert.type(mod.pinMode, 'function')
+    assert.type(mod.digitalWrite, 'function')
+    assert.type(mod.digitalRead, 'function')
+    assert.type(mod.analogRead, 'function')
+    assert.type(mod.analogReadMillivolts, 'function')
+  })
+})
+
+describe.runIf(runsHwModules)('module: pwm', () => {
+  test('exports exist', async () => {
+    const mod = await import('mikro/pwm')
+    assert.type(mod.Pwm, 'function')
+  })
+})
+
+describe.runIf(runsHwModules)('module: neopixel', () => {
+  test('exports exist', async () => {
+    const mod = await import('mikro/neopixel')
+    assert.type(mod.NeoPixel, 'function')
+  })
+})
+
+describe.runIf(runsHwModules)('module: i2c', () => {
+  test('exports exist', async () => {
+    const mod = await import('mikro/i2c')
+    assert.type(mod.I2c, 'function')
+  })
+})
+
+describe.runIf(runsHwModules)('module: spi', () => {
+  test('exports exist', async () => {
+    const mod = await import('mikro/spi')
+    assert.type(mod.Spi, 'function')
+  })
+})
+
+describe.runIf(runsHwModules)('module: sleep', () => {
+  test('exports exist', async () => {
+    const mod = await import('mikro/sleep')
+    assert.type(mod.sleep, 'function')
+    assert.type(mod.deepSleep, 'function')
+    assert.type(mod.lightSleep, 'function')
+    assert.type(mod.canWakeFromExt0, 'function')
+    assert.type(mod.canWakeFromExt1, 'function')
+  })
+
+  test('getWakeupCause returns a string', async () => {
+    const {getWakeupCause} = await import('mikro/sys')
+    const cause = getWakeupCause()
+    assert.type(cause, 'string')
+  })
+
+  test('sleep resolves after delay', async () => {
+    const {sleep} = await import('mikro/sleep')
+    const start = Date.now()
+    await sleep(50)
+    const elapsed = Date.now() - start
+    assert.truthy(elapsed >= 40, `expected >= 40ms, got ${elapsed}`)
+  })
+})

--- a/dev/e2e/test/modules-network.test.heap-baseline.json
+++ b/dev/e2e/test/modules-network.test.heap-baseline.json
@@ -1,11 +1,14 @@
 {
+  "esp32c3": {
+    "heapDelta": 518
+  },
   "esp32c5": {
-    "heapDelta": 45050
+    "heapDelta": 45775
   },
   "esp32c6": {
-    "heapDelta": 45789
+    "heapDelta": 45775
   },
   "simulator": {
-    "heapDelta": 65724
+    "heapDelta": 67647
   }
 }

--- a/dev/e2e/test/modules-network.test.ts
+++ b/dev/e2e/test/modules-network.test.ts
@@ -1,10 +1,18 @@
+import {memoryUsage} from 'mikro/sys'
 import {assert, describe, test} from 'mikro/test'
 
 // Network-related modules in a separate file: wifi, fetch, and sntp
 // each cost ~6-8KB of bytecode. Combined with pin/pwm/etc they exceed
-// the heap on constrained devices.
+// the heap on constrained devices. Loading all three together retains
+// ~46KB (measured on esp32c6); the gate's extra ~10KB covers
+// import-time evaluation peaks above the retained size. Chips with
+// less free heap in the per-file runtime (e.g. esp32c3) skip this
+// file.
 
-describe('module: wifi', () => {
+const m = memoryUsage()
+const runsNetworkModules = m.heapTotal - m.heapUsed > 56 * 1024
+
+describe.runIf(runsNetworkModules)('module: wifi', () => {
   test('exports exist', async () => {
     const mod = await import('mikro/wifi')
     assert.type(mod.wifi, 'object')
@@ -15,14 +23,14 @@ describe('module: wifi', () => {
   })
 })
 
-describe('module: http/request', () => {
+describe.runIf(runsNetworkModules)('module: http/request', () => {
   test('exports exist', async () => {
     const mod = await import('mikro/http/request')
     assert.type(mod.request, 'function')
   })
 })
 
-describe('module: sntp', () => {
+describe.runIf(runsNetworkModules)('module: sntp', () => {
   test('exports exist', async () => {
     const mod = await import('mikro/sntp')
     assert.type(mod.sntp, 'object')

--- a/dev/e2e/test/modules.test.heap-baseline.json
+++ b/dev/e2e/test/modules.test.heap-baseline.json
@@ -1,11 +1,14 @@
 {
+  "esp32c3": {
+    "heapDelta": 3833
+  },
   "esp32c5": {
-    "heapDelta": 31242
+    "heapDelta": 3833
   },
   "esp32c6": {
-    "heapDelta": 30761
+    "heapDelta": 3833
   },
   "simulator": {
-    "heapDelta": 55149
+    "heapDelta": 4001
   }
 }

--- a/dev/e2e/test/modules.test.ts
+++ b/dev/e2e/test/modules.test.ts
@@ -7,72 +7,9 @@ import {version} from 'mikro/sys'
 import {assert, describe, test} from 'mikro/test'
 
 // Verify built-in modules load and export the right types.
-// Hardware modules that cost ~6KB each are split across files
-// so each gets a fresh heap.
-
-describe('module: pin', () => {
-  test('exports exist', async () => {
-    const mod = await import('mikro/pin')
-    assert.type(mod.pinMode, 'function')
-    assert.type(mod.digitalWrite, 'function')
-    assert.type(mod.digitalRead, 'function')
-    assert.type(mod.analogRead, 'function')
-    assert.type(mod.analogReadMillivolts, 'function')
-  })
-})
-
-describe('module: pwm', () => {
-  test('exports exist', async () => {
-    const mod = await import('mikro/pwm')
-    assert.type(mod.Pwm, 'function')
-  })
-})
-
-describe('module: neopixel', () => {
-  test('exports exist', async () => {
-    const mod = await import('mikro/neopixel')
-    assert.type(mod.NeoPixel, 'function')
-  })
-})
-
-describe('module: i2c', () => {
-  test('exports exist', async () => {
-    const mod = await import('mikro/i2c')
-    assert.type(mod.I2c, 'function')
-  })
-})
-
-describe('module: spi', () => {
-  test('exports exist', async () => {
-    const mod = await import('mikro/spi')
-    assert.type(mod.Spi, 'function')
-  })
-})
-
-describe('module: sleep', () => {
-  test('exports exist', async () => {
-    const mod = await import('mikro/sleep')
-    assert.type(mod.sleep, 'function')
-    assert.type(mod.deepSleep, 'function')
-    assert.type(mod.lightSleep, 'function')
-    assert.type(mod.canWakeFromExt0, 'function')
-    assert.type(mod.canWakeFromExt1, 'function')
-  })
-
-  test('getWakeupCause returns a string', async () => {
-    const {getWakeupCause} = await import('mikro/sys')
-    const cause = getWakeupCause()
-    assert.type(cause, 'string')
-  })
-
-  test('sleep resolves after delay', async () => {
-    const {sleep} = await import('mikro/sleep')
-    const start = Date.now()
-    await sleep(50)
-    const elapsed = Date.now() - start
-    assert.truthy(elapsed >= 40, `expected >= 40ms, got ${elapsed}`)
-  })
-})
+// Hardware modules that cost ~6KB each live in modules-hw.test.ts,
+// network modules in modules-network.test.ts, so each group gets a
+// fresh heap and low-memory chips can skip the groups that don't fit.
 
 describe('module: stdio', () => {
   test('stdout.write exists', () => {

--- a/dev/e2e/test/observable.test.heap-baseline.json
+++ b/dev/e2e/test/observable.test.heap-baseline.json
@@ -1,4 +1,7 @@
 {
+  "esp32c3": {
+    "heapDelta": 4473
+  },
   "esp32c5": {
     "heapDelta": 4473
   },

--- a/dev/e2e/test/result.test.heap-baseline.json
+++ b/dev/e2e/test/result.test.heap-baseline.json
@@ -1,11 +1,14 @@
 {
+  "esp32c3": {
+    "heapDelta": 4130
+  },
   "esp32c5": {
-    "heapDelta": 4050
+    "heapDelta": 4130
   },
   "esp32c6": {
     "heapDelta": 4130
   },
   "simulator": {
-    "heapDelta": 4254
+    "heapDelta": 4358
   }
 }

--- a/dev/e2e/test/schema.test.heap-baseline.json
+++ b/dev/e2e/test/schema.test.heap-baseline.json
@@ -1,4 +1,7 @@
 {
+  "esp32c3": {
+    "heapDelta": 4153
+  },
   "esp32c5": {
     "heapDelta": 4153
   },

--- a/dev/e2e/test/smoke.test.heap-baseline.json
+++ b/dev/e2e/test/smoke.test.heap-baseline.json
@@ -1,4 +1,7 @@
 {
+  "esp32c3": {
+    "heapDelta": 3833
+  },
   "esp32c5": {
     "heapDelta": 3833
   },

--- a/dev/e2e/test/sys.test.heap-baseline.json
+++ b/dev/e2e/test/sys.test.heap-baseline.json
@@ -1,4 +1,7 @@
 {
+  "esp32c3": {
+    "heapDelta": 3833
+  },
   "esp32c5": {
     "heapDelta": 3833
   },

--- a/dev/e2e/test/udp.test.heap-baseline.json
+++ b/dev/e2e/test/udp.test.heap-baseline.json
@@ -1,11 +1,14 @@
 {
+  "esp32c3": {
+    "heapDelta": 4073
+  },
   "esp32c5": {
-    "heapDelta": -352
+    "heapDelta": 144
   },
   "esp32c6": {
-    "heapDelta": -352
+    "heapDelta": 144
   },
   "simulator": {
-    "heapDelta": 568
+    "heapDelta": 4313
   }
 }

--- a/dev/e2e/test/udp.test.ts
+++ b/dev/e2e/test/udp.test.ts
@@ -1,12 +1,20 @@
 /* eslint-disable no-console */
 import {env} from 'mikro/env'
+import {memoryUsage} from 'mikro/sys'
 import {assert, beforeAll, describe, test} from 'mikro/test'
 import {bind} from 'mikro/udp'
-import {wifi} from 'mikro/wifi'
 
 const WIFI_SSID = env.get('WIFI_SSID')
 const WIFI_PASSPHRASE = env.get('WIFI_PASSPHRASE')
 const hasWifi = WIFI_SSID && WIFI_PASSPHRASE
+
+// The wifi module retains ~20KB once loaded (imported lazily in
+// beforeAll so the lifecycle tests still run where it doesn't fit);
+// the gate doubles that for import-time evaluation peaks and native
+// wifi startup allocations. Chips whose per-file runtime has less
+// free heap skip the roundtrip section (e.g. esp32c3).
+const m = memoryUsage()
+const fitsWifi = m.heapTotal - m.heapUsed > 40 * 1024
 
 /* ── Lifecycle tests — work on bare device, no network needed ───── */
 
@@ -54,10 +62,11 @@ describe('udp lifecycle', () => {
 
 /* ── Roundtrip — needs an interface up; gated on WiFi env vars ──── */
 
-describe.runIf(hasWifi)('udp over wifi', () => {
+describe.runIf(hasWifi && fitsWifi)('udp over wifi', () => {
   let localIp: string
 
   beforeAll(async () => {
+    const {wifi} = await import('mikro/wifi')
     const connected = await wifi.connect(WIFI_SSID!, WIFI_PASSPHRASE!)
     assert.equal(connected.ok, true, 'wifi connect')
     if (connected.ok) {

--- a/dev/e2e/test/wifi-e2e.test.heap-baseline.json
+++ b/dev/e2e/test/wifi-e2e.test.heap-baseline.json
@@ -1,11 +1,14 @@
 {
+  "esp32c3": {
+    "heapDelta": 26282
+  },
   "esp32c5": {
-    "heapDelta": 46031
+    "heapDelta": 46756
   },
   "esp32c6": {
-    "heapDelta": 46770
+    "heapDelta": 46756
   },
   "simulator": {
-    "heapDelta": 67825
+    "heapDelta": 634
   }
 }

--- a/dev/e2e/test/wifi-e2e.test.ts
+++ b/dev/e2e/test/wifi-e2e.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import {env} from 'mikro/env'
+import {memoryUsage} from 'mikro/sys'
 import {assert, describe, test} from 'mikro/test'
 
 // These tests only run when WIFI_SSID and WIFI_PASSPHRASE env vars are set.
@@ -10,6 +11,13 @@ const WIFI_PASSPHRASE = env.get('WIFI_PASSPHRASE')
 
 const hasWifi = WIFI_SSID && WIFI_PASSPHRASE
 
+// The fetch and sntp tests load their module graphs on top of an
+// already-connected wifi stack (~20KB retained); together that needs
+// ~48KB of free JS heap (estimate). Chips with less skip those two
+// tests but still cover connect/disconnect (e.g. esp32c3).
+const m = memoryUsage()
+const fitsFetch = m.heapTotal - m.heapUsed > 48 * 1024
+
 describe.runIf(hasWifi)('wifi e2e', () => {
   test('connect to wifi', async () => {
     const {wifi} = await import('mikro/wifi')
@@ -19,7 +27,7 @@ describe.runIf(hasWifi)('wifi e2e', () => {
     if (result.ok) console.log(`connected: ${result.value.ip}`)
   })
 
-  test('http request', async () => {
+  test.runIf(fitsFetch)('http request', async () => {
     const {request} = await import('mikro/http/request')
     const result = await request('http://httpbingo.org/get')
     assert.ok(result)
@@ -27,7 +35,7 @@ describe.runIf(hasWifi)('wifi e2e', () => {
     if (result.ok) await result.value.close()
   })
 
-  test('sntp sync', async () => {
+  test.runIf(fitsFetch)('sntp sync', async () => {
     const {sntp} = await import('mikro/sntp')
     const result = await sntp.sync({servers: ['pool.ntp.org']})
     assert.ok(result)

--- a/dev/e2e/test/withUnload.test.heap-baseline.json
+++ b/dev/e2e/test/withUnload.test.heap-baseline.json
@@ -1,4 +1,10 @@
 {
+  "esp32c3": {
+    "heapDelta": 7878
+  },
+  "esp32c5": {
+    "heapDelta": 8342
+  },
   "esp32c6": {
     "heapDelta": 8342
   },

--- a/dev/e2e/test/withUnload.test.ts
+++ b/dev/e2e/test/withUnload.test.ts
@@ -4,13 +4,20 @@ import {assert, describe, test} from 'mikro/test'
 
 type Evals = Record<string, number>
 
+// Loading the phase fixture tree while sampling heap marks needs real
+// working room: with ~35KB free at module eval the load still OOMs on
+// esp32c3, so require a comfortable margin before running the reclaim
+// test.
+const m = memoryUsage()
+const fitsPhaseTree = m.heapTotal - m.heapUsed > 48 * 1024
+
 describe('withUnload', () => {
   test('rejects a builtin (anchored) module', async () => {
     // Builtins (mikrojs/*, native:*) are anchored and cannot be unloaded.
     await assert.rejects(() => withUnload(import('mikro/result'), (m) => m))
   })
 
-  test('unloads a nested module tree and reclaims its heap', async () => {
+  test.runIf(fitsPhaseTree)('unloads a nested module tree and reclaims its heap', async () => {
     const g = globalThis as unknown as {__phaseEvals?: Evals}
 
     const before = memoryUsage().heapUsed


### PR DESCRIPTION
The heavy test files OOM'd at module load on esp32c3. Split them so each fits, lazy-import the wifi and http module graphs, and skip sections that need more heap than the runtime has via free-heap gates. Heap baselines re-recorded for esp32c3, esp32c5, esp32c6, and the simulator.