### PR TITLE
fix(cli): treat native: specifiers as firmware builtins in the tracer

### DIFF
--- a/packages/mikro/src/__test__/constants.test.ts
+++ b/packages/mikro/src/__test__/constants.test.ts
@@ -1,0 +1,25 @@
+import {describe, expect, it} from 'vitest'
+
+import {isBuiltinModule} from '../constants.js'
+
+describe('isBuiltinModule', () => {
+  it('treats any native: specifier as a builtin', () => {
+    // `native:` is a firmware-only scheme that never resolves to a file on disk,
+    // so the tracer must always skip it — including app-local native modules.
+    expect(isBuiltinModule('native:mikro/pin')).toBe(true)
+    expect(isBuiltinModule('native:mikrobird/melspec')).toBe(true)
+    expect(isBuiltinModule('native:console')).toBe(true)
+  })
+
+  it('matches core mikro builtins', () => {
+    expect(isBuiltinModule('mikro')).toBe(true)
+    expect(isBuiltinModule('mikro/wifi')).toBe(true)
+    expect(isBuiltinModule('fetch')).toBe(true)
+  })
+
+  it('does not match ordinary specifiers', () => {
+    expect(isBuiltinModule('react')).toBe(false)
+    expect(isBuiltinModule('@mikrojs/some-board')).toBe(false)
+    expect(isBuiltinModule('./local.js')).toBe(false)
+  })
+})

--- a/packages/mikro/src/constants.ts
+++ b/packages/mikro/src/constants.ts
@@ -22,7 +22,12 @@ export const BUILTIN_EXTERNALS = ['mikro', 'mikro/*', '@mikrojs/*']
 
 /** Check if a module specifier matches a firmware builtin pattern.
  * Note: @mikrojs/* packages are only builtins if they have native code.
- * The trace resolver handles this dynamically by checking for ./cmake exports. */
+ * The trace resolver handles this dynamically by checking for ./cmake exports.
+ * `native:` is a firmware-only scheme: it never resolves to a file on disk, so
+ * it is always a builtin (the on-device loader binds it to the registered native
+ * modules). This lets app-local native code be imported without packaging it. */
 export function isBuiltinModule(id: string): boolean {
-  return BUILTINS.includes(id) || id === 'mikro' || id.startsWith('mikro/')
+  return (
+    id.startsWith('native:') || BUILTINS.includes(id) || id === 'mikro' || id.startsWith('mikro/')
+  )
 }


### PR DESCRIPTION
The app import tracer resolved native: imports as real on-disk modules and failed when an app imported app-local native code (`native:<pkg>/<id>`). The `native:` scheme is firmware-only and is bound on-device against the registered native modules, so isBuiltinModule now reports it as a builtin and the tracer skips it. This matches the esbuild externals plugin, which already externalized native:, and lets app-local native code be imported without promoting it to a package with a `./cmake export`.