### PR TITLE
fix(repl): echo input immediately instead of waiting on device timing

### DIFF
--- a/packages/@mikrojs/native/src/mik_repl.cpp
+++ b/packages/@mikrojs/native/src/mik_repl.cpp
@@ -25,7 +25,6 @@ static JSContext* repl_ctx = nullptr;
 static MIKRuntime* repl_mik_rt = nullptr;
 static int show_depth = 2;
 static bool show_hidden = false;
-static bool show_time = false;
 
 /* ── Protocol mode state ─────────────────────────────────────────── */
 
@@ -285,6 +284,15 @@ static JSValue repl_eval_and_pump(JSContext* ctx, const char* code, size_t len) 
     }
 }
 
+/* Emit eval duration (since t0) as a PROMPT message; the CLI renders it on the
+ * result line when timing display is enabled. */
+static void repl_send_timing(MIKReplTransport* transport, int64_t t0) {
+    int64_t elapsed = MIK_GetPlatform()->get_boot_us() - t0;
+    char timing[32];
+    int tlen = snprintf(timing, sizeof(timing), "%.1fms", (double)elapsed / 1000.0);
+    mik__proto_send(transport, MIK_MSG_PROMPT, timing, tlen);
+}
+
 /* ── Tab completion ──────────────────────────────────────────────── */
 
 static constexpr int MAX_COMPLETIONS = 32;
@@ -315,10 +323,10 @@ static void completion_callback(CompletionBuf& cb, int argc, const char* const* 
 
     /* Check for directive completion */
     if (argc == 1 && last_token[0] == '/') {
-        static const char* directives[] = {"/help",   "/mem",    "/gc",     "/exit",
-                                           "/ls",     "/cat",    "/rm",     "/time",
-                                           "/depth",  "/hidden", "/df",     "/du",
-                                           "/pause",  "/resume", "/info"};
+        static const char* directives[] = {"/help",   "/mem",    "/gc",   "/exit",
+                                           "/ls",     "/cat",    "/rm",   "/depth",
+                                           "/hidden", "/df",     "/du",   "/pause",
+                                           "/resume", "/info"};
         size_t tok_len = strlen(last_token);
         for (size_t i = 0; i < countof(directives); i++) {
             if (strncmp(directives[i], last_token, tok_len) == 0) {
@@ -431,7 +439,6 @@ static bool handle_directive_impl(JSContext* ctx, const char* line, std::string&
             "/help      Show this help\n"
             "/mem       Show heap memory usage\n"
             "/gc        Run garbage collector\n"
-            "/time      Toggle timing display\n"
             "/depth N   Set object inspection depth (default 2)\n"
             "/hidden    Toggle hidden property display\n"
             "/pause     Pause app (suspend timers/callbacks)\n"
@@ -559,12 +566,6 @@ static bool handle_directive_impl(JSContext* ctx, const char* line, std::string&
         long freed = (long)before.malloc_size - (long)after.malloc_size;
         dir_printf(out, "GC collected %ld bytes (%ld -> %ld)\n", freed,
                    (long)before.malloc_size, (long)after.malloc_size);
-        return true;
-    }
-
-    if (strcmp(line, "/time") == 0) {
-        show_time = !show_time;
-        dir_printf(out, "Timing %s\n", show_time ? "on" : "off");
         return true;
     }
 
@@ -884,7 +885,6 @@ void MIK_ProtocolOpen(MIKReplTransport* transport) {
     repl_active = true;
     show_depth = 2;
     show_hidden = false;
-    show_time = false;
 
     /* Build MSG_READY with CBOR device info: {"chip": tstr, "id": tstr, "v": tstr}.
      * Cached here and only emitted in response to a client CMD_HELLO so a
@@ -985,10 +985,7 @@ void MIK_ProtocolServeLoop(void) {
                 std::string code = repl_rewrite_const_let(payload.c_str());
                 code = repl_maybe_wrap_object(code);
 
-                int64_t t0 = 0;
-                if (show_time) {
-                    t0 = platform->get_boot_us();
-                }
+                int64_t t0 = platform->get_boot_us();
 
                 repl_evaluating = true;
                 repl_async_skipped = false;
@@ -1045,15 +1042,8 @@ void MIK_ProtocolServeLoop(void) {
 
                     JS_FreeValue(ctx, exc);
 
-                    /* Send timing before error so CLI can attach it to the input echo */
-                    if (show_time) {
-                        int64_t elapsed = platform->get_boot_us() - t0;
-                        char timing[64];
-                        int tlen =
-                            snprintf(timing, sizeof(timing), "%.1fms", (double)elapsed / 1000.0);
-                        mik__proto_send(transport, MIK_MSG_PROMPT, timing, tlen);
-                    }
-
+                    /* Timing precedes the error so the CLI can render it on that line. */
+                    repl_send_timing(transport, t0);
                     mik__proto_send(transport, MIK_MSG_EVAL_ERROR, msg.c_str(), msg.size());
                 } else if (!JS_IsUndefined(result)) {
                     std::string inspected = mik_inspect(ctx, result, show_depth, false, show_hidden);
@@ -1063,28 +1053,14 @@ void MIK_ProtocolServeLoop(void) {
                     JS_SetPropertyStr(ctx, global, "_", JS_DupValue(ctx, result));
                     JS_FreeValue(ctx, global);
 
-                    /* Send timing before result so CLI can attach it to the input echo */
-                    if (show_time) {
-                        int64_t elapsed = platform->get_boot_us() - t0;
-                        char timing[64];
-                        int tlen =
-                            snprintf(timing, sizeof(timing), "%.1fms", (double)elapsed / 1000.0);
-                        mik__proto_send(transport, MIK_MSG_PROMPT, timing, tlen);
-                    }
-
+                    /* Timing precedes the result so the CLI can render it on that line. */
+                    repl_send_timing(transport, t0);
                     mik__proto_send(transport, MIK_MSG_RESULT, inspected.c_str(),
                                     inspected.size());
                 } else {
-                    /* Send timing before empty result */
-                    if (show_time) {
-                        int64_t elapsed = platform->get_boot_us() - t0;
-                        char timing[64];
-                        int tlen =
-                            snprintf(timing, sizeof(timing), "%.1fms", (double)elapsed / 1000.0);
-                        mik__proto_send(transport, MIK_MSG_PROMPT, timing, tlen);
-                    }
-
-                    /* undefined result — send empty result so CLI knows eval finished */
+                    /* undefined result — send timing then an empty result so the CLI
+                     * knows the eval finished. */
+                    repl_send_timing(transport, t0);
                     mik__proto_send(transport, MIK_MSG_RESULT, nullptr, 0);
                 }
 

--- a/packages/@mikrojs/native/test/repl_protocol_test.cpp
+++ b/packages/@mikrojs/native/test/repl_protocol_test.cpp
@@ -508,26 +508,19 @@ TEST_CASE("CMD_DIRECTIVE /gc returns MSG_INFO" * doctest::test_suite("repl_proto
     proto_teardown();
 }
 
-TEST_CASE("CMD_DIRECTIVE /time toggles timing" * doctest::test_suite("repl_protocol")) {
+TEST_CASE("CMD_EVAL always emits MSG_PROMPT with timing" * doctest::test_suite("repl_protocol")) {
     proto_setup();
 
     std::vector<uint8_t> input;
-    append_frame(input, MIK_CMD_DIRECTIVE, "/time");
     append_frame(input, MIK_CMD_EVAL, "1");
-    append_frame(input, MIK_CMD_DIRECTIVE, "/time"); /* toggle off */
     append_frame(input, MIK_CMD_EXIT, nullptr);
 
     auto frames = run_protocol(input);
 
-    /* First /time should report "on" */
-    auto infos = find_frames(frames, MIK_MSG_INFO);
-    CHECK_MESSAGE(infos.size() >= 1, "Should have at least one MSG_INFO");
-    CHECK_MESSAGE(infos[0]->payload.find("on") != std::string::npos,
-                  "First /time should report 'on'");
-
-    /* Should have a MSG_PROMPT with timing info after eval */
+    /* Timing is reported unconditionally; whether to display it is a host-side
+     * concern (the CLI's `/time` toggle). */
     auto* prompt = find_frame(frames, MIK_MSG_PROMPT);
-    CHECK_MESSAGE(prompt != nullptr, "Should receive MSG_PROMPT with timing");
+    CHECK_MESSAGE(prompt != nullptr, "Every eval should emit MSG_PROMPT with timing");
     CHECK_MESSAGE(prompt->payload.find("ms") != std::string::npos,
                   "Timing prompt should contain 'ms'");
 

--- a/packages/mikro/src/cli/lib/__test__/replStateMachine.test.ts
+++ b/packages/mikro/src/cli/lib/__test__/replStateMachine.test.ts
@@ -252,7 +252,7 @@ describe('replStateMachine', () => {
       const [next, effects] = reduce(s, keyAction('', {return: true, ctrl: true}))
       expect(next.input).toBe('')
       expect(next.evaluating).toBe(true)
-      expect(next.pendingInput).toBe('1+1')
+      expect(next.events.at(-1)).toEqual({type: 'input', code: '1+1'})
       expect(effects).toContainEqual({type: 'eval', code: '1+1'})
       expect(effects).toContainEqual({type: 'appendHistory', entry: '1+1'})
     })
@@ -358,6 +358,26 @@ describe('replStateMachine', () => {
       expect(effects).toContainEqual({type: 'setAlias', name: ''})
     })
 
+    test('/time toggles display host-side without forwarding to the device', () => {
+      const state = createInitialState()
+      const [ready] = reduce(
+        state,
+        deviceEvent({type: 'ready', chip: 'ESP32', id: null, version: null}),
+      )
+      expect(ready.showTiming).toBe(false)
+
+      const s = typeChars(ready, '/time')
+      const [on, effects] = reduce(s, keyAction('', {return: true, ctrl: true}))
+      expect(on.showTiming).toBe(true)
+      // Host-side only: never sent to the device.
+      expect(effects.find((e) => e.type === 'directive')).toBeUndefined()
+      expect(on.events.at(-1)).toEqual({type: 'info', text: 'Timing display on'})
+
+      const s2 = typeChars(on, '/time')
+      const [off] = reduce(s2, keyAction('', {return: true, ctrl: true}))
+      expect(off.showTiming).toBe(false)
+    })
+
     test('/pause sets paused flag', () => {
       const state = createInitialState()
       const [ready] = reduce(
@@ -456,7 +476,7 @@ describe('replStateMachine', () => {
       expect(next.events.at(-1)).toEqual({type: 'log', text: 'hello'})
     })
 
-    test('result event clears evaluating and flushes pending input', () => {
+    test('input is echoed on submit, before the result arrives', () => {
       const state = createInitialState()
       const [ready] = reduce(
         state,
@@ -465,17 +485,39 @@ describe('replStateMachine', () => {
       const s = typeChars(ready, '1+1')
       const [submitted] = reduce(s, keyAction('', {return: true, ctrl: true}))
       expect(submitted.evaluating).toBe(true)
-      expect(submitted.pendingInput).toBe('1+1')
+      // Echo lands immediately — no device round-trip required.
+      expect(submitted.events.find((e) => e.type === 'input')).toEqual({type: 'input', code: '1+1'})
 
       const [afterResult] = reduce(submitted, deviceEvent({type: 'result', text: '2'}))
       expect(afterResult.evaluating).toBe(false)
-      // pendingInput is flushed by prompt (which carries timing), not result
-      expect(afterResult.pendingInput).toBe('1+1')
+      expect(afterResult.events.at(-1)).toEqual({type: 'result', text: '2', timing: undefined})
+    })
 
-      const [next] = reduce(afterResult, deviceEvent({type: 'prompt', timing: ''}))
-      expect(next.pendingInput).toBeNull()
-      const inputEvent = next.events.find((e) => e.type === 'input')
-      expect(inputEvent).toBeDefined()
+    test('empty result is kept (renders as undefined)', () => {
+      const state = createInitialState()
+      const [ready] = reduce(
+        state,
+        deviceEvent({type: 'ready', chip: 'ESP32', id: null, version: null}),
+      )
+      const s = typeChars(ready, 'void 0')
+      const [submitted] = reduce(s, keyAction('', {return: true, ctrl: true}))
+      const [next] = reduce(submitted, deviceEvent({type: 'result', text: ''}))
+      expect(next.events.at(-1)).toEqual({type: 'result', text: '', timing: undefined})
+    })
+
+    test('prompt timing is attached to the result line', () => {
+      const state = createInitialState()
+      const [ready] = reduce(
+        state,
+        deviceEvent({type: 'ready', chip: 'ESP32', id: null, version: null}),
+      )
+      const s = typeChars(ready, '1+1')
+      const [submitted] = reduce(s, keyAction('', {return: true, ctrl: true}))
+      // Device sends timing (prompt) just before the result.
+      const [withTiming] = reduce(submitted, deviceEvent({type: 'prompt', timing: '5ms'}))
+      const [next] = reduce(withTiming, deviceEvent({type: 'result', text: '2'}))
+      expect(next.events.at(-1)).toEqual({type: 'result', text: '2', timing: '5ms'})
+      expect(next.pendingTiming).toBeNull()
     })
 
     test('eval_error clears evaluating', () => {
@@ -908,39 +950,6 @@ describe('replStateMachine', () => {
       const state = createInitialState()
       const [next] = reduce(state, deviceEvent({type: 'prompt', timing: '3ms'}))
       expect(next.pendingTiming).toBe('3ms')
-    })
-
-    test('timing is attached to flushed input', () => {
-      const state = createInitialState()
-      const [ready] = reduce(
-        state,
-        deviceEvent({type: 'ready', chip: 'ESP32', id: null, version: null}),
-      )
-      const s = typeChars(ready, '1+1')
-      const [submitted] = reduce(s, keyAction('', {return: true, ctrl: true}))
-      // Device sends timing, then result
-      const [withTiming] = reduce(submitted, deviceEvent({type: 'prompt', timing: '5ms'}))
-      const [next] = reduce(withTiming, deviceEvent({type: 'result', text: '2'}))
-      const inputEvent = next.events.find((e) => e.type === 'input')
-      expect(inputEvent).toEqual({type: 'input', code: '1+1', timing: '5ms'})
-    })
-
-    test('empty result does not add result event', () => {
-      const state = createInitialState()
-      const [ready] = reduce(
-        state,
-        deviceEvent({type: 'ready', chip: 'ESP32', id: null, version: null}),
-      )
-      const s = typeChars(ready, 'undefined')
-      const [submitted] = reduce(s, keyAction('', {return: true, ctrl: true}))
-      const [afterResult] = reduce(submitted, deviceEvent({type: 'result', text: ''}))
-      // No result event added
-      const resultEvents = afterResult.events.filter((e) => e.type === 'result')
-      expect(resultEvents).toHaveLength(0)
-
-      // Input flushed by prompt
-      const [next] = reduce(afterResult, deviceEvent({type: 'prompt', timing: ''}))
-      expect(next.pendingInput).toBeNull()
     })
 
     test('empty completions are ignored', () => {

--- a/packages/mikro/src/cli/lib/serial/ReplConsole.tsx
+++ b/packages/mikro/src/cli/lib/serial/ReplConsole.tsx
@@ -317,13 +317,29 @@ export function ReplConsole({
         {(event, index) => {
           const text = eventText(event, deviceName)
           const color = eventColor(event)
-          const isDimmed = event.type === 'input' || event.type === 'debug'
-          const timing = event.type === 'input' ? event.timing : undefined
+          const isResult = event.type === 'result'
+          const isDimmed = event.type === 'input' || event.type === 'debug' || isResult
+          // Timing always arrives from the device; `/time` decides whether to show it.
+          const timing =
+            state.showTiming && (event.type === 'result' || event.type === 'eval_error')
+              ? event.timing
+              : undefined
+          // `❯` you typed, `❮•` the value returning, `✖` an error.
+          const prefix = isResult
+            ? '❮• '
+            : event.type === 'eval_error'
+              ? `${figures.cross} `
+              : event.type === 'input'
+                ? prompt
+                : ''
+          // Empty result means the eval produced `undefined` (shown, dimmed).
+          const body = isResult && text === '' ? 'undefined' : text
 
           return (
             <Text key={index} color={color} dimColor={isDimmed}>
-              {timing ? `${timing} ` : ''}
-              {text}
+              {prefix}
+              {body}
+              {timing ? <Text dimColor>{`   ${timing}`}</Text> : null}
             </Text>
           )
         }}

--- a/packages/mikro/src/cli/lib/serial/replStateMachine.ts
+++ b/packages/mikro/src/cli/lib/serial/replStateMachine.ts
@@ -39,7 +39,7 @@ export type ReplLogEvent =
   | ReplEvent
   | {type: 'connecting'; port?: string}
   | {type: 'restarting'}
-  | {type: 'input'; code: string; timing?: string}
+  | {type: 'input'; code: string}
 
 export interface ReplMachineState {
   connection: ConnectionState
@@ -51,6 +51,9 @@ export interface ReplMachineState {
   historyDraft: string | null
   showWelcome: boolean
   evaluating: boolean
+  /** Whether eval timing is shown on result lines. Host-side toggle (`/time`);
+   *  the device always reports timing, the CLI decides whether to render it. */
+  showTiming: boolean
   paused: boolean
   ctrlCPending: boolean
   returnPending: boolean
@@ -61,7 +64,6 @@ export interface ReplMachineState {
   footerError: string | null
   overrideHint: string | null
   contextHint: string | null
-  pendingInput: string | null
   pendingTiming: string | null
   overlay: null | 'env'
   events: ReplLogEvent[]
@@ -224,6 +226,7 @@ export function createInitialState(port?: string, history: string[] = []): ReplM
     historyDraft: null,
     showWelcome: true,
     evaluating: false,
+    showTiming: false,
     paused: false,
     ctrlCPending: false,
     returnPending: false,
@@ -232,7 +235,6 @@ export function createInitialState(port?: string, history: string[] = []): ReplM
     footerError: null,
     overrideHint: null,
     contextHint: null,
-    pendingInput: null,
     pendingTiming: null,
     overlay: null,
     events: [{type: 'connecting', port}],
@@ -312,12 +314,14 @@ function reduceSessionEvent(
     case 'debug':
       return [{...state, events: [...state.events, event]}, []]
     case 'eval_error':
-      return [{...state, evaluating: false, events: [...state.events, event]}, []]
     case 'result': {
-      if (event.text.length > 0) {
-        return [{...state, evaluating: false, events: [...state.events, event]}, []]
-      }
-      return [{...state, evaluating: false}, []]
+      // Attach the timing captured from the preceding `prompt` so it renders on
+      // the result line. Empty results are kept (rendered as `undefined`).
+      const entry = {...event, timing: state.pendingTiming ?? undefined}
+      return [
+        {...state, evaluating: false, pendingTiming: null, events: [...state.events, entry]},
+        [],
+      ]
     }
     case 'completions': {
       const result = event.result
@@ -329,9 +333,8 @@ function reduceSessionEvent(
       return [{...state, events: [...state.events, event]}, []]
     }
     case 'prompt': {
-      // Flush pending input now that we have timing info from the prompt
-      const next = flushPendingInput({...state, pendingTiming: event.timing}, event)
-      return [next, []]
+      // Stash timing; it's attached to the next result/error line.
+      return [{...state, pendingTiming: event.timing}, []]
     }
     case 'raw':
     case 'test':
@@ -361,21 +364,6 @@ function reduceSessionEvent(
     }
     default:
       return [state, []]
-  }
-}
-
-function flushPendingInput(state: ReplMachineState, _trigger: ReplEvent): ReplMachineState {
-  if (!state.pendingInput) return state
-  const inputEvent: ReplLogEvent = {
-    type: 'input',
-    code: state.pendingInput,
-    timing: state.pendingTiming ?? undefined,
-  }
-  return {
-    ...state,
-    pendingInput: null,
-    pendingTiming: null,
-    events: [...state.events, inputEvent],
   }
 }
 
@@ -676,10 +664,19 @@ function reduceSubmit(state: ReplMachineState): [ReplMachineState, ReplEffect[]]
     const inputEvent: ReplLogEvent = {type: 'input', code}
     const hostHelp: ReplLogEvent = {
       type: 'info',
-      text: 'Host commands: /alias set <name> (set a local alias) · /alias unset (remove the alias)',
+      text: 'Host commands: /time (toggle eval timing) · /alias set <name> (set a local alias) · /alias unset (remove the alias)',
     }
     const next = {...resetState, events: [...resetState.events, inputEvent, hostHelp]}
     return [next, [...effects, {type: 'directive', code}]]
+  }
+
+  // `/time` is host-side: the device always reports timing, this toggles display.
+  if (code === '/time') {
+    const showTiming = !state.showTiming
+    const inputEvent: ReplLogEvent = {type: 'input', code}
+    const info: ReplLogEvent = {type: 'info', text: `Timing display ${showTiming ? 'on' : 'off'}`}
+    const next = {...resetState, showTiming, events: [...resetState.events, inputEvent, info]}
+    return [next, effects]
   }
 
   // `/alias` is host-side (writes the local alias file), not forwarded.
@@ -704,11 +701,12 @@ function reduceSubmit(state: ReplMachineState): [ReplMachineState, ReplEffect[]]
     return [next, [...effects, {type: 'directive', code}]]
   }
 
-  // Eval: defer input echo until result arrives
+  // Eval: echo immediately; timing (if any) rides on the result line later.
+  const inputEvent: ReplLogEvent = {type: 'input', code}
   return [
     {
       ...resetState,
-      pendingInput: code,
+      events: [...resetState.events, inputEvent],
       pendingTiming: null,
       evaluating: true,
     },

--- a/packages/mikro/src/cli/lib/session.ts
+++ b/packages/mikro/src/cli/lib/session.ts
@@ -97,6 +97,9 @@ export interface ReadyEvent {
 export interface TextEvent {
   type: 'log' | 'warn' | 'error' | 'info' | 'debug' | 'result' | 'eval_error'
   text: string
+  /** Attached by the REPL state machine to `result`/`eval_error` entries so the
+   *  eval duration (from the preceding `prompt`) renders on the result line. */
+  timing?: string
 }
 
 export interface CompletionsEvent {

--- a/packages/mikro/src/simulator/simProcess.ts
+++ b/packages/mikro/src/simulator/simProcess.ts
@@ -261,7 +261,6 @@ function forwardHostMessage(msg: {type: string; data: string}): void {
 let runner: DevRunner | null = null
 let stopRunner: (() => void) | null = null
 let messagesSub: {unsubscribe(): void} | null = null
-let showTime = false
 
 /** Resolve `package.json#main` (or `main.js` fallback) to an absolute path
  * inside appDir, or null if no entry can be found. */
@@ -528,10 +527,13 @@ function processEvalQueue(): void {
   if (!runner) return
   while (evalQueue.length > 0) {
     const code = evalQueue.shift()!
-    const t0 = showTime ? performance.now() : 0
+    const t0 = performance.now()
+    const timing = (): string => `${(performance.now() - t0).toFixed(1)}ms`
     try {
       const result = runner.runtime.evalForRepl(code)
       forwardPendingMessages()
+      // Timing precedes the result so the CLI can render it on that line.
+      send(MSG_PROMPT, timing())
       if (result !== undefined) {
         send(MSG_RESULT, result)
       } else {
@@ -543,9 +545,9 @@ function processEvalQueue(): void {
       // "Name: message\nstack" string from the QuickJS exception. err.stack
       // would prepend "Error: " plus the Node-side frames we don't want.
       const text = err instanceof Error ? err.message : String(err)
+      send(MSG_PROMPT, timing())
       send(MSG_EVAL_ERROR, text)
     }
-    send(MSG_PROMPT, showTime ? `${(performance.now() - t0).toFixed(1)}ms` : '')
   }
 }
 
@@ -757,7 +759,6 @@ function handleDirective(payload: Buffer): void {
         '/help      Show this help\n' +
           '/mem       Show heap memory usage\n' +
           '/gc        Run garbage collector\n' +
-          '/time      Toggle timing display\n' +
           '/pause     Pause app (suspend timers/callbacks)\n' +
           '/resume    Resume app\n' +
           '/ls [DIR]  List directory contents\n' +
@@ -811,11 +812,6 @@ function handleDirective(payload: Buffer): void {
         runner.paused = false
         send(MSG_INFO, 'App resumed')
       }
-      break
-
-    case '/time':
-      showTime = !showTime
-      send(MSG_INFO, `Timing ${showTime ? 'on' : 'off'}`)
       break
 
     case '/info': {


### PR DESCRIPTION
Eval input echoed only when the device sent a timing message, which is gated behind /time (off by default), so input did not echo in the common case. Echo now happens on submit, with a ❮• marker on results and ✖ on errors, and undefined results are shown.

/time becomes a host-side display toggle in the CLI. The firmware and simulator always report timing and the CLI decides whether to render it. This removes the device show_time global, the /time directive, and its help and completion entries.