### PR TITLE
feat(cli): offer to reflash incompatible device firmware

### DIFF
--- a/packages/mikro/src/cli/commands/console.tsx
+++ b/packages/mikro/src/cli/commands/console.tsx
@@ -5,6 +5,7 @@ import {flag, option} from '@optique/core/primitives'
 
 import {DevicePicker} from '../components/DevicePicker.js'
 import {port} from '../lib/portValueParser.js'
+import {FirmwareGate} from '../lib/serial/FirmwareGate.js'
 import {InkReplMode} from '../lib/serial/InkReplMode.js'
 import {runAgentRepl} from '../lib/serial/runAgentRepl.js'
 
@@ -23,6 +24,11 @@ export const args = command(
         description: message`Reset the device and force safe mode (skips autorun). Use when the deployed app is crash-looping.`,
       }),
     ),
+    yes: optional(
+      flag('-y', '--yes', {
+        description: message`If the device firmware is incompatible, flash CLI-matched firmware without prompting`,
+      }),
+    ),
   }),
 )
 
@@ -32,7 +38,7 @@ type Props = {
 
 export async function run(config: InferValue<typeof args>) {
   return runAgentRepl(
-    {port: config.port, recover: config.recover === true},
+    {port: config.port, recover: config.recover === true, yes: config.yes === true},
     {
       command: 'console',
       nextActions: [
@@ -44,15 +50,19 @@ export async function run(config: InferValue<typeof args>) {
 }
 
 export default function ConsoleCmd(props: Props) {
-  const {port, recover} = props.args
+  const {port, recover, yes} = props.args
   return (
     <DevicePicker port={port}>
       {(device) => (
-        <InkReplMode
-          devicePath={device.path}
-          serialNumber={device.serialNumber}
-          recover={recover === true}
-        />
+        <FirmwareGate devicePath={device.path} command="console" yes={yes === true}>
+          {() => (
+            <InkReplMode
+              devicePath={device.path}
+              serialNumber={device.serialNumber}
+              recover={recover === true}
+            />
+          )}
+        </FirmwareGate>
       )}
     </DevicePicker>
   )

--- a/packages/mikro/src/cli/commands/deploy.tsx
+++ b/packages/mikro/src/cli/commands/deploy.tsx
@@ -16,11 +16,15 @@ import {agentEmit, agentResult, isAgentMode} from '../lib/agent.js'
 import {build} from '../lib/build.js'
 import {collectFiles, loadEnvFiles, validateNvsKeys} from '../lib/deploy.js'
 import {formatDeployEvent} from '../lib/deployProgress.js'
+import {FirmwareIncompatibleError} from '../lib/firmwareCompat.js'
+import {flashFirmware} from '../lib/flashFirmware.js'
 import {parseLogLevel, parseMinifier, parseMinifyLevel} from '../lib/parseMinifier.js'
+import {detectPreferredPm, mikroCommand} from '../lib/pkgManager.js'
 import {port} from '../lib/portValueParser.js'
 import {getMikroDir, resolveProjectRoot} from '../lib/projectRoot.js'
 import {resolveEntry} from '../lib/resolveEntry.js'
 import {getPredeployCommands, runHooks} from '../lib/runHooks.js'
+import {FirmwareGate} from '../lib/serial/FirmwareGate.js'
 import {InkReplConsole} from '../lib/serial/InkReplConsole.js'
 import {openSession} from '../lib/serial/openSession.js'
 import type {ReplSession} from '../lib/session.js'
@@ -90,6 +94,11 @@ export const args = command(
     logLevel: optional(
       option('--loglevel', string({metavar: 'LEVEL'}), {
         description: message`Log level: none, error, warn, info, debug. Console calls below this level are eliminated at build time.`,
+      }),
+    ),
+    yes: optional(
+      flag('-y', '--yes', {
+        description: message`If the device firmware is incompatible, flash CLI-matched firmware without prompting`,
       }),
     ),
     json: optional(flag('--json', {description: message`Output as JSON`})),
@@ -221,6 +230,20 @@ export async function run(
         ),
     )
     if (last.type !== 'complete') throw new Error('Deploy did not complete')
+  } catch (err) {
+    // Non-interactive reflash: the Ink path is gated by FirmwareGate, so a
+    // FirmwareIncompatibleError only reaches here in headless modes
+    // (--json / --agent / no TTY). Flash CLI-matched firmware when --yes was
+    // passed; otherwise rethrow and let the caller surface the error.
+    if (err instanceof FirmwareIncompatibleError && config.yes === true) {
+      handles.close()
+      log('Device firmware is incompatible with this CLI. Flashing CLI-matched firmware…')
+      await flashFirmware({port: devicePath, onProgress: (m) => log(m)})
+      const pm = await detectPreferredPm()
+      log(`Firmware updated. Re-run ${mikroCommand(pm, 'deploy')}.`)
+      process.exit(0)
+    }
+    throw err
   } finally {
     if (!config.console) handles.close()
   }
@@ -258,7 +281,11 @@ export default function Deploy(props: Props) {
 
   return (
     <DevicePicker port={config.port}>
-      {(device) => <DeployInner config={config} device={device} />}
+      {(device) => (
+        <FirmwareGate devicePath={device.path} command="deploy" yes={config.yes === true}>
+          {() => <DeployInner config={config} device={device} />}
+        </FirmwareGate>
+      )}
     </DevicePicker>
   )
 }

--- a/packages/mikro/src/cli/commands/dev.tsx
+++ b/packages/mikro/src/cli/commands/dev.tsx
@@ -12,6 +12,7 @@ import {parseLogLevel, parseMinifier, parseMinifyLevel} from '../lib/parseMinifi
 import {port} from '../lib/portValueParser.js'
 import {resolveEntry} from '../lib/resolveEntry.js'
 import {createDevSession, type DevSessionHandle} from '../lib/serial/devSession.js'
+import {FirmwareGate} from '../lib/serial/FirmwareGate.js'
 import {
   type InkReplDriverContext,
   type InkReplDriverResult,
@@ -70,6 +71,11 @@ export const args = command(
       }),
     ),
     agent: optional(flag('--agent', {description: message`NDJSON agent protocol over stdio`})),
+    yes: optional(
+      flag('-y', '--yes', {
+        description: message`If the device firmware is incompatible, flash CLI-matched firmware without prompting`,
+      }),
+    ),
   }),
 )
 
@@ -83,7 +89,7 @@ export async function run(config: InferValue<typeof args>) {
   let stateSub: Subscription | null = null
 
   return runAgentRepl(
-    {port: config.port},
+    {port: config.port, yes: config.yes === true},
     {
       command: 'dev',
       onReady: async ({session}) => {
@@ -166,7 +172,7 @@ export async function run(config: InferValue<typeof args>) {
 }
 
 export default function Dev(props: Props) {
-  const {port, noMinify, noBytecode, forceDeploy, noWatch, noHooks} = props.args
+  const {port, noMinify, noBytecode, forceDeploy, noWatch, noHooks, yes} = props.args
   const minifier = parseMinifier(props.args.minifier)
   const minifyLevel = parseMinifyLevel(props.args.minifyLevel)
   const logLevel = parseLogLevel(props.args.logLevel)
@@ -211,13 +217,17 @@ export default function Dev(props: Props) {
   return (
     <DevicePicker port={port}>
       {(device) => (
-        <InkReplMode
-          devicePath={device.path}
-          serialNumber={device.serialNumber}
-          logLevel={logLevel}
-          driver={driver}
-          watch={watch}
-        />
+        <FirmwareGate devicePath={device.path} command="dev" yes={yes === true}>
+          {() => (
+            <InkReplMode
+              devicePath={device.path}
+              serialNumber={device.serialNumber}
+              logLevel={logLevel}
+              driver={driver}
+              watch={watch}
+            />
+          )}
+        </FirmwareGate>
       )}
     </DevicePicker>
   )

--- a/packages/mikro/src/cli/commands/flash.tsx
+++ b/packages/mikro/src/cli/commands/flash.tsx
@@ -1,5 +1,3 @@
-import {getEsptoolPath} from '@mikrojs/esptool'
-import {hasPrebuiltFirmware, prebuiltFirmwareDir} from '@mikrojs/firmware'
 import {command, constant, message, object, optional} from '@optique/core'
 import type {InferValue} from '@optique/core/parser'
 import {flag, option} from '@optique/core/primitives'
@@ -11,10 +9,9 @@ import React, {useEffect, useMemo, useState} from 'react'
 import type {Observable} from 'rxjs'
 
 import {type PortInfo, useDevices} from '../hooks/useDevices.js'
-import {type BoardInfo, discoverBoards} from '../lib/boards.js'
 import {formatDeviceList} from '../lib/deviceLabel.js'
-import {type FlasherArgs, getWriteFlashMultiArgs, readFlasherArgs} from '../lib/esptool.js'
-import {type Chip, resolveFrom} from '../lib/firmware.js'
+import {type FlasherArgs, getWriteFlashMultiArgs} from '../lib/esptool.js'
+import {resolveFlashPlan} from '../lib/flashFirmware.js'
 import {INITIAL_SPAWN_STATE, ospawn, type SpawnState} from '../lib/ospawn.js'
 import {detectPreferredPm, mikroCommand, type PkgManager} from '../lib/pkgManager.js'
 import {port} from '../lib/portValueParser.js'
@@ -84,50 +81,6 @@ type InitState =
   | {status: 'ready'; flasherArgs: FlasherArgs; esptoolPath: string}
   | {status: 'error'; error: Error}
 
-async function resolveEsptool(): Promise<string> {
-  return await getEsptoolPath()
-}
-
-async function detectChip(esptoolPath: string, port: string): Promise<Chip> {
-  const {execFile} = await import('node:child_process')
-  const {promisify} = await import('node:util')
-  const execFileAsync = promisify(execFile)
-
-  try {
-    const {stdout} = await execFileAsync(esptoolPath, ['--port', port, 'chip-id'])
-
-    // esptool chip_id output contains "Detecting chip type... ESP32-C6" or similar
-    const match = stdout.match(/Detecting chip type\.\.\.\s*(\S+)/i)
-    if (match) {
-      return match[1]!.toLowerCase().replace(/-/g, '')
-    }
-  } catch {
-    // Detection failed, fall through
-  }
-
-  throw new Error(
-    `Could not detect chip type. Use --target to specify the chip (e.g. --target esp32c6).`,
-  )
-}
-
-async function discoverBoard(boardFlag: string | undefined): Promise<BoardInfo | undefined> {
-  const boards = await discoverBoards(process.cwd())
-  if (boardFlag) {
-    const board = boards.find((b) => b.name === boardFlag)
-    if (!board) {
-      throw new Error(
-        `Board '${boardFlag}' not found in project dependencies.\n` +
-          (boards.length > 0
-            ? `Available boards: ${boards.map((b) => b.name).join(', ')}`
-            : `No board packages found. Add a board package to your dependencies.`),
-      )
-    }
-    return board
-  }
-  // Auto-discover if exactly one board
-  return boards.length === 1 ? boards[0] : undefined
-}
-
 export default function FlashCmd(props: Props) {
   const {
     args: {
@@ -170,63 +123,15 @@ export default function FlashCmd(props: Props) {
     if (!devicePath) return
 
     async function init() {
-      if (buildDir) {
-        // Local build mode
-        const [flasherArgs, esptoolPath] = await Promise.all([
-          readFlasherArgs(buildDir),
-          resolveEsptool(),
-        ])
-        setInitState({status: 'ready', flasherArgs, esptoolPath})
-      } else if (from) {
-        // --from: unified firmware source resolution
-        setInitState({status: 'loading', message: 'Resolving esptool…'})
-        const esptoolPath = await resolveEsptool()
-
-        // Discover board for artifact selection
-        const board = await discoverBoard(boardFlag)
-        let resolvedChip: Chip | undefined = target ?? board?.chip
-        if (!resolvedChip) {
-          setInitState({status: 'loading', message: 'Detecting chip…'})
-          resolvedChip = await detectChip(esptoolPath, devicePath!)
-        }
-
-        const firmwareDir = await resolveFrom({
-          from,
-          chip: resolvedChip,
-          board: board?.name,
-          onProgress: (message) => setInitState({status: 'loading', message}),
-        })
-        const flasherArgs = await readFlasherArgs(firmwareDir)
-        setInitState({status: 'ready', flasherArgs, esptoolPath})
-      } else {
-        // Default: bundled prebuilt firmware shipped inside @mikrojs/firmware,
-        // matched to this CLI's version via the lockstep release group.
-        setInitState({status: 'loading', message: 'Resolving esptool…'})
-        const esptoolPath = await resolveEsptool()
-
-        const board = await discoverBoard(boardFlag)
-
-        let resolvedChip: Chip
-        if (target) {
-          resolvedChip = target
-        } else if (board) {
-          resolvedChip = board.chip
-        } else {
-          setInitState({status: 'loading', message: 'Detecting chip…'})
-          resolvedChip = await detectChip(esptoolPath, devicePath!)
-        }
-
-        if (!hasPrebuiltFirmware(resolvedChip)) {
-          throw new Error(
-            `No bundled firmware for ${resolvedChip}. ` +
-              `Build a custom firmware locally and flash with --build-dir, ` +
-              `or fetch a CI artifact with --from=mikrojs/mikro@<sha>.`,
-          )
-        }
-
-        const flasherArgs = await readFlasherArgs(prebuiltFirmwareDir(resolvedChip))
-        setInitState({status: 'ready', flasherArgs, esptoolPath})
-      }
+      const plan = await resolveFlashPlan({
+        port: devicePath!,
+        buildDir,
+        from,
+        board: boardFlag,
+        target,
+        onProgress: (message) => setInitState({status: 'loading', message}),
+      })
+      setInitState({status: 'ready', ...plan})
     }
 
     init().catch((err: unknown) => {

--- a/packages/mikro/src/cli/lib/__test__/session.test.ts
+++ b/packages/mikro/src/cli/lib/__test__/session.test.ts
@@ -1,9 +1,11 @@
 import {createRequire} from 'node:module'
 
 import {encode as encodeCbor} from 'cbor2'
-import {lastValueFrom, Subject} from 'rxjs'
-import {afterEach, describe, expect, it} from 'vitest'
+import {firstValueFrom, lastValueFrom, Subject} from 'rxjs'
+import {inc} from 'semver'
+import {afterEach, describe, expect, it, vi} from 'vitest'
 
+import {FirmwareIncompatibleError} from '../firmwareCompat.js'
 import {
   buildFrame,
   CMD_DEPLOY_ABORT,
@@ -22,7 +24,12 @@ import {
   MSG_OK,
   MSG_READY,
 } from '../protocol.js'
-import {connectRepl as connectReplImpl, type ReplEvent, type ReplSession} from '../session.js'
+import {
+  connectRepl as connectReplImpl,
+  type ConnectReplOptions,
+  type ReplEvent,
+  type ReplSession,
+} from '../session.js'
 import type {Transport} from '../transport.js'
 
 // Track every session opened by a test so we can close any that the test
@@ -32,8 +39,8 @@ import type {Transport} from '../transport.js'
 // DeviceTimeoutError that kills the run.
 const openSessions = new Set<ReplSession>()
 
-function connectRepl(transport: Transport): ReplSession {
-  const session = connectReplImpl(transport)
+function connectRepl(transport: Transport, options?: ConnectReplOptions): ReplSession {
+  const session = connectReplImpl(transport, options)
   openSessions.add(session)
   return session
 }
@@ -41,6 +48,7 @@ function connectRepl(transport: Transport): ReplSession {
 afterEach(() => {
   for (const session of openSessions) session.close()
   openSessions.clear()
+  vi.restoreAllMocks()
 })
 
 const require = createRequire(import.meta.url)
@@ -426,6 +434,57 @@ describe('session', () => {
       await session.config.delete('KEY')
 
       session.close()
+    })
+  })
+
+  describe('firmware compat policy', () => {
+    /** Outside any ^x.y range the CLI can ever be in. */
+    const INCOMPATIBLE_VERSION = '0.0.1'
+    /** In-range but not equal: next patch of the CLI's own version. */
+    const NEWER_IN_RANGE = inc(CLI_VERSION, 'patch')!
+
+    function awaitReadyWith(version: string, compat?: ConnectReplOptions['compat']) {
+      const {transport, sendFrame} = createMockTransport()
+      const session = connectRepl(transport, compat ? {compat} : undefined)
+      session.messages$.subscribe(() => {})
+      const ready = firstValueFrom(session.awaitReady$(1000))
+      sendFrame(MSG_READY, Buffer.from(encodeCbor({chip: 'test', id: '0', v: version})))
+      return ready
+    }
+
+    it("'enforce' (default) rejects awaitReady$ on incompatible firmware", async () => {
+      await expect(awaitReadyWith(INCOMPATIBLE_VERSION)).rejects.toBeInstanceOf(
+        FirmwareIncompatibleError,
+      )
+    })
+
+    it("'report' resolves silently and attaches the incompatible advisory", async () => {
+      const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+      const ready = await awaitReadyWith(INCOMPATIBLE_VERSION, 'report')
+
+      expect(ready.advisory?.kind).to.equal('incompatible')
+      expect(ready.advisory?.message).to.contain('not compatible')
+      expect(stderr).not.toHaveBeenCalled()
+    })
+
+    it("'report' stays silent on the soft update_available advisory", async () => {
+      const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+      const ready = await awaitReadyWith(NEWER_IN_RANGE, 'report')
+
+      expect(ready.advisory?.kind).to.equal('device_newer')
+      expect(stderr).not.toHaveBeenCalled()
+    })
+
+    it("'best-effort' warns on stderr once and proceeds on incompatible firmware", async () => {
+      const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+      const ready = await awaitReadyWith(INCOMPATIBLE_VERSION, 'best-effort')
+
+      expect(ready.advisory?.kind).to.equal('incompatible')
+      expect(stderr).toHaveBeenCalledTimes(1)
+      expect(String(stderr.mock.calls[0]![0])).to.contain('Attempting anyway')
     })
   })
 })

--- a/packages/mikro/src/cli/lib/flashFirmware.ts
+++ b/packages/mikro/src/cli/lib/flashFirmware.ts
@@ -1,0 +1,164 @@
+import {getEsptoolPath} from '@mikrojs/esptool'
+import {hasPrebuiltFirmware, prebuiltFirmwareDir} from '@mikrojs/firmware'
+import {lastValueFrom} from 'rxjs'
+
+import {type BoardInfo, discoverBoards} from './boards.js'
+import {type FlasherArgs, getWriteFlashMultiArgs, readFlasherArgs} from './esptool.js'
+import {type Chip, resolveFrom} from './firmware.js'
+import {ospawn} from './ospawn.js'
+
+export const DEFAULT_FLASH_BAUD = 460800
+
+export interface FlashPlanOptions {
+  /** Serial port of the device to flash. */
+  port: string
+  /** Local ESP-IDF build directory. Mutually exclusive with `from`. */
+  buildDir?: string
+  /** Firmware source ref (release tag, branch, commit, repo, or archive URL). */
+  from?: string
+  /** Board name; auto-discovered from project dependencies if omitted. */
+  board?: string
+  /** Target chip; auto-detected via esptool if omitted. */
+  target?: Chip
+  /** Progress callback for the resolution/flash phases. */
+  onProgress?: (message: string) => void
+}
+
+export interface FlashPlan {
+  esptoolPath: string
+  flasherArgs: FlasherArgs
+}
+
+/** Detect the chip type of the device on `port` via `esptool chip-id`. */
+export async function detectChip(esptoolPath: string, port: string): Promise<Chip> {
+  const {execFile} = await import('node:child_process')
+  const {promisify} = await import('node:util')
+  const execFileAsync = promisify(execFile)
+
+  try {
+    const {stdout} = await execFileAsync(esptoolPath, ['--port', port, 'chip-id'])
+
+    // esptool chip_id output contains "Detecting chip type... ESP32-C6" or similar
+    const match = stdout.match(/Detecting chip type\.\.\.\s*(\S+)/i)
+    if (match) {
+      return match[1]!.toLowerCase().replace(/-/g, '')
+    }
+  } catch {
+    // Detection failed, fall through
+  }
+
+  throw new Error(
+    `Could not detect chip type. Use --target to specify the chip (e.g. --target esp32c6).`,
+  )
+}
+
+/** Resolve a board package from project dependencies, honoring an explicit
+ *  `--board` flag. Returns undefined when no flag is given and the project
+ *  has zero or several boards (the caller falls back to chip detection). */
+export async function discoverBoard(boardFlag: string | undefined): Promise<BoardInfo | undefined> {
+  const boards = await discoverBoards(process.cwd())
+  if (boardFlag) {
+    const board = boards.find((b) => b.name === boardFlag)
+    if (!board) {
+      throw new Error(
+        `Board '${boardFlag}' not found in project dependencies.\n` +
+          (boards.length > 0
+            ? `Available boards: ${boards.map((b) => b.name).join(', ')}`
+            : `No board packages found. Add a board package to your dependencies.`),
+      )
+    }
+    return board
+  }
+  // Auto-discover if exactly one board
+  return boards.length === 1 ? boards[0] : undefined
+}
+
+/**
+ * Resolve everything needed to flash, without running esptool: the esptool
+ * binary plus the per-chip flasher arguments (firmware files, flash mode,
+ * etc.). Mirrors the three source modes of `mikro flash`:
+ *   - `buildDir`: a local ESP-IDF build
+ *   - `from`: a downloaded firmware ref
+ *   - neither: the prebuilt firmware bundled with this CLI version
+ */
+export async function resolveFlashPlan(opts: FlashPlanOptions): Promise<FlashPlan> {
+  const {port, buildDir, from, board: boardFlag, target, onProgress} = opts
+
+  if (buildDir) {
+    const [flasherArgs, esptoolPath] = await Promise.all([
+      readFlasherArgs(buildDir),
+      getEsptoolPath(),
+    ])
+    return {esptoolPath, flasherArgs}
+  }
+
+  onProgress?.('Resolving esptool…')
+  const esptoolPath = await getEsptoolPath()
+  const board = await discoverBoard(boardFlag)
+
+  if (from) {
+    let resolvedChip: Chip | undefined = target ?? board?.chip
+    if (!resolvedChip) {
+      onProgress?.('Detecting chip…')
+      resolvedChip = await detectChip(esptoolPath, port)
+    }
+    const firmwareDir = await resolveFrom({
+      from,
+      chip: resolvedChip,
+      board: board?.name,
+      onProgress: (message) => onProgress?.(message),
+    })
+    const flasherArgs = await readFlasherArgs(firmwareDir)
+    return {esptoolPath, flasherArgs}
+  }
+
+  // Default: bundled prebuilt firmware shipped inside @mikrojs/firmware,
+  // matched to this CLI's version via the lockstep release group.
+  let resolvedChip: Chip
+  if (target) {
+    resolvedChip = target
+  } else if (board) {
+    resolvedChip = board.chip
+  } else {
+    onProgress?.('Detecting chip…')
+    resolvedChip = await detectChip(esptoolPath, port)
+  }
+
+  if (!hasPrebuiltFirmware(resolvedChip)) {
+    throw new Error(
+      `No bundled firmware for ${resolvedChip}. ` +
+        `Build a custom firmware locally and flash with --build-dir, ` +
+        `or fetch a CI artifact with --from=mikrojs/mikro@<sha>.`,
+    )
+  }
+
+  const flasherArgs = await readFlasherArgs(prebuiltFirmwareDir(resolvedChip))
+  return {esptoolPath, flasherArgs}
+}
+
+/**
+ * Resolve and flash firmware to completion, headlessly. Resolves on success,
+ * rejects with the esptool failure on error. The serial port must be free
+ * (no open session) before calling — esptool needs exclusive bootloader
+ * access. Used by the auto-reflash flow; the interactive `mikro flash`
+ * command renders its own live progress and only shares `resolveFlashPlan`.
+ */
+export async function flashFirmware(opts: FlashPlanOptions & {baudRate?: number}): Promise<void> {
+  const {port, baudRate = DEFAULT_FLASH_BAUD, onProgress} = opts
+  const {esptoolPath, flasherArgs} = await resolveFlashPlan(opts)
+
+  onProgress?.(`Flashing ${flasherArgs.chip} firmware…`)
+  const esptoolArgs = getWriteFlashMultiArgs({
+    chip: flasherArgs.chip,
+    port,
+    baudRate,
+    before: flasherArgs.before,
+    after: flasherArgs.after,
+    flashMode: flasherArgs.flashMode,
+    flashSize: flasherArgs.flashSize,
+    files: flasherArgs.files,
+  })
+
+  const final = await lastValueFrom(ospawn(esptoolPath, esptoolArgs))
+  if (final.error) throw final.error
+}

--- a/packages/mikro/src/cli/lib/serial/FirmwareGate.tsx
+++ b/packages/mikro/src/cli/lib/serial/FirmwareGate.tsx
@@ -1,0 +1,209 @@
+import spinners from 'cli-spinners'
+import figures from 'figures'
+import {Box, Text, useInput} from 'ink'
+import {type ReactNode, useEffect, useState} from 'react'
+import {firstValueFrom} from 'rxjs'
+
+import {flashFirmware} from '../flashFirmware.js'
+import {detectPreferredPm, installVersionCommand, mikroCommand} from '../pkgManager.js'
+import {Spinner} from '../Spinner.js'
+import {openSession} from './openSession.js'
+
+/** Probe handshake budget. A healthy device replies to CMD_HELLO almost
+ *  immediately; this only bounds how long we wait before giving up on the
+ *  compat probe and letting the command's own connect handle a slow or
+ *  silent device. Kept well under the command's own 10s ready timeout. */
+const PROBE_TIMEOUT_MS = 4000
+
+type GateState =
+  | {status: 'probing'}
+  | {status: 'ok'}
+  | {status: 'prompt'; deviceVersion: string | null}
+  | {status: 'flashing'; message: string}
+  | {status: 'flashed'}
+  | {status: 'declined'}
+  | {status: 'flash_error'; message: string}
+
+export interface FirmwareGateProps {
+  devicePath: string
+  command: 'dev' | 'deploy' | 'console'
+  /** Skip the y/N prompt and flash immediately on incompatibility. */
+  yes?: boolean
+  /** Rendered once the firmware is confirmed compatible (or undetermined). */
+  children: () => ReactNode
+}
+
+/**
+ * Gate that sits between device selection and a REPL-class command's UI.
+ * It opens a short probe session to check firmware compatibility:
+ *
+ *   - compatible (or undetermined — slow/silent device): render `children`
+ *     and let the command connect normally.
+ *   - incompatible: prompt to flash CLI-matched firmware (or flash straight
+ *     away with `yes`), then exit with a "re-run" hint. We deliberately do
+ *     not reconnect after flashing — the device resets and its USB-CDC port
+ *     re-enumerates, so a clean re-run is more robust than resuming.
+ *
+ * The probe session is always closed before rendering children or flashing
+ * so the port is free for whoever runs next.
+ */
+export function FirmwareGate(props: FirmwareGateProps) {
+  const {devicePath, command, yes, children} = props
+  const [state, setState] = useState<GateState>({status: 'probing'})
+
+  // Probe compatibility once on mount.
+  useEffect(() => {
+    let cancelled = false
+    const handles = openSession({port: devicePath, compat: 'report'})
+
+    handles
+      .then(async (h) => {
+        try {
+          const ready = await firstValueFrom(h.session.awaitReady$(PROBE_TIMEOUT_MS))
+          if (cancelled) return
+          if (ready.advisory?.kind === 'incompatible') {
+            setState(
+              yes
+                ? {status: 'flashing', message: 'Preparing firmware…'}
+                : {status: 'prompt', deviceVersion: ready.version},
+            )
+          } else {
+            setState({status: 'ok'})
+          }
+        } finally {
+          h.close()
+        }
+      })
+      .catch(() => {
+        // Timeout / disconnect / unresolved port: don't block. Proceed and
+        // let the command's own connect surface the real failure as today.
+        if (!cancelled) setState({status: 'ok'})
+      })
+
+    return () => {
+      cancelled = true
+      handles.then((h) => h.close()).catch(() => {})
+    }
+  }, [devicePath, yes])
+
+  // Run the flash once we enter the flashing state.
+  useEffect(() => {
+    if (state.status !== 'flashing') return
+    let cancelled = false
+    flashFirmware({
+      port: devicePath,
+      onProgress: (message) => {
+        if (!cancelled) setState({status: 'flashing', message})
+      },
+    }).then(
+      () => {
+        if (!cancelled) setState({status: 'flashed'})
+      },
+      (err: unknown) => {
+        if (cancelled) return
+        setState({status: 'flash_error', message: err instanceof Error ? err.message : String(err)})
+      },
+    )
+    return () => {
+      cancelled = true
+    }
+    // Only react to entering 'flashing'; message updates re-render in place.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.status === 'flashing', devicePath])
+
+  // Terminal states exit the process as a side effect (not during render).
+  useEffect(() => {
+    if (state.status === 'flashed') process.exit(0)
+    if (state.status === 'declined' || state.status === 'flash_error') process.exit(1)
+  }, [state.status])
+
+  if (state.status === 'ok') return <>{children()}</>
+
+  if (state.status === 'probing') {
+    return (
+      <Text>
+        <Spinner spinner={spinners.dots} /> Checking firmware on {devicePath}…
+      </Text>
+    )
+  }
+
+  if (state.status === 'prompt') {
+    return <ReflashPrompt {...state} command={command} onConfirm={setState} />
+  }
+
+  if (state.status === 'flashing') {
+    return (
+      <Text>
+        <Spinner spinner={spinners.dots} /> {state.message}
+      </Text>
+    )
+  }
+
+  if (state.status === 'flashed') {
+    return <FlashedNotice command={command} />
+  }
+
+  if (state.status === 'flash_error') {
+    return (
+      <Text color="red">
+        {figures.cross} Flashing failed: {state.message}
+      </Text>
+    )
+  }
+
+  // 'declined' — the incompatibility message is printed by the prompt itself.
+  return null
+}
+
+function ReflashPrompt(props: {
+  deviceVersion: string | null
+  command: 'dev' | 'deploy' | 'console'
+  onConfirm: (state: GateState) => void
+}) {
+  const {deviceVersion, onConfirm} = props
+  const [pm, setPm] = useState<'npm' | 'pnpm' | 'yarn' | 'bun'>('npm')
+  useEffect(() => {
+    detectPreferredPm().then(setPm, () => {})
+  }, [])
+
+  useInput((input) => {
+    if (input.toLowerCase() === 'y') {
+      onConfirm({status: 'flashing', message: 'Preparing firmware…'})
+    } else {
+      onConfirm({status: 'declined'})
+    }
+  })
+
+  const got = deviceVersion ?? 'an unknown version'
+  return (
+    <Box flexDirection="column">
+      <Text color="yellow">
+        {figures.warning} Device is running mikrojs v{got}, which is not compatible with this CLI.
+      </Text>
+      <Text>
+        Flash CLI-matched firmware now? <Text bold>(y/N)</Text>
+      </Text>
+      <Text color="gray">
+        {figures.pointerSmall} Or keep the device as-is and install a matching CLI:{' '}
+        {deviceVersion
+          ? installVersionCommand(pm, 'mikro', deviceVersion)
+          : mikroCommand(pm, 'flash')}
+      </Text>
+    </Box>
+  )
+}
+
+function FlashedNotice(props: {command: 'dev' | 'deploy' | 'console'}) {
+  const [pm, setPm] = useState<'npm' | 'pnpm' | 'yarn' | 'bun'>('npm')
+  useEffect(() => {
+    detectPreferredPm().then(setPm, () => {})
+  }, [])
+  return (
+    <Box flexDirection="column">
+      <Text color="green">{figures.tick} Firmware updated.</Text>
+      <Text>
+        {figures.pointerSmall} Re-run <Text bold>{mikroCommand(pm, props.command)}</Text>
+      </Text>
+    </Box>
+  )
+}

--- a/packages/mikro/src/cli/lib/serial/openSession.ts
+++ b/packages/mikro/src/cli/lib/serial/openSession.ts
@@ -26,9 +26,11 @@ export interface OpenSessionOptions {
   /**
    * Firmware-version policy. 'best-effort' lets read-only diagnostic
    * commands proceed against incompatible firmware with a warning instead
-   * of a hard error. Defaults to 'enforce'. See ConnectReplOptions.compat.
+   * of a hard error; 'report' proceeds silently and only attaches the
+   * advisory (used by FirmwareGate's probe). Defaults to 'enforce'.
+   * See ConnectReplOptions.compat.
    */
-  compat?: 'enforce' | 'best-effort'
+  compat?: 'enforce' | 'best-effort' | 'report'
 }
 
 /**

--- a/packages/mikro/src/cli/lib/serial/runAgentRepl.ts
+++ b/packages/mikro/src/cli/lib/serial/runAgentRepl.ts
@@ -1,3 +1,5 @@
+import {firstValueFrom} from 'rxjs'
+
 import {
   agentEmit,
   agentError,
@@ -6,6 +8,9 @@ import {
   forwardSessionToAgent,
   type NextAction,
 } from '../agent.js'
+import {FirmwareIncompatibleError} from '../firmwareCompat.js'
+import {flashFirmware} from '../flashFirmware.js'
+import {detectPreferredPm, mikroCommand} from '../pkgManager.js'
 import {openSession, type SessionHandles} from './openSession.js'
 
 export interface AgentReplHooks {
@@ -35,7 +40,7 @@ export interface AgentReplHooks {
  *
  * Per-command behavior slots in via the `hooks` object.
  */
-export async function runAgentRepl<T extends {port?: string; recover?: boolean}>(
+export async function runAgentRepl<T extends {port?: string; recover?: boolean; yes?: boolean}>(
   config: T,
   hooks: AgentReplHooks,
 ): Promise<never> {
@@ -68,8 +73,41 @@ export async function runAgentRepl<T extends {port?: string; recover?: boolean}>
   process.on('SIGTERM', () => process.exit(0))
 
   try {
+    // With --yes, gate on readiness explicitly so the compat check runs (and
+    // can throw FirmwareIncompatibleError) even for commands whose onReady
+    // doesn't touch the session (console has no onReady at all). Without
+    // --yes, keep the old behavior: console must keep forwarding raw output
+    // from a device that never reports ready (post-mortem use).
+    if (config.yes === true) {
+      await firstValueFrom(handles.session.awaitReady$())
+    }
     await hooks.onReady?.(handles)
   } catch (err) {
+    // Non-interactive reflash: with --yes, an incompatible firmware is
+    // flashed with CLI-matched firmware instead of erroring out. We exit
+    // afterward rather than reconnect (the device re-enumerates on reset).
+    if (err instanceof FirmwareIncompatibleError && config.yes === true) {
+      dispose()
+      agentEmit({
+        type: 'raw',
+        text: 'Device firmware incompatible; flashing CLI-matched firmware…\n',
+      })
+      try {
+        await flashFirmware({
+          port: handles.devicePath,
+          onProgress: (m) => agentEmit({type: 'raw', text: m + '\n'}),
+        })
+      } catch (flashErr) {
+        const fmsg = flashErr instanceof Error ? flashErr.message : String(flashErr)
+        agentError(hooks.command, `Flashing failed: ${fmsg}`, {fix: 'Run mikro flash manually'})
+        process.exit(1)
+      }
+      const pm = await detectPreferredPm()
+      agentResult(hooks.command, {firmwareUpdated: true}, [
+        {command: mikroCommand(pm, hooks.command), description: `Re-run ${hooks.command}`},
+      ])
+      process.exit(0)
+    }
     const msg = err instanceof Error ? err.message : String(err)
     agentError(hooks.command, msg, {fix: 'Check device connection and try again'})
     process.exit(1)

--- a/packages/mikro/src/cli/lib/session.ts
+++ b/packages/mikro/src/cli/lib/session.ts
@@ -372,11 +372,15 @@ export interface ConnectReplOptions {
    *   - 'enforce' (default): an incompatible firmware version throws
    *     FirmwareIncompatibleError, blocking the command.
    *   - 'best-effort': an incompatible version is downgraded to a one-time
-   *     warning and the command proceeds anyway. For read-only diagnostic
-   *     commands (logs, env list) where reading a mismatched device's state
-   *     is worth attempting even if the wire protocol may have drifted.
+   *     stderr warning and the command proceeds anyway. For read-only
+   *     diagnostic commands (logs, env list) where reading a mismatched
+   *     device's state is worth attempting even if the wire protocol may
+   *     have drifted.
+   *   - 'report': never throws, never prints — just attaches the advisory
+   *     (including 'incompatible') to the ReadyEvent. For callers that probe
+   *     compatibility and render their own UI (FirmwareGate).
    */
-  compat?: 'enforce' | 'best-effort'
+  compat?: 'enforce' | 'best-effort' | 'report'
 }
 
 export function connectRepl(
@@ -530,17 +534,22 @@ export function connectRepl(
         if (compatPolicy === 'enforce') {
           throw new FirmwareIncompatibleError(formatIncompatibleError(compat, pm))
         }
-        // best-effort: warn once and proceed anyway.
-        const warning = formatBestEffortWarning(compat, pm)
-        if (!advisoryShown) {
+        // best-effort: warn once and proceed. report: stay silent (the
+        // caller renders its own UI from the attached advisory).
+        const message =
+          compatPolicy === 'best-effort'
+            ? formatBestEffortWarning(compat, pm)
+            : formatIncompatibleError(compat, pm)
+        if (compatPolicy === 'best-effort' && !advisoryShown) {
           advisoryShown = true
-          process.stderr.write(warning + '\n')
+          process.stderr.write(message + '\n')
         }
-        return {...event, advisory: {kind: 'incompatible', message: warning}}
+        return {...event, advisory: {kind: 'incompatible', message}}
       }
       // status === 'update_available'
       const message = formatAdvisory(compat, pm)
-      if (!advisoryShown) {
+      // report mode stays silent; the soft notice is for direct CLI runs.
+      if (compatPolicy !== 'report' && !advisoryShown) {
         advisoryShown = true
         process.stderr.write(message + '\n')
       }


### PR DESCRIPTION
dev, deploy, and console now probe firmware compatibility before connecting and, when the device is out of the CLI's range, offer to flash CLI-matched firmware (-y/--yes skips the prompt) instead of dead-ending on a version error. They flash and exit with a re-run hint rather than reconnecting, since the device re-enumerates on reset.