### PR TITLE
fix(firmware): pick up version changes without a clean build

### DIFF
--- a/packages/@mikrojs/firmware/components/mikrojs/CMakeLists.txt
+++ b/packages/@mikrojs/firmware/components/mikrojs/CMakeLists.txt
@@ -116,6 +116,11 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 target_compile_definitions(${COMPONENT_LIB} PRIVATE "MIK_FW_VERSION=\"${_MIK_VERSION}\"")
+# The version is read at configure time, so configure must re-run when the
+# firmware package version changes — otherwise an incremental idf.py build
+# flashes a binary that still reports the stale MIK_FW_VERSION.
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_LIST_DIR}/../../package.json")
 
 # UTC build timestamp. `string(TIMESTAMP ... UTC)` honors SOURCE_DATE_EPOCH
 # when set. Refreshes on re-configure only (idf.py triggers this on each

--- a/packages/@mikrojs/native/CMakeLists.txt
+++ b/packages/@mikrojs/native/CMakeLists.txt
@@ -120,6 +120,10 @@ if(NOT _MIK_VERSION_RESULT EQUAL 0 OR _MIK_VERSION STREQUAL "")
     message(FATAL_ERROR "Failed to resolve package version for MIK_FW_VERSION. Check that package.json exists at the workspace root.")
 endif()
 target_compile_definitions(mikrojs PRIVATE "MIK_FW_VERSION=\"${_MIK_VERSION}\"")
+# The version is read at configure time, so configure must re-run when it
+# changes — otherwise incremental builds keep the stale MIK_FW_VERSION.
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../package.json")
 
 # UTC build timestamp. `string(TIMESTAMP ... UTC)` honors SOURCE_DATE_EPOCH
 # when set (for reproducible builds). Refreshes on re-configure only, not


### PR DESCRIPTION
MIK_FW_VERSION is read from package.json at configure time, but the file was not a configure dependency, so incremental builds kept flashing binaries that report a stale version until a fullclean. Declare it via CMAKE_CONFIGURE_DEPENDS in both the ESP-IDF component and the host library.