### PR TITLE
fix(firmware): stop spi/uart/i2c write over-reading buffer views

### DIFF
--- a/packages/@mikrojs/firmware/components/mikrojs/mik_i2c.cpp
+++ b/packages/@mikrojs/firmware/components/mikrojs/mik_i2c.cpp
@@ -198,10 +198,12 @@ static JSValue js_i2c_write(JSContext* ctx, JSValue this_val, int argc, JSValue*
     uint8_t* data;
 
     /* Try typed array (Uint8Array) first, then raw ArrayBuffer */
-    size_t offset, elem_size;
+    size_t offset, elem_size, buf_len;
     JSValue ab = JS_GetTypedArrayBuffer(ctx, argv[1], &offset, &data_len, &elem_size);
     if (!JS_IsException(ab)) {
-        data = JS_GetArrayBuffer(ctx, &data_len, ab);
+        /* data_len keeps the view length; the full backing buffer goes to a
+         * throwaway so a subarray view isn't over-read. */
+        data = JS_GetArrayBuffer(ctx, &buf_len, ab);
         JS_FreeValue(ctx, ab);
         if (!data) return JS_ThrowTypeError(ctx, "expected Uint8Array as argument 2");
         data += offset;

--- a/packages/@mikrojs/firmware/components/mikrojs/mik_spi.cpp
+++ b/packages/@mikrojs/firmware/components/mikrojs/mik_spi.cpp
@@ -221,10 +221,12 @@ static JSValue js_spi_transfer(JSContext* ctx, JSValue this_val, int argc, JSVal
     /* Extract data from Uint8Array or ArrayBuffer */
     size_t data_len;
     uint8_t* data;
-    size_t offset, elem_size;
+    size_t offset, elem_size, buf_len;
     JSValue ab = JS_GetTypedArrayBuffer(ctx, argv[0], &offset, &data_len, &elem_size);
     if (!JS_IsException(ab)) {
-        data = JS_GetArrayBuffer(ctx, &data_len, ab);
+        /* data_len keeps the view length; the full backing buffer goes to a
+         * throwaway so a subarray view isn't over-read. */
+        data = JS_GetArrayBuffer(ctx, &buf_len, ab);
         JS_FreeValue(ctx, ab);
         if (!data) return JS_ThrowTypeError(ctx, "expected Uint8Array as argument 1");
         data += offset;
@@ -264,10 +266,12 @@ static JSValue js_spi_write(JSContext* ctx, JSValue this_val, int argc, JSValue*
     /* Extract data from Uint8Array or ArrayBuffer */
     size_t data_len;
     uint8_t* data;
-    size_t offset, elem_size;
+    size_t offset, elem_size, buf_len;
     JSValue ab = JS_GetTypedArrayBuffer(ctx, argv[0], &offset, &data_len, &elem_size);
     if (!JS_IsException(ab)) {
-        data = JS_GetArrayBuffer(ctx, &data_len, ab);
+        /* data_len keeps the view length; the full backing buffer goes to a
+         * throwaway so a subarray view isn't over-read. */
+        data = JS_GetArrayBuffer(ctx, &buf_len, ab);
         JS_FreeValue(ctx, ab);
         if (!data) return JS_ThrowTypeError(ctx, "expected Uint8Array as argument 1");
         data += offset;

--- a/packages/@mikrojs/firmware/components/mikrojs/mik_uart.cpp
+++ b/packages/@mikrojs/firmware/components/mikrojs/mik_uart.cpp
@@ -244,10 +244,12 @@ static JSValue js_uart_write(JSContext* ctx, JSValue this_val, int argc, JSValue
 
     size_t data_len;
     uint8_t* data;
-    size_t offset, elem_size;
+    size_t offset, elem_size, buf_len;
     JSValue ab = JS_GetTypedArrayBuffer(ctx, argv[0], &offset, &data_len, &elem_size);
     if (!JS_IsException(ab)) {
-        data = JS_GetArrayBuffer(ctx, &data_len, ab);
+        /* data_len keeps the view length; the full backing buffer goes to a
+         * throwaway so a subarray view isn't over-read. */
+        data = JS_GetArrayBuffer(ctx, &buf_len, ab);
         JS_FreeValue(ctx, ab);
         if (!data) return JS_ThrowTypeError(ctx, "expected Uint8Array as argument 1");
         data += offset;


### PR DESCRIPTION
JS_GetArrayBuffer reports the whole backing buffer, which clobbered the typed-array view length and let a subarray view over-read past its end. Read the buffer length into a throwaway and keep the view length, the same fix already applied to i2s.