### PR TITLE
fix(firmware): guard MIK_InitPromise OOM to avoid gc_decref double-free

### DIFF
--- a/packages/@mikrojs/firmware/components/mikrojs/mik_http.cpp
+++ b/packages/@mikrojs/firmware/components/mikrojs/mik_http.cpp
@@ -581,6 +581,14 @@ static JSValue mik__http_request(JSContext* ctx, JSValue this_val, int argc, JSV
     MIKHttpPending pending = {};
     pending.id = mik__http_st(mik_rt)->next_id++;
     JSValue headers_promise = MIK_InitPromise(ctx, &pending.headers_promise);
+    if (JS_IsException(headers_promise)) {
+        /* OOM building the promise. Nothing is registered yet, so just free the
+         * request and propagate. Do NOT register this pending entry: its
+         * headers_promise.rfuncs are unwritten on failure, and a later
+         * consume/destroy would free dangling values (gc_decref underflow). */
+        mik__http_free_request(&req);
+        return JS_EXCEPTION;
+    }
 
     auto* cancelled = new std::atomic<bool>(false);
     pending.cancelled = cancelled;
@@ -672,6 +680,12 @@ static JSValue mik__http_next_message(JSContext* ctx, JSValue this_val, int argc
 
     /* Slow path: wait. Create a new promise stored on the pending entry. */
     JSValue promise = MIK_InitPromise(ctx, &p->next_promise);
+    if (JS_IsException(promise)) {
+        /* OOM building the promise. Do NOT mark next_promise_active: rfuncs are
+         * unwritten on failure, so a later resolve/destroy would free dangling
+         * values (gc_decref underflow). */
+        return JS_EXCEPTION;
+    }
     p->next_promise_active = true;
     return promise;
 }

--- a/packages/@mikrojs/firmware/components/mikrojs/mik_sntp.cpp
+++ b/packages/@mikrojs/firmware/components/mikrojs/mik_sntp.cpp
@@ -144,6 +144,15 @@ static JSValue mik__sntp_sync(JSContext* ctx, JSValue this_val, int argc, JSValu
 
     /* Create and return promise wrapped in result */
     JSValue promise = MIK_InitPromise(ctx, &state->sync_promise);
+    if (JS_IsException(promise)) {
+        /* OOM building the promise. Tear down so we don't leave a half-started
+         * sync, and crucially do NOT set sync_pending: MIK_InitPromise leaves
+         * sync_promise.rfuncs unwritten on failure, so a later consume/destroy
+         * would free dangling values (gc_decref refcount underflow). */
+        esp_netif_sntp_deinit();
+        state->running = false;
+        return JS_EXCEPTION;
+    }
     state->sync_pending = true;
 
     return mik__result_ok(ctx, promise);


### PR DESCRIPTION
Under heap exhaustion MIK_InitPromise returns JS_EXCEPTION and leaves the MIKPromise rfuncs unwritten. sntp_sync and http_request set their pending flag / registered the entry anyway, so a later consume or destroy freed those dangling values, tripping the gc_decref_child refcount assert and corrupting the heap. Bail out without setting the flag or registering the entry when the promise fails to init.