### PR TITLE
fix(http): name out-of-memory when an alloc-class TLS error surfaces

### DIFF
--- a/packages/@mikrojs/firmware/components/mikrojs/mik_http.cpp
+++ b/packages/@mikrojs/firmware/components/mikrojs/mik_http.cpp
@@ -218,9 +218,17 @@ static void mik__http_task(void* arg) {
             int tls_flags = 0;
             esp_err_t last_tls_err =
                 esp_http_client_get_and_clear_last_tls_error(client, &tls_code, &tls_flags);
+            /* Alloc-class failures surface as opaque transport codes: 0x008d
+             * is PSA's INSUFFICIENT_MEMORY (-141) leaking through the mbedtls
+             * slot untranslated, 0x7f00 is MBEDTLS_ERR_SSL_ALLOC_FAILED. Name
+             * the condition when a trustworthy code is present; otherwise
+             * keep the plain connect error (no heap-level guessing). */
+            bool out_of_memory = err == ESP_ERR_NO_MEM || last_tls_err == ESP_ERR_NO_MEM ||
+                                 tls_code == 0x008d || tls_code == 0x7f00;
             snprintf(error_buf, sizeof(error_buf),
-                     "fetch failed: could not connect to %s (%s, errno=%d, "
+                     "fetch failed: %s %s (%s, errno=%d, "
                      "esp_tls=%s, mbedtls=-0x%04x, flags=0x%x)",
+                     out_of_memory ? "out of memory connecting to" : "could not connect to",
                      args->req.url, esp_err_to_name(err), sock_errno,
                      esp_err_to_name(last_tls_err), tls_code, tls_flags);
             have_error = true;


### PR DESCRIPTION
A memory-starved TLS handshake on no-PSRAM chips printed opaque transport codes, such as a raw PSA INSUFFICIENT_MEMORY (-141) surfacing as mbedtls=-0x008d. Map the alloc-class codes (PSA -141, MBEDTLS_ERR_SSL_ALLOC_FAILED, ESP_ERR_NO_MEM) to an explicit out-of-memory message. Failures without such a code keep the plain connect error; no heap-level guessing.