### PR TITLE
fix(release): apply quickjs patches before packing tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,6 +200,15 @@ jobs:
           ignore-scripts: 'true' # no C++ toolchain on this runner; pure-TS dists only
           registry-url: https://registry.npmjs.org
 
+      # ignore-scripts skips the @mikrojs/quickjs postinstall that applies the
+      # mikrojs-local QuickJS patches. Apply them explicitly so the packed
+      # tarball ships patched source; the gate fails the release if it didn't
+      # (an unpatched tarball makes @mikrojs/native fail to compile downstream).
+      - name: Apply QuickJS patches
+        run: node packages/@mikrojs/quickjs/apply-patches.js
+      - name: Verify QuickJS patches applied
+        run: node packages/@mikrojs/quickjs/verify-patches.js
+
       # Apply the version computed by plan. Same value also written by the
       # firmware-build action — using one source of truth ensures sys.version
       # in the firmware matches the version published to npm.

--- a/packages/@mikrojs/quickjs/apply-patches.js
+++ b/packages/@mikrojs/quickjs/apply-patches.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * Apply mikrojs-local QuickJS patches to the submodule working tree.
+ *
+ * Patches live in patches/*.patch and are applied idempotently: if
+ * `git apply --reverse --check` succeeds the patch is already present.
+ *
+ * Importable (`applyPatches()`) and runnable (`node apply-patches.js`).
+ * The release publish job runs it explicitly: that job installs with
+ * --ignore-scripts, so the postinstall that normally applies the patch
+ * never runs. Without this the packed @mikrojs/quickjs tarball ships
+ * unpatched QuickJS source and every consumer fails to compile
+ * @mikrojs/native (which calls the patched module-management symbols).
+ */
+import {execFileSync} from 'node:child_process'
+import {existsSync, readdirSync} from 'node:fs'
+import {dirname, join} from 'node:path'
+import {fileURLToPath} from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const qjsDir = join(__dirname, 'deps', 'quickjs')
+const patchesDir = join(__dirname, 'patches')
+
+export function applyPatches() {
+  if (!existsSync(patchesDir)) return
+  const files = readdirSync(patchesDir)
+    .filter((f) => f.endsWith('.patch'))
+    .sort()
+  for (const f of files) {
+    const patch = join(patchesDir, f)
+    // Probe: is the patch already applied?
+    try {
+      execFileSync('git', ['apply', '--reverse', '--check', patch], {
+        cwd: qjsDir,
+        stdio: 'pipe',
+      })
+      continue // already applied
+    } catch {
+      // not applied — fall through
+    }
+    try {
+      execFileSync('git', ['apply', patch], {cwd: qjsDir, stdio: 'inherit'})
+      console.log(`@mikrojs/quickjs: applied patch ${f}`)
+    } catch (err) {
+      console.error(`@mikrojs/quickjs: failed to apply ${f}`, err.message)
+      process.exit(1)
+    }
+  }
+}
+
+// Run directly: sync the submodule, then apply patches.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const repoRoot = join(__dirname, '..', '..', '..')
+  try {
+    execFileSync(
+      'git',
+      ['submodule', 'update', '--init', 'packages/@mikrojs/quickjs/deps/quickjs'],
+      {
+        cwd: repoRoot,
+        stdio: 'inherit',
+      },
+    )
+  } catch {
+    if (!existsSync(join(qjsDir, 'quickjs.c'))) {
+      console.error(
+        '@mikrojs/quickjs: Failed to initialize QuickJS submodule.\n' +
+          'Run manually: git submodule update --init packages/@mikrojs/quickjs/deps/quickjs',
+      )
+      process.exit(1)
+    }
+  }
+  applyPatches()
+}

