### PR TITLE
feat(wifi)!: configure txPower on connect, power radio down on disconnect

### DIFF
--- a/dev/e2e/test/http-request-e2e.test.ts
+++ b/dev/e2e/test/http-request-e2e.test.ts
@@ -33,7 +33,7 @@ describe.runIf(hasWifi && !isSim && fitsHttp)('http request e2e', () => {
   beforeAll(async () => {
     ;({request} = await import('mikro/http/request'))
     const {wifi} = await import('mikro/wifi')
-    const connected = await wifi.connect(WIFI_SSID!, WIFI_PASSPHRASE!)
+    const connected = await wifi.connect({ssid: WIFI_SSID!, passphrase: WIFI_PASSPHRASE!})
     assert.equal(connected.ok, true, 'wifi connect')
     if (connected.ok) console.log(`connected: ${connected.value.ip}`)
 

--- a/dev/e2e/test/http-request-streaming.test.ts
+++ b/dev/e2e/test/http-request-streaming.test.ts
@@ -33,7 +33,7 @@ describe.runIf(hasWifi && !isSim && fitsHttp)('http request streaming', () => {
     ;({request} = await import('mikro/http/request'))
     ;({decodeUtf8, splitLines} = await import('mikro/stream'))
     const {wifi} = await import('mikro/wifi')
-    const connected = await wifi.connect(WIFI_SSID!, WIFI_PASSPHRASE!)
+    const connected = await wifi.connect({ssid: WIFI_SSID!, passphrase: WIFI_PASSPHRASE!})
     assert.equal(connected.ok, true, 'wifi connect')
     if (connected.ok) console.log(`connected: ${connected.value.ip}`)
 

--- a/dev/e2e/test/http-server-e2e.test.ts
+++ b/dev/e2e/test/http-server-e2e.test.ts
@@ -25,7 +25,7 @@ describe.runIf(hasWifi && !isSim && fitsHttp)('http server e2e', () => {
   beforeAll(async () => {
     ;({request} = await import('mikro/http/request'))
     const {wifi} = await import('mikro/wifi')
-    const connected = await wifi.connect(WIFI_SSID!, WIFI_PASSPHRASE!)
+    const connected = await wifi.connect({ssid: WIFI_SSID!, passphrase: WIFI_PASSPHRASE!})
     assert.equal(connected.ok, true, 'wifi connect')
     if (!connected.ok) return
     base = `http://${connected.value.ip}:${PORT}`

--- a/dev/e2e/test/udp.test.ts
+++ b/dev/e2e/test/udp.test.ts
@@ -67,7 +67,7 @@ describe.runIf(hasWifi && fitsWifi)('udp over wifi', () => {
 
   beforeAll(async () => {
     const {wifi} = await import('mikro/wifi')
-    const connected = await wifi.connect(WIFI_SSID!, WIFI_PASSPHRASE!)
+    const connected = await wifi.connect({ssid: WIFI_SSID!, passphrase: WIFI_PASSPHRASE!})
     assert.equal(connected.ok, true, 'wifi connect')
     if (connected.ok) {
       localIp = connected.value.ip

--- a/dev/e2e/test/wifi-e2e.test.ts
+++ b/dev/e2e/test/wifi-e2e.test.ts
@@ -21,7 +21,7 @@ const fitsFetch = m.heapTotal - m.heapUsed > 48 * 1024
 describe.runIf(hasWifi)('wifi e2e', () => {
   test('connect to wifi', async () => {
     const {wifi} = await import('mikro/wifi')
-    const result = await wifi.connect(WIFI_SSID!, WIFI_PASSPHRASE!)
+    const result = await wifi.connect({ssid: WIFI_SSID!, passphrase: WIFI_PASSPHRASE!})
     assert.equal(result.ok, true)
     assert.truthy(result.ok && result.value.ip, 'should have an IP address')
     if (result.ok) console.log(`connected: ${result.value.ip}`)

--- a/dev/kitchen-sink/app/main.ts
+++ b/dev/kitchen-sink/app/main.ts
@@ -105,7 +105,7 @@ console.log('connecting to wifi...')
 logMem('before wifi connect')
 
 if (WIFI_SSID && WIFI_PASSPHRASE) {
-  const connectResult = await wifi.connect(WIFI_SSID, WIFI_PASSPHRASE)
+  const connectResult = await wifi.connect({ssid: WIFI_SSID, passphrase: WIFI_PASSPHRASE})
   console.log('wifi connect:', connectResult)
   logMem('after wifi connect')
 

--- a/dev/sram-pressure/app/main.ts
+++ b/dev/sram-pressure/app/main.ts
@@ -15,7 +15,7 @@ const ssid = env.require('WIFI_SSID')
 const passphrase = env.require('WIFI_PASSPHRASE')
 
 console.log('Connecting to %s ...', ssid)
-const connect = await wifi.connect(ssid, passphrase)
+const connect = await wifi.connect({ssid, passphrase})
 if (!connect.ok) {
   console.error('WiFi connect failed: %s', connect.error.name)
 } else {

--- a/docs/api/wifi.md
+++ b/docs/api/wifi.md
@@ -16,7 +16,7 @@ The default export is a `Wifi` singleton. Use it to connect to networks, scan fo
 ```ts twoslash
 import {wifi} from 'mikro/wifi'
 // ---cut---
-const result = await wifi.connect('MyNetwork', 'password123')
+const result = await wifi.connect({ssid: 'MyNetwork', passphrase: 'password123'})
 if (!result.ok) {
   console.error('WiFi failed: %s', result.error.name)
 } else {
@@ -26,18 +26,34 @@ if (!result.ok) {
 
 ## Station methods
 
-### wifi.connect(ssid, passphrase)
+### wifi.connect(options)
 
 ```ts
-connect(ssid: string, passphrase: string): Promise<Result<WifiConnectionInfo, WifiError>>
+connect(options: WifiConnectOptions): Promise<Result<WifiConnectionInfo, WifiError>>
 ```
 
-Connects to a WiFi network. Returns connection info with IP, netmask, and gateway on success.
-
-### wifi.disconnect()
+Connects to a WiFi network. Returns connection info with IP, netmask, and gateway on success. Set `txPower` to cap the radio's transmit power (in dBm) for this session; the driver quantizes it to an allowed level.
 
 ```ts
-disconnect(): Result<void, WifiError>
+interface WifiConnectOptions {
+  ssid: string
+  passphrase: string
+  txPower?: number
+}
+```
+
+### wifi.disconnect(options?)
+
+```ts
+disconnect(options?: WifiDisconnectOptions): Result<void, WifiError>
+```
+
+Disconnects from the current network. By default this also powers the radio down and releases its memory. Pass `{shutdown: false}` to keep the radio up for a faster reconnect.
+
+```ts
+interface WifiDisconnectOptions {
+  shutdown?: boolean // default: true
+}
 ```
 
 ### wifi.scan(options?)
@@ -97,15 +113,15 @@ ipConfig(opts: StaticIpConfig): Result<void, WifiError>
 
 ## Station properties
 
-| Property        | Type                           | Description                                 |
-| --------------- | ------------------------------ | ------------------------------------------- |
-| `isConnected`   | `boolean`                      | Whether the station is connected            |
-| `mac`           | `string` (readonly)            | MAC address                                 |
-| `hostname`      | `string \| undefined`          | Hostname (read/write)                       |
-| `txPower`       | `number`                       | Transmit power (read/write)                 |
-| `rssiThreshold` | `number`                       | Low-RSSI event threshold (read/write)       |
-| `powerSave`     | `PowerSaveMode`                | Power save mode: `'none'`, `'min'`, `'max'` |
-| `country`       | `WifiCountryCode \| undefined` | Regulatory country code                     |
+| Property        | Type                           | Description                                         |
+| --------------- | ------------------------------ | --------------------------------------------------- |
+| `isConnected`   | `boolean`                      | Whether the station is connected                    |
+| `mac`           | `string` (readonly)            | MAC address                                         |
+| `hostname`      | `string \| undefined`          | Hostname (read/write)                               |
+| `txPower`       | `number` (readonly)            | Transmit power in dBm; set via `connect({txPower})` |
+| `rssiThreshold` | `number`                       | Low-RSSI event threshold (read/write)               |
+| `powerSave`     | `PowerSaveMode`                | Power save mode: `'none'`, `'min'`, `'max'`         |
+| `country`       | `WifiCountryCode \| undefined` | Regulatory country code                             |
 
 ## Station events
 

--- a/docs/developing-for-microcontrollers.md
+++ b/docs/developing-for-microcontrollers.md
@@ -175,7 +175,7 @@ import {wifi} from 'mikro/wifi'
 declare const ssid: string
 declare const passphrase: string
 // ---cut---
-const result = await wifi.connect(ssid, passphrase)
+const result = await wifi.connect({ssid, passphrase})
 if (!result.ok) {
   console.error('WiFi failed: %s', result.error.name)
   // Retry, fall back, or sleep and try later

--- a/docs/examples/http-server.md
+++ b/docs/examples/http-server.md
@@ -26,7 +26,7 @@ const ssid = env.require('WIFI_SSID')
 const passphrase = env.require('WIFI_PASSPHRASE')
 
 console.log('Connecting to %s...', ssid)
-const connected = await wifi.connect(ssid, passphrase)
+const connected = await wifi.connect({ssid, passphrase})
 if (!connected.ok) {
   console.error('WiFi connect failed: %s', connected.error.name)
 } else {

--- a/docs/examples/sntp.md
+++ b/docs/examples/sntp.md
@@ -57,7 +57,7 @@ const passphrase = env.require('WIFI_PASSPHRASE')
 
 // Connect to WiFi
 console.log(`Connecting to ${ssid}...`)
-const connectResult = await wifi.connect(ssid, passphrase)
+const connectResult = await wifi.connect({ssid, passphrase})
 if (!connectResult.ok) {
   console.error('WiFi connect failed: %s', connectResult.error.name)
 } else {

--- a/docs/examples/udp-discovery.md
+++ b/docs/examples/udp-discovery.md
@@ -57,7 +57,7 @@ const ANNOUNCE_MS = 2000
 const ssid = env.require('WIFI_SSID')
 const passphrase = env.require('WIFI_PASSPHRASE')
 
-const connected = await wifi.connect(ssid, passphrase)
+const connected = await wifi.connect({ssid, passphrase})
 if (connected.ok) {
   const bound = await bind({port: PORT, family: 'ipv4'})
   if (bound.ok) {

--- a/docs/examples/wifi-fetch.md
+++ b/docs/examples/wifi-fetch.md
@@ -54,7 +54,7 @@ const passphrase = env.require('WIFI_PASSPHRASE')
 
 // Connect to WiFi
 console.log(`Connecting to ${ssid}...`)
-const connectResult = await wifi.connect(ssid, passphrase)
+const connectResult = await wifi.connect({ssid, passphrase})
 if (!connectResult.ok) {
   console.error('WiFi connect failed: %s', connectResult.error.name)
 } else {

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -121,7 +121,10 @@ const hasWifi = env.get('WIFI_SSID') && env.get('WIFI_PASSPHRASE')
 describe.runIf(hasWifi)('wifi', () => {
   test('connect', async () => {
     const {wifi} = await import('mikro/wifi')
-    const result = await wifi.connect(env.get('WIFI_SSID')!, env.get('WIFI_PASSPHRASE')!)
+    const result = await wifi.connect({
+      ssid: env.get('WIFI_SSID')!,
+      passphrase: env.get('WIFI_PASSPHRASE')!,
+    })
     assert.ok(result)
   })
 })
@@ -312,7 +315,7 @@ const pass = env.get('WIFI_PASSPHRASE')
 describe.runIf(ssid && pass)('wifi', () => {
   test('connect', async () => {
     const {wifi} = await import('mikro/wifi')
-    const result = await wifi.connect(ssid!, pass!)
+    const result = await wifi.connect({ssid: ssid!, passphrase: pass!})
     assert.equal(result.ok, true)
   })
 })

--- a/examples/http-server/app/main.ts
+++ b/examples/http-server/app/main.ts
@@ -8,7 +8,7 @@ const ssid = env.require('WIFI_SSID')
 const passphrase = env.require('WIFI_PASSPHRASE')
 
 console.log('Connecting to %s...', ssid)
-const connected = await wifi.connect(ssid, passphrase)
+const connected = await wifi.connect({ssid, passphrase})
 if (!connected.ok) {
   console.error('WiFi connect failed: %s', connected.error.name)
 } else {

--- a/examples/network-mic/app/main.ts
+++ b/examples/network-mic/app/main.ts
@@ -21,7 +21,7 @@ const ssid = env.require('WIFI_SSID')
 const passphrase = env.require('WIFI_PASSPHRASE')
 
 console.log('Connecting to %s...', ssid)
-const connected = await wifi.connect(ssid, passphrase)
+const connected = await wifi.connect({ssid, passphrase})
 if (!connected.ok) {
   // onPanic: restart (mikro.config.ts) retries the connection on a clean boot.
   panic(`WiFi connect failed: ${connected.error.name}`)

--- a/examples/sntp/app/main.ts
+++ b/examples/sntp/app/main.ts
@@ -11,7 +11,7 @@ const passphrase = env.require('WIFI_PASSPHRASE')
 
 // Connect to WiFi
 console.log(`Connecting to ${ssid}...`)
-const connectResult = await wifi.connect(ssid, passphrase)
+const connectResult = await wifi.connect({ssid, passphrase})
 if (!connectResult.ok) {
   console.error('WiFi connect failed: %s', connectResult.error.name)
 } else {

--- a/examples/udp-discovery/app/main.ts
+++ b/examples/udp-discovery/app/main.ts
@@ -16,7 +16,7 @@ const ssid = env.require('WIFI_SSID')
 const passphrase = env.require('WIFI_PASSPHRASE')
 
 console.log('Connecting to %s...', ssid)
-const connected = await wifi.connect(ssid, passphrase)
+const connected = await wifi.connect({ssid, passphrase})
 if (!connected.ok) {
   console.error('WiFi connect failed: %s', connected.error.name)
 } else {

--- a/examples/wifi-fetch/app/main.ts
+++ b/examples/wifi-fetch/app/main.ts
@@ -8,7 +8,7 @@ const passphrase = env.require('WIFI_PASSPHRASE')
 
 // Connect to WiFi
 console.log(`Connecting to ${ssid}...`)
-const connectResult = await wifi.connect(ssid, passphrase)
+const connectResult = await wifi.connect({ssid, passphrase})
 if (!connectResult.ok) {
   console.error('WiFi connect failed:', connectResult.error)
 } else {

--- a/packages/@mikrojs/firmware/components/mikrojs/mik_wifi.cpp
+++ b/packages/@mikrojs/firmware/components/mikrojs/mik_wifi.cpp
@@ -477,11 +477,65 @@ static JSValue mik__wifi_connect(JSContext* ctx, JSValue this_val, int argc, JSV
     return mik__result_ok(ctx, promise);
 }
 
+/* Fully tear down the WiFi driver so the heap used by the radio stack, beacon
+ * offsets, event handlers, and netif interfaces is returned to the pool. Shared
+ * by disconnect({shutdown:true}) and runtime teardown. Safe to call when the
+ * radio is already down. */
+static void mik__wifi_radio_teardown(void) {
+    if (!s_wifi_initialized) return;
+    if (s_wifi_started) {
+        esp_wifi_stop();
+        s_wifi_started = false;
+    }
+    /* ensure_initialized registered these via esp_event_handler_instance_register
+     * with a nullptr context out-param, so we can't use instance_unregister.
+     * esp_event_handler_unregister matches on (base, id, handler fn) instead. */
+    esp_event_handler_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, mik__wifi_event_handler);
+    esp_event_handler_unregister(IP_EVENT, IP_EVENT_STA_GOT_IP, mik__wifi_event_handler);
+    esp_wifi_deinit();
+    if (s_sta_netif) {
+        esp_netif_destroy_default_wifi(s_sta_netif);
+        s_sta_netif = nullptr;
+    }
+    if (s_ap_netif) {
+        esp_netif_destroy_default_wifi(s_ap_netif);
+        s_ap_netif = nullptr;
+    }
+    s_wifi_initialized = false;
+}
+
 static JSValue mik__wifi_disconnect(JSContext* ctx, JSValue this_val, int argc, JSValue* argv) {
+    bool shutdown = argc < 1 || JS_IsUndefined(argv[0]) || JS_ToBool(ctx, argv[0]);
+
     esp_err_t err = esp_wifi_disconnect();
-    if (err != ESP_OK) {
+    /* When shutting down we proceed to teardown even if the radio was never
+     * started, so a plain disconnect() reliably powers things down. */
+    if (err != ESP_OK && !(shutdown && (err == ESP_ERR_WIFI_NOT_STARTED ||
+                                        err == ESP_ERR_WIFI_NOT_INIT))) {
         return mik__result_err_named(ctx, "DisconnectFailed",
                                "Failed to disconnect from WiFi: %s", esp_err_to_name(err));
+    }
+
+    if (shutdown) {
+        /* Teardown unregisters the event handlers, so a connect/scan in flight
+         * would never be settled by the event loop. Settle them now (with an
+         * error Result, matching the consume failure path) so the awaiting JS
+         * resolves deterministically instead of hanging until runtime teardown. */
+        MIKRuntime* mik_rt = MIK_GetRuntime(ctx);
+        MIKWifiState* state = mik_rt ? mik__wifi_st(mik_rt) : nullptr;
+        if (state && state->connect_pending) {
+            JSValue result = mik__result_err_named(ctx, "ConnectFailed",
+                                                   "WiFi disconnected before connecting");
+            MIK_ResolvePromise(ctx, &state->connect_promise, 1, &result);
+            state->connect_pending = false;
+        }
+        if (state && state->scan_pending) {
+            JSValue result = mik__result_err_named(ctx, "ScanFailed",
+                                                   "WiFi shut down during scan");
+            MIK_ResolvePromise(ctx, &state->scan_promise, 1, &result);
+            state->scan_pending = false;
+        }
+        mik__wifi_radio_teardown();
     }
     return mik__result_ok_void(ctx);
 }
@@ -1100,7 +1154,7 @@ static JSValue mik__wifi_ap_set_inactive_timeout(JSContext* ctx, JSValue this_va
 
 static const JSCFunctionListEntry mik__wifi_proto_funcs[] = {
     MIK_CFUNC_DEF("connect", 2, mik__wifi_connect),
-    MIK_CFUNC_DEF("disconnect", 0, mik__wifi_disconnect),
+    MIK_CFUNC_DEF("disconnect", 1, mik__wifi_disconnect),
     MIK_CFUNC_DEF("rssi", 0, mik__wifi_rssi),
     MIK_CFUNC_DEF("ip", 0, mik__wifi_ip),
     MIK_CFUNC_DEF("status", 0, mik__wifi_status),
@@ -1410,35 +1464,11 @@ void mik__wifi_destroy(JSContext* ctx) {
     delete state;
     mik__wifi_st(mik_rt) = nullptr;
 
-    /* Fully tear down the WiFi driver so the heap used by the radio stack,
-     * beacon offsets, event handlers, and netif interfaces is returned to
-     * the pool. Without this, repeated runtime lifecycles (e.g. on-device
-     * test suites that create + destroy a runtime per test) eventually hit
-     * `alloc pm_beacon_offset fail` when the heap is too fragmented for
-     * even small internal allocations. */
-    if (s_wifi_initialized) {
-        if (s_wifi_started) {
-            esp_wifi_stop();
-            s_wifi_started = false;
-        }
-        /* ensure_initialized registered these via esp_event_handler_instance_register
-         * with a nullptr context out-param, so we can't use instance_unregister.
-         * esp_event_handler_unregister matches on (base, id, handler fn) instead. */
-        esp_event_handler_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID,
-                                     mik__wifi_event_handler);
-        esp_event_handler_unregister(IP_EVENT, IP_EVENT_STA_GOT_IP,
-                                     mik__wifi_event_handler);
-        esp_wifi_deinit();
-        if (s_sta_netif) {
-            esp_netif_destroy_default_wifi(s_sta_netif);
-            s_sta_netif = nullptr;
-        }
-        if (s_ap_netif) {
-            esp_netif_destroy_default_wifi(s_ap_netif);
-            s_ap_netif = nullptr;
-        }
-        s_wifi_initialized = false;
-    }
+    /* Return the radio heap to the pool. Without this, repeated runtime
+     * lifecycles (e.g. on-device test suites that create + destroy a runtime
+     * per test) eventually hit `alloc pm_beacon_offset fail` when the heap is
+     * too fragmented for even small internal allocations. */
+    mik__wifi_radio_teardown();
 }
 
 MIK_REGISTER_MODULE(wifi, "native:mikro/wifi", mik__wifi_init, mik__wifi_consume, mik__wifi_destroy)

--- a/packages/@mikrojs/firmware/components/mikrojs/test/wifi_test.cpp
+++ b/packages/@mikrojs/firmware/components/mikrojs/test/wifi_test.cpp
@@ -151,13 +151,13 @@ TEST_CASE("Wifi connect returns a promise", "[wifi]") {
     setup();
 
     // Only test that connect() returns a Promise — don't actually wait for connection.
-    // We call disconnect() right after to avoid leaving WiFi in "connecting" state.
+    // disconnect(false) keeps the radio up to avoid tearing it down between tests.
     JSValue ret = eval_module(R"(
         import { Wifi } from "native:mikro/wifi";
         const wifi = new Wifi();
         const result = wifi.connect("test", "pass");
         globalThis.__isPromise = result.ok && result.value instanceof Promise;
-        wifi.disconnect();
+        wifi.disconnect(false);
     )");
     TEST_ASSERT_FALSE_MESSAGE(JS_IsException(ret), "Module eval should not throw");
 
@@ -165,6 +165,68 @@ TEST_CASE("Wifi connect returns a promise", "[wifi]") {
     JSValue isPromise = JS_GetPropertyStr(ctx, global, "__isPromise");
     TEST_ASSERT_TRUE_MESSAGE(JS_ToBool(ctx, isPromise), "connect() should return a Promise");
     JS_FreeValue(ctx, isPromise);
+    JS_FreeValue(ctx, global);
+    teardown();
+}
+
+/* ── Disconnect shutdown powers the radio down and stays reusable ──── */
+
+TEST_CASE("Wifi disconnect({shutdown:true}) tears down and re-inits on reuse", "[wifi]") {
+    setup();
+
+    // disconnect(true) is the default: it powers the radio down. A subsequent
+    // call (here getTxPower, which lazily restarts the radio) must still work.
+    JSValue ret = eval_module(R"(
+        import { Wifi } from "native:mikro/wifi";
+        const wifi = new Wifi();
+        wifi.connect("test", "pass");
+        const down = wifi.disconnect(true);
+        const reuse = wifi.getTxPower();
+        globalThis.__downOk = down.ok;
+        globalThis.__reuseOk = reuse.ok;
+    )");
+    TEST_ASSERT_FALSE_MESSAGE(JS_IsException(ret), "Module eval should not throw");
+
+    JSValue global = JS_GetGlobalObject(ctx);
+    JSValue downOk = JS_GetPropertyStr(ctx, global, "__downOk");
+    JSValue reuseOk = JS_GetPropertyStr(ctx, global, "__reuseOk");
+    TEST_ASSERT_TRUE_MESSAGE(JS_ToBool(ctx, downOk), "disconnect(true) should return ok");
+    TEST_ASSERT_TRUE_MESSAGE(JS_ToBool(ctx, reuseOk), "radio should re-init after shutdown");
+    JS_FreeValue(ctx, downOk);
+    JS_FreeValue(ctx, reuseOk);
+    JS_FreeValue(ctx, global);
+    teardown();
+}
+
+/* ── Disconnect shutdown settles a connect in flight ──────────────── */
+
+TEST_CASE("Wifi disconnect({shutdown:true}) settles a pending connect", "[wifi]") {
+    setup();
+
+    // Teardown unregisters the event handlers, so the connect promise must be
+    // settled by disconnect() itself — otherwise the await would hang forever.
+    JSValue ret = eval_module(R"(
+        import { Wifi } from "native:mikro/wifi";
+        const wifi = new Wifi();
+        const result = wifi.connect("test", "pass");
+        globalThis.__settled = "pending";
+        if (result.ok) {
+            result.value.then((res) => {
+                globalThis.__settled = res.ok ? "ok" : res.error.name;
+            });
+        }
+        wifi.disconnect(true);
+    )");
+    TEST_ASSERT_FALSE_MESSAGE(JS_IsException(ret), "Module eval should not throw");
+
+    JSValue global = JS_GetGlobalObject(ctx);
+    JSValue settled = JS_GetPropertyStr(ctx, global, "__settled");
+    const char* settled_str = JS_ToCString(ctx, settled);
+    TEST_ASSERT_NOT_NULL(settled_str);
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("ConnectFailed", settled_str,
+                                     "pending connect should settle as ConnectFailed, not hang");
+    JS_FreeCString(ctx, settled_str);
+    JS_FreeValue(ctx, settled);
     JS_FreeValue(ctx, global);
     teardown();
 }

--- a/packages/@mikrojs/native/runtime/internal.d.ts
+++ b/packages/@mikrojs/native/runtime/internal.d.ts
@@ -425,7 +425,7 @@ declare module 'native:mikro/wifi' {
       ssid: string,
       passphrase: string,
     ): R<Promise<R<{ip: string; netmask: string; gateway: string}>>>
-    disconnect(): R<void>
+    disconnect(shutdown?: boolean): R<void>
     rssi(): R<number>
     ip(): string
     status(): number

--- a/packages/@mikrojs/native/runtime/wifi/types.ts
+++ b/packages/@mikrojs/native/runtime/wifi/types.ts
@@ -116,9 +116,24 @@ export interface WifiAp {
   readonly onStationDisconnect: Observable<ApStationInfo>
 }
 
+export interface WifiConnectOptions {
+  ssid: string
+  passphrase: string
+  /** Max transmit power in dBm. Applies to the radio; quantized by the driver. */
+  txPower?: number
+}
+
+export interface WifiDisconnectOptions {
+  /**
+   * Power the radio down and release its heap after disconnecting. Defaults to
+   * `true`. Pass `false` to keep the radio up for a faster reconnect.
+   */
+  shutdown?: boolean
+}
+
 export interface Wifi {
-  connect(ssid: string, passphrase: string): Promise<Result<WifiConnectionInfo, WifiError>>
-  disconnect(): Result<void, WifiError>
+  connect(options: WifiConnectOptions): Promise<Result<WifiConnectionInfo, WifiError>>
+  disconnect(options?: WifiDisconnectOptions): Result<void, WifiError>
   rssi(): Result<number, WifiError>
   ip(): string | undefined
   status(): WifiStatus
@@ -137,7 +152,7 @@ export interface Wifi {
 
   readonly ap: WifiAp
 
-  txPower: number
+  readonly txPower: number
   rssiThreshold: number
 
   powerSave: PowerSaveMode

--- a/packages/@mikrojs/native/runtime/wifi/wifi.ts
+++ b/packages/@mikrojs/native/runtime/wifi/wifi.ts
@@ -14,7 +14,9 @@ import type {
   Wifi,
   WifiAp,
   WifiConnectionInfo,
+  WifiConnectOptions,
   WifiCountryCode,
+  WifiDisconnectOptions,
   WifiDisconnectReason,
   WifiError,
   WifiStatus,
@@ -81,7 +83,12 @@ const RETRY_DELAY_MS = 2000
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
 
 const wifi: Wifi = {
-  async connect(ssid: string, passphrase: string): Promise<Result<WifiConnectionInfo, WifiError>> {
+  async connect(options: WifiConnectOptions): Promise<Result<WifiConnectionInfo, WifiError>> {
+    const {ssid, passphrase, txPower} = options
+    if (txPower !== undefined) {
+      const txResult = native.setTxPower(txPower)
+      if (!txResult.ok) return txResult
+    }
     for (let attempt = 0; attempt <= MAX_CONNECT_RETRIES; attempt++) {
       const startResult = native.connect(ssid, passphrase)
       if (!startResult.ok) return startResult
@@ -93,14 +100,15 @@ const wifi: Wifi = {
 
       // eslint-disable-next-line no-console
       console.warn(`WiFi connect failed, retrying in ${RETRY_DELAY_MS}ms…`)
-      native.disconnect()
+      // Keep the radio up between retries so the next attempt reconnects fast.
+      native.disconnect(false)
       await sleep(RETRY_DELAY_MS)
     }
     return err({name: 'ConnectFailed' as const, message: 'max retries exceeded'})
   },
 
-  disconnect(): Result<void, WifiError> {
-    return native.disconnect()
+  disconnect(options?: WifiDisconnectOptions): Result<void, WifiError> {
+    return native.disconnect(options?.shutdown)
   },
 
   rssi(): Result<number, WifiError> {
@@ -157,10 +165,6 @@ const wifi: Wifi = {
   get txPower(): number {
     const result = native.getTxPower()
     return result.ok ? result.value : 0
-  },
-
-  set txPower(dbm: number) {
-    native.setTxPower(dbm)
   },
 
   get rssiThreshold(): number {

--- a/packages/create-mikro/src/templates/http-server/app/main.ts
+++ b/packages/create-mikro/src/templates/http-server/app/main.ts
@@ -8,7 +8,7 @@ const ssid = env.require("WIFI_SSID");
 const passphrase = env.require("WIFI_PASSPHRASE");
 
 console.log("Connecting to %s...", ssid);
-const connected = await wifi.connect(ssid, passphrase);
+const connected = await wifi.connect({ ssid, passphrase });
 if (!connected.ok) {
   console.error("WiFi connect failed: %s", connected.error.name);
 } else {

--- a/packages/create-mikro/src/templates/sntp/app/main.ts
+++ b/packages/create-mikro/src/templates/sntp/app/main.ts
@@ -11,7 +11,7 @@ const passphrase = env.require("WIFI_PASSPHRASE");
 
 // Connect to WiFi
 console.log(`Connecting to ${ssid}...`);
-const connectResult = await wifi.connect(ssid, passphrase);
+const connectResult = await wifi.connect({ ssid, passphrase });
 if (!connectResult.ok) {
   console.error("WiFi connect failed: %s", connectResult.error.name);
 } else {

--- a/packages/create-mikro/src/templates/udp-discovery/app/main.ts
+++ b/packages/create-mikro/src/templates/udp-discovery/app/main.ts
@@ -16,7 +16,7 @@ const ssid = env.require("WIFI_SSID");
 const passphrase = env.require("WIFI_PASSPHRASE");
 
 console.log("Connecting to %s...", ssid);
-const connected = await wifi.connect(ssid, passphrase);
+const connected = await wifi.connect({ ssid, passphrase });
 if (!connected.ok) {
   console.error("WiFi connect failed: %s", connected.error.name);
 } else {

--- a/packages/create-mikro/src/templates/wifi-fetch/app/main.ts
+++ b/packages/create-mikro/src/templates/wifi-fetch/app/main.ts
@@ -8,7 +8,7 @@ const passphrase = env.require("WIFI_PASSPHRASE");
 
 // Connect to WiFi
 console.log(`Connecting to ${ssid}...`);
-const connectResult = await wifi.connect(ssid, passphrase);
+const connectResult = await wifi.connect({ ssid, passphrase });
 if (!connectResult.ok) {
   console.error("WiFi connect failed: %s", connectResult.error.name);
 } else {

--- a/packages/mikro/src/_exports/sim.ts
+++ b/packages/mikro/src/_exports/sim.ts
@@ -18,7 +18,7 @@ export interface SimStubMethods {
       ssid: string,
       passphrase: string,
     ): NR<Promise<NR<{ip: string; netmask: string; gateway: string}>>>
-    disconnect(): NRV
+    disconnect(shutdown?: boolean): NRV
     rssi(): NR<number>
     ip(): string
     status(): number

--- a/skills/mikrojs-dev/SKILL.md
+++ b/skills/mikrojs-dev/SKILL.md
@@ -158,7 +158,10 @@ import {wifi} from 'mikro/wifi'
 import {request} from 'mikro/http/request'
 
 // WiFi uses 40-65 KB of heap. Connecting/disconnecting repeatedly wastes memory.
-const conn = await wifi.connect(import.meta.env.WIFI_SSID, import.meta.env.WIFI_PASS)
+const conn = await wifi.connect({
+  ssid: import.meta.env.WIFI_SSID,
+  passphrase: import.meta.env.WIFI_PASS,
+})
 if (!conn.ok) {
   console.error('WiFi failed:', conn.error)
   // Consider: retry with backoff, or panic if WiFi is required


### PR DESCRIPTION

BREAKING CHANGE: wifi.connect() now takes an options object `{ssid, passphrase, txPower?}` instead of positional arguments. `wifi.disconnect()` now powers the radio down and frees its heap by default; pass `{shutdown: false}` to keep it up for a fast reconnect. `wifi.txPower` is read-only; set it via `connect({txPower})`.