--- a/packages/@mikrojs/quickjs/package.json
+++ b/packages/@mikrojs/quickjs/package.json
@@ -19,6 +19,7 @@
     "url": "git+https://github.com/mikrojs/mikro.git"
   },
   "files": [
+    "apply-patches.js",
     "deps/quickjs/*.c",
     "deps/quickjs/*.h",
     "deps/quickjs/LICENSE",
@@ -33,7 +34,9 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "postinstall": "node postinstall.js"
+    "apply-patches": "node apply-patches.js",
+    "postinstall": "node postinstall.js",
+    "verify-patches": "node verify-patches.js"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/packages/@mikrojs/quickjs/postinstall.js
+++ b/packages/@mikrojs/quickjs/postinstall.js
@@ -8,14 +8,15 @@
  * Skips gracefully if cc or the submodule is not available.
  */
 import {execFileSync} from 'node:child_process'
-import {existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync} from 'node:fs'
+import {existsSync, mkdirSync, readFileSync, writeFileSync} from 'node:fs'
 import {dirname, join} from 'node:path'
 import {fileURLToPath} from 'node:url'
+
+import {applyPatches} from './apply-patches.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const binDir = join(__dirname, 'bin')
 const qjsDir = join(__dirname, 'deps', 'quickjs')
-const patchesDir = join(__dirname, 'patches')
 const repoRoot = join(__dirname, '..', '..', '..')
 
 // Always sync submodule to the pinned commit
@@ -39,33 +40,6 @@ try {
 // Applied idempotently: if `git apply --reverse --check` succeeds, the
 // patch is already present, skip it.
 applyPatches()
-
-function applyPatches() {
-  if (!existsSync(patchesDir)) return
-  const files = readdirSync(patchesDir)
-    .filter((f) => f.endsWith('.patch'))
-    .sort()
-  for (const f of files) {
-    const patch = join(patchesDir, f)
-    // Probe: is the patch already applied?
-    try {
-      execFileSync('git', ['apply', '--reverse', '--check', patch], {
-        cwd: qjsDir,
-        stdio: 'pipe',
-      })
-      continue // already applied
-    } catch {
-      // not applied — fall through
-    }
-    try {
-      execFileSync('git', ['apply', patch], {cwd: qjsDir, stdio: 'inherit'})
-      console.log(`@mikrojs/quickjs: applied patch ${f}`)
-    } catch (err) {
-      console.error(`@mikrojs/quickjs: failed to apply ${f}`, err.message)
-      process.exit(1)
-    }
-  }
-}
 
 // Determine the current submodule commit to detect changes
 let currentCommit = ''

--- a/packages/@mikrojs/quickjs/verify-patches.js
+++ b/packages/@mikrojs/quickjs/verify-patches.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * Release gate: assert every symbol the mikrojs QuickJS patches add to
+ * quickjs.h is present in the (post-patch) header that will be packed.
+ *
+ * Catches the failure mode where the publish job ships unpatched QuickJS
+ * source (e.g. the apply step was skipped under --ignore-scripts), which
+ * makes @mikrojs/native fail to compile in every consumer. Run after
+ * apply-patches.js and before publishing.
+ */
+import {readdirSync, readFileSync} from 'node:fs'
+import {dirname, join} from 'node:path'
+import {fileURLToPath} from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const qjsHeader = join(__dirname, 'deps', 'quickjs', 'quickjs.h')
+const patchesDir = join(__dirname, 'patches')
+
+// Collect the symbols the patches add to quickjs.h: added (+) lines that
+// declare a JS_EXTERN function. Captures the function-name token before '('.
+const wanted = new Set()
+for (const f of readdirSync(patchesDir)
+  .filter((name) => name.endsWith('.patch'))
+  .sort()) {
+  const patch = readFileSync(join(patchesDir, f), 'utf8')
+  for (const line of patch.split('\n')) {
+    if (!line.startsWith('+')) continue
+    const match = line.match(/^\+\s*JS_EXTERN\b.*?\b(JS_[A-Za-z0-9_]+)\s*\(/)
+    if (match) wanted.add(match[1])
+  }
+}
+
+if (wanted.size === 0) {
+  console.error('verify-patches: no JS_EXTERN symbols found in patches/ — patch format changed?')
+  process.exit(1)
+}
+
+const header = readFileSync(qjsHeader, 'utf8')
+const missing = [...wanted].filter(
+  (sym) => !new RegExp(`\\bJS_EXTERN\\b.*\\b${sym}\\b`).test(header),
+)
+
+if (missing.length) {
+  console.error(
+    `verify-patches: quickjs.h is missing patched symbols: ${missing.join(', ')}\n` +
+      'The QuickJS patches were not applied before packing. Run ' +
+      '`node packages/@mikrojs/quickjs/apply-patches.js` before publishing.',
+  )
+  process.exit(1)
+}
+
+console.log(`verify-patches: OK — ${wanted.size} patched symbol(s) present in quickjs.h`)


### PR DESCRIPTION
The publish job installs with --ignore-scripts, so the postinstall that applies the mikrojs-local QuickJS patches never runs and the packed @mikrojs/quickjs tarball ships unpatched upstream source. Consumers then fail to compile @mikrojs/native, which calls the patched module symbols. Apply the patches explicitly and gate the release on their presence